### PR TITLE
feat(catalog): add mlr, gh-aw, and gh-aw-firewall

### DIFF
--- a/catalog/gh-aw-firewall.json
+++ b/catalog/gh-aw-firewall.json
@@ -1,0 +1,21 @@
+{
+  "name": "gh-aw-firewall",
+  "category": "platform",
+  "install_method": "github_release_binary",
+  "description": "GitHub Agentic Workflows Firewall: Squid-proxy-based egress firewall that sandboxes AI agent commands in a Docker container with a domain allowlist",
+  "homepage": "https://github.com/github/gh-aw-firewall",
+  "github_repo": "github/gh-aw-firewall",
+  "binary_name": "awf",
+  "download_url_template": "https://github.com/github/gh-aw-firewall/releases/download/{version}/awf-linux-{arch}",
+  "arch_map": {
+    "x86_64": "x64",
+    "aarch64": "arm64"
+  },
+  "notes": "Direct binary download, not an archive. Upstream uses 'x64' (not 'amd64') in asset names. Requires Docker at runtime to launch the sandboxed Squid proxy.",
+  "tags": [
+    "github",
+    "ci",
+    "agentic",
+    "security"
+  ]
+}

--- a/catalog/gh-aw.json
+++ b/catalog/gh-aw.json
@@ -1,0 +1,21 @@
+{
+  "name": "gh-aw",
+  "category": "platform",
+  "install_method": "github_release_binary",
+  "description": "GitHub Agentic Workflows: gh extension that compiles natural-language Markdown workflow definitions into hardened GitHub Actions workflows",
+  "homepage": "https://github.com/github/gh-aw",
+  "github_repo": "github/gh-aw",
+  "binary_name": "gh-aw",
+  "download_url_template": "https://github.com/github/gh-aw/releases/download/{version}/linux-{arch}",
+  "arch_map": {
+    "x86_64": "amd64",
+    "aarch64": "arm64",
+    "armv7l": "arm"
+  },
+  "notes": "Direct binary download, not an archive. Upstream's preferred install path is 'gh extension install github/gh-aw' (requires the gh CLI). The catalog uses a standalone binary install since gh extensions are not yet modeled as an install_method.",
+  "tags": [
+    "github",
+    "ci",
+    "agentic"
+  ]
+}

--- a/catalog/mlr.json
+++ b/catalog/mlr.json
@@ -1,0 +1,21 @@
+{
+  "name": "mlr",
+  "category": "general",
+  "install_method": "github_release_binary",
+  "description": "Like awk/sed/cut/jq for name-indexed data such as CSV, TSV, JSON and JSON Lines",
+  "homepage": "https://miller.readthedocs.io/",
+  "github_repo": "johnkerl/miller",
+  "binary_name": "mlr",
+  "download_url_template": "https://github.com/johnkerl/miller/releases/download/{version}/miller-{version_nov}-linux-{arch}.tar.gz",
+  "arch_map": {
+    "x86_64": "amd64",
+    "aarch64": "arm64",
+    "armv7l": "armv7"
+  },
+  "tags": [
+    "data",
+    "csv",
+    "json",
+    "text-utils"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds three new GitHub-release-binary catalog entries (catalog grows 93 → 96):

- **[mlr](https://github.com/johnkerl/miller)** (Miller) — `awk`/`sed`/`cut`/`jq` for CSV, TSV, JSON, and JSON Lines. Standard `tar.gz` release layout from `johnkerl/miller`. Arch map matches existing convention (`amd64`/`arm64`/`armv7`). Category: `general`, alongside `jq`/`yq`/`qsv`.
- **[gh-aw](https://github.com/github/gh-aw)** — GitHub Agentic Workflows. A tool that compiles natural-language Markdown workflow definitions into hardened GitHub Actions workflows. Direct-binary download (no archive), modeled on the existing `direnv` pattern. Category: `platform`.
- **[gh-aw-firewall](https://github.com/github/gh-aw-firewall)** (binary `awf`) — Squid-proxy-based egress firewall that sandboxes AI agent commands in a Docker container with a domain allowlist. Direct-binary download; upstream asset names use `x64` (not `amd64`), so `arch_map` reflects that. Category: `platform`.

## Decisions

- **`gh-aw` install method:** Upstream's documented install path is `gh extension install github/gh-aw`, but the catalog does not currently model `gh` CLI extensions as an `install_method`. Since `github/gh-aw` publishes prebuilt per-arch binaries alongside the extension, I used `github_release_binary` (matching what the task prompt approved) and documented the alternative install path in the entry's `notes` field for maintainers and users.
- **`gh-aw-firewall` arch_map:** Upstream uses `x64`/`arm64` rather than the more common `amd64`/`arm64`, so the entry maps `x86_64 -> x64`. `armv7l` is omitted because upstream does not publish an armv7 binary.
- **No changes to `CATALOG_SUMMARY.md` / `COVERAGE.md`:** Both docs are manually maintained snapshots whose totals already lag the catalog (last touched 2026-04-18 at 45 / 56 / 89 entries vs. the actual 93 pre-change). Left alone to keep this PR scoped and avoid drift-fixing unrelated tools.

## Test plan

- [x] All three new JSON files parse cleanly (`jq . catalog/*.json`).
- [x] `uv run python -m pytest -x -q --ignore=tests/integration` — 598 passed, 1 skipped.
- [x] `tests/test_catalog_and_collectors.py` (schema-validity sweep across all `catalog/*.json`) — 28 passed.
- [x] `./scripts/test_smoke.sh` — green.
- [x] `ToolCatalog().has_tool(...)` returns `True` for all three new names; total entries 96.
- [x] Verified upstream asset URLs resolve (HTTP 302 to GitHub release CDN) for `mlr` v6.18.1, `gh-aw` v0.71.5, `gh-aw-firewall` v0.25.43.
- [ ] Actual `make install-mlr` / `make install-gh-aw` / `make install-gh-aw-firewall` smoke install on a clean host (not run here — relies on network + writeable `~/.local/bin`).