### PR TITLE
ci: pin python-audit.yml to @main

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,9 +13,7 @@ permissions: {}
 
 jobs:
   audit:
-    # Pinned to feat/python-audit-workflow until netresearch/.github#19 merges.
-    # Switch to @main after merge.
-    uses: netresearch/.github/.github/workflows/python-audit.yml@feat/python-audit-workflow
+    uses: netresearch/.github/.github/workflows/python-audit.yml@main
     permissions:
       contents: read
     with:


### PR DESCRIPTION
Follow-up to #75. The reusable `python-audit.yml` workflow [merged into netresearch/.github main](https://github.com/netresearch/.github/pull/19), so drop the temporary `@feat/python-audit-workflow` pin.

## Test plan

- [x] YAML valid (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] On-push CI: `audit / pip-audit`, `audit / bandit`, `audit / CycloneDX SBOM` all resolve `python-audit.yml@main` at the merge commit and pass.