### PR TITLE
feat(catalog): add opengrep (fully-OSS Semgrep fork)

### DIFF
--- a/catalog/COVERAGE.md
+++ b/catalog/COVERAGE.md
@@ -46,7 +46,7 @@ Most now in catalog, one dedicated script:
 
 ## Installation Method Distribution
 
-- **github_release_binary**: 31 tools
+- **github_release_binary**: 32 tools
 - **uv_tool**: 8 tools (Python CLI tools)
 - **package_manager**: 10 tools (pip, pipx, poetry, npm, pnpm, yarn, gem, composer, sponge, entr)
 - **hashicorp_zip**: 1 tool (terraform)
@@ -56,9 +56,9 @@ Most now in catalog, one dedicated script:
 - **dedicated_script**: 10 tools (runtimes: go, rust, python, node; special: uv, docker, git, ctags, gam)
 - **system_package**: 2 tools (cscope, rename variants)
 
-## Total: 69 tools tracked
+## Total: 71 tools tracked
 
-- **54 tools** have catalog entries
+- **56 tools** have catalog entries
 - **10 tools** use dedicated scripts (runtimes + special cases)
 - **5 tools** are system packages only
 

--- a/catalog/COVERAGE.md
+++ b/catalog/COVERAGE.md
@@ -2,16 +2,16 @@
 
 This file documents which tools have catalog entries and which use dedicated install scripts.
 
-## Tools with Catalog Entries (55)
+## Tools with Catalog Entries (56)
 
 These tools use the catalog-based installation system with generic installers:
 
 - ansible, ast-grep, aws, bandit, bat, black, codex, composer, curlie, dasel
 - delta, direnv, dive, entr, fd, flake8, fx, fzf, gem, gemini, gh, git-absorb
 - git-branchless, git-lfs, gitleaks, glab, golangci-lint, httpie, isort, just
-- kubectl, ninja, npm, parallel, pip, pipx, pnpm, poetry, pre-commit, prettier
-- rga, ripgrep, ruff, sd, semgrep, shellcheck, shfmt, sponge, terraform, tfsec
-- trivy, watchexec, xsv, yarn, yq
+- kubectl, ninja, npm, opengrep, parallel, pip, pipx, pnpm, poetry, pre-commit
+- prettier, rga, ripgrep, ruff, sd, semgrep, shellcheck, shfmt, sponge, terraform
+- tfsec, trivy, watchexec, xsv, yarn, yq
 
 ## Tools with Dedicated Install Scripts
 

--- a/catalog/opengrep.json
+++ b/catalog/opengrep.json
@@ -1,0 +1,16 @@
+{
+  "name": "opengrep",
+  "category": "devops",
+  "install_method": "github_release_binary",
+  "description": "Fully open-source static analysis (SAST) engine — CLI-compatible fork of Semgrep (LGPL-2.1)",
+  "homepage": "https://github.com/opengrep/opengrep",
+  "github_repo": "opengrep/opengrep",
+  "binary_name": "opengrep",
+  "download_url_template": "https://github.com/opengrep/opengrep/releases/download/{version}/opengrep_manylinux_{arch}",
+  "arch_map": {
+    "x86_64": "x86",
+    "aarch64": "aarch64"
+  },
+  "version_flag": "--version",
+  "auto_update": true
+}

--- a/upstream_versions.json
+++ b/upstream_versions.json
@@ -175,6 +175,13 @@
       "tool_url": "https://github.com/GAM-team/GAM",
       "upstream_method": "gh"
     },
+    "gem": {
+      "latest_tag": "bundler-v4.0.2",
+      "latest_url": "https://github.com/rubygems/rubygems/releases/tag/bundler-v4.0.2",
+      "latest_version": "4.0.2",
+      "tool_url": "https://github.com/rubygems/rubygems",
+      "upstream_method": "gh"
+    },
     "gemini": {
       "latest_tag": "v0.28.2",
       "latest_url": "https://github.com/google-gemini/gemini-cli/releases/tag/v0.28.2",
@@ -182,13 +189,6 @@
       "tool_url": "https://www.npmjs.com/package/@google/gemini-cli",
       "upstream_method": "npm",
       "npm_package": "@google/gemini-cli"
-    },
-    "gem": {
-      "latest_tag": "bundler-v4.0.2",
-      "latest_url": "https://github.com/rubygems/rubygems/releases/tag/bundler-v4.0.2",
-      "latest_version": "4.0.2",
-      "tool_url": "https://github.com/rubygems/rubygems",
-      "upstream_method": "gh"
     },
     "gh": {
       "latest_tag": "2.83.2",
@@ -329,6 +329,13 @@
       "latest_version": "11.7.0",
       "tool_url": "https://www.npmjs.com/package/npm",
       "upstream_method": "npm"
+    },
+    "opengrep": {
+      "latest_tag": "1.19.0",
+      "latest_url": "https://github.com/opengrep/opengrep/releases/tag/1.19.0",
+      "latest_version": "1.19.0",
+      "tool_url": "https://github.com/opengrep/opengrep",
+      "upstream_method": "gh"
     },
     "parallel": {
       "latest_tag": "20251122",
@@ -538,13 +545,6 @@
       "latest_url": "https://github.com/mikefarah/yq/releases/tag/4.50.1",
       "latest_version": "4.50.1",
       "tool_url": "https://github.com/mikefarah/yq",
-      "upstream_method": "gh"
-    },
-    "opengrep": {
-      "latest_tag": "1.19.0",
-      "latest_url": "https://github.com/opengrep/opengrep/releases/tag/1.19.0",
-      "latest_version": "1.19.0",
-      "tool_url": "https://github.com/opengrep/opengrep",
       "upstream_method": "gh"
     }
   }

--- a/upstream_versions.json
+++ b/upstream_versions.json
@@ -539,6 +539,13 @@
       "latest_version": "4.50.1",
       "tool_url": "https://github.com/mikefarah/yq",
       "upstream_method": "gh"
+    },
+    "opengrep": {
+      "latest_tag": "1.19.0",
+      "latest_url": "https://github.com/opengrep/opengrep/releases/tag/1.19.0",
+      "latest_version": "1.19.0",
+      "tool_url": "https://github.com/opengrep/opengrep",
+      "upstream_method": "gh"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds [`catalog/opengrep.json`](./catalog/opengrep.json) — installs the statically-linked [opengrep](https://github.com/opengrep/opengrep) binary from GitHub releases (v1.19.0 latest) via the existing `github_release_binary` installer; auto-update enabled.
- Keeps `semgrep` in the catalog alongside — both tools coexist so users can choose based on license/feature needs.
- Refreshes `upstream_versions.json` baseline (+1 entry) and bumps `COVERAGE.md` tool count 55 → 56.

**Why both?** Opengrep is an LGPL-2.1 fork of Semgrep, created after Semgrep relicensed the Community rule registry to CC-BY-NC-SA. CLI-compatible (same rules, same `.semgrepignore`, same `nosemgrep:` comments), fully-OSS engine, no Pro/account gating. See the companion PR in [security-audit-skill](https://github.com/netresearch/security-audit-skill/pull/new/feat/opengrep) for audit guidance.

## Test plan
- [x] `bash scripts/installers/github_release_binary.sh opengrep` → installs to `~/.local/bin/opengrep`, reports `1.19.0`
- [x] `opengrep --version` → `1.19.0` ✅
- [x] `uv run python audit.py opengrep` → ✅ UP-TO-DATE with proper upstream link
- [x] `uv run pytest -x -q` → **546 passed**, 1 skipped
- [x] `uv run pre-commit run --files catalog/opengrep.json catalog/COVERAGE.md upstream_versions.json` → all passing