### PR TITLE
feat(catalog): add actionlint, dust, tree, hyperfine, difftastic, scc

### DIFF
--- a/catalog/actionlint.json
+++ b/catalog/actionlint.json
@@ -1,0 +1,44 @@
+{
+  "name": "actionlint",
+  "category": "devops",
+  "install_method": "auto",
+  "description": "Static checker for GitHub Actions workflow files",
+  "homepage": "https://github.com/rhysd/actionlint",
+  "github_repo": "rhysd/actionlint",
+  "binary_name": "actionlint",
+  "download_url_template": "https://github.com/rhysd/actionlint/releases/download/{version}/actionlint_{version_nov}_linux_{arch}.tar.gz",
+  "arch_map": {
+    "x86_64": "amd64",
+    "aarch64": "arm64"
+  },
+  "available_methods": [
+    {
+      "method": "github_release_binary",
+      "priority": 1,
+      "config": {
+        "repo": "rhysd/actionlint",
+        "asset_pattern": "actionlint_.*_linux_amd64.tar.gz"
+      }
+    },
+    {
+      "method": "go",
+      "priority": 2,
+      "config": {
+        "package": "github.com/rhysd/actionlint/cmd/actionlint"
+      }
+    },
+    {
+      "method": "brew",
+      "priority": 3,
+      "config": {
+        "package": "actionlint"
+      }
+    }
+  ],
+  "requires": [],
+  "tags": [
+    "linter",
+    "github-actions",
+    "ci"
+  ]
+}

--- a/catalog/difftastic.json
+++ b/catalog/difftastic.json
@@ -1,0 +1,43 @@
+{
+  "name": "difftastic",
+  "category": "git",
+  "install_method": "auto",
+  "description": "A structural diff tool that understands syntax - compares files by parsing them",
+  "homepage": "https://github.com/Wilfred/difftastic",
+  "github_repo": "Wilfred/difftastic",
+  "binary_name": "difft",
+  "download_url_template": "https://github.com/Wilfred/difftastic/releases/download/{version}/difft-{arch}-unknown-linux-gnu.tar.gz",
+  "arch_map": {
+    "x86_64": "x86_64",
+    "aarch64": "aarch64"
+  },
+  "available_methods": [
+    {
+      "method": "github_release_binary",
+      "priority": 1,
+      "config": {
+        "repo": "Wilfred/difftastic",
+        "asset_pattern": "difft-x86_64-unknown-linux-gnu.tar.gz"
+      }
+    },
+    {
+      "method": "cargo",
+      "priority": 2,
+      "config": {
+        "crate": "difftastic"
+      }
+    },
+    {
+      "method": "brew",
+      "priority": 3,
+      "config": {
+        "package": "difftastic"
+      }
+    }
+  ],
+  "requires": [],
+  "tags": [
+    "diff",
+    "syntax-aware"
+  ]
+}

--- a/catalog/dust.json
+++ b/catalog/dust.json
@@ -1,0 +1,43 @@
+{
+  "name": "dust",
+  "category": "general",
+  "install_method": "auto",
+  "description": "A more intuitive version of du - disk usage viewer written in Rust",
+  "homepage": "https://github.com/bootandy/dust",
+  "github_repo": "bootandy/dust",
+  "binary_name": "dust",
+  "download_url_template": "https://github.com/bootandy/dust/releases/download/{version}/dust-{version}-{arch}-unknown-linux-musl.tar.gz",
+  "arch_map": {
+    "x86_64": "x86_64",
+    "aarch64": "aarch64"
+  },
+  "available_methods": [
+    {
+      "method": "github_release_binary",
+      "priority": 1,
+      "config": {
+        "repo": "bootandy/dust",
+        "asset_pattern": "dust-.*-x86_64-unknown-linux-musl.tar.gz"
+      }
+    },
+    {
+      "method": "cargo",
+      "priority": 2,
+      "config": {
+        "crate": "du-dust"
+      }
+    },
+    {
+      "method": "brew",
+      "priority": 3,
+      "config": {
+        "package": "dust"
+      }
+    }
+  ],
+  "requires": [],
+  "tags": [
+    "disk-usage",
+    "file-utils"
+  ]
+}

--- a/catalog/hyperfine.json
+++ b/catalog/hyperfine.json
@@ -1,0 +1,43 @@
+{
+  "name": "hyperfine",
+  "category": "general",
+  "install_method": "auto",
+  "description": "A command-line benchmarking tool with statistical analysis",
+  "homepage": "https://github.com/sharkdp/hyperfine",
+  "github_repo": "sharkdp/hyperfine",
+  "binary_name": "hyperfine",
+  "download_url_template": "https://github.com/sharkdp/hyperfine/releases/download/{version}/hyperfine-{version}-{arch}-unknown-linux-musl.tar.gz",
+  "arch_map": {
+    "x86_64": "x86_64",
+    "aarch64": "aarch64"
+  },
+  "available_methods": [
+    {
+      "method": "github_release_binary",
+      "priority": 1,
+      "config": {
+        "repo": "sharkdp/hyperfine",
+        "asset_pattern": "hyperfine-.*-x86_64-unknown-linux-musl.tar.gz"
+      }
+    },
+    {
+      "method": "cargo",
+      "priority": 2,
+      "config": {
+        "crate": "hyperfine"
+      }
+    },
+    {
+      "method": "apt",
+      "priority": 3,
+      "config": {
+        "package": "hyperfine"
+      }
+    }
+  ],
+  "requires": [],
+  "tags": [
+    "benchmark",
+    "performance"
+  ]
+}

--- a/catalog/scc.json
+++ b/catalog/scc.json
@@ -1,0 +1,43 @@
+{
+  "name": "scc",
+  "category": "general",
+  "install_method": "auto",
+  "description": "Sloc, Cloc and Code - fast accurate code counter with complexity calculations",
+  "homepage": "https://github.com/boyter/scc",
+  "github_repo": "boyter/scc",
+  "binary_name": "scc",
+  "download_url_template": "https://github.com/boyter/scc/releases/download/{version}/scc_Linux_{arch}.tar.gz",
+  "arch_map": {
+    "x86_64": "x86_64",
+    "aarch64": "arm64"
+  },
+  "available_methods": [
+    {
+      "method": "github_release_binary",
+      "priority": 1,
+      "config": {
+        "repo": "boyter/scc",
+        "asset_pattern": "scc_Linux_x86_64.tar.gz"
+      }
+    },
+    {
+      "method": "go",
+      "priority": 2,
+      "config": {
+        "package": "github.com/boyter/scc/v3"
+      }
+    },
+    {
+      "method": "brew",
+      "priority": 3,
+      "config": {
+        "package": "scc"
+      }
+    }
+  ],
+  "requires": [],
+  "tags": [
+    "code-counter",
+    "statistics"
+  ]
+}

--- a/catalog/tree.json
+++ b/catalog/tree.json
@@ -1,0 +1,19 @@
+{
+  "name": "tree",
+  "category": "general",
+  "install_method": "package_manager",
+  "description": "Display directory structure as a tree diagram",
+  "homepage": "https://github.com/Old-Man-Programmer/tree",
+  "github_repo": "Old-Man-Programmer/tree",
+  "binary_name": "tree",
+  "version_command": "tree --version 2>&1 | head -1",
+  "packages": {
+    "apt": "tree",
+    "brew": "tree",
+    "dnf": "tree",
+    "pacman": "tree"
+  },
+  "tags": [
+    "file-utils"
+  ]
+}


### PR DESCRIPTION
## Summary

- Add 6 new tools to the catalog (82 → 88 tools)
- **actionlint** — GitHub Actions workflow linter (devops, Go binary)
- **dust** — intuitive disk usage viewer, du replacement (general, Rust)
- **tree** — directory tree display (general, package-manager only)
- **hyperfine** — command-line benchmarking with statistical analysis (general, Rust)
- **difftastic** — syntax-aware structural diff tool (git, Rust, binary name: `difft`)
- **scc** — fast code counter with complexity calculations (general, Go)

Chose **scc** over tokei because tokei's latest releases (v13.0.0, v14.0.0) ship with zero binary assets, making automated version tracking unreliable.

## Test plan

- [x] All 6 JSON files parse correctly
- [x] All 6 tools recognized by audit system (`all_tools()` returns 88)
- [x] 492 tests pass