### PR TITLE
ci(tests): run tests via reusable python-ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,46 +40,34 @@ jobs:
           mypy cli_audit --ignore-missing-imports
         continue-on-error: true
 
+  # Unit + integration tests with coverage and Codecov upload, via the
+  # org-standard reusable. Replaces the inline copy whose per-repo
+  # codecov-action reference Renovate kept bumping (#88). Coverage is
+  # uploaded once (ubuntu / 3.14) instead of from every matrix cell.
   test:
     name: Test Suite
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.14']
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
-
-      - name: Run unit tests
-        run: |
-          pytest tests/ --ignore=tests/integration -v --cov=cli_audit --cov-report=xml --cov-report=term
-
-      - name: Run integration tests
-        run: |
-          pytest tests/integration -v --cov=cli_audit --cov-append --cov-report=xml --cov-report=term
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
-          flags: unittests
-          name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
-          fail_ci_if_error: false
+    uses: netresearch/.github/.github/workflows/python-ci.yml@main
+    permissions:
+      contents: read
+    with:
+      os-versions: '["ubuntu-latest", "macos-latest", "windows-latest"]'
+      python-versions: '["3.14"]'
+      cache: "pip"
+      cache-dependency-path: "requirements-dev.txt"
+      install-cmd: "python -m pip install --upgrade pip && pip install -r requirements-dev.txt"
+      run-lint: false
+      run-type-check: false
+      run-tests: true
+      test-cmd: >-
+        pytest tests/ --ignore=tests/integration -v --cov=cli_audit
+        --cov-report=xml --cov-report=term &&
+        pytest tests/integration -v --cov=cli_audit --cov-append
+        --cov-report=xml --cov-report=term
+      upload-coverage-codecov: true
+      coverage-os: "ubuntu-latest"
+      coverage-python-version: "3.14"
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   security:
     name: Security Scan


### PR DESCRIPTION
## What

Replaces the inline `Test Suite` job with the org-standard `netresearch/.github/.github/workflows/python-ci.yml@main` reusable (added in netresearch/.github#174). It runs the unit + integration pytest suites with coverage and uploads to Codecov.

`lint`, `security`, `build`, `docs`, and `integration-e2e` are unchanged. The reusable caller keeps the job name `test`, so the `needs: [lint, test]` / `needs: [test]` dependencies stay valid.

## Why

Renovate was bumping `codecov/codecov-action` in this repo per release (#88). The action now lives once in `python-ci.yml` and is pinned/bumped centrally — the same model PHP repos use via `php-ci.yml`. There is no longer an inline `codecov-action` reference here.

Closes #88.

## Behavior notes

- Test execution still runs across `ubuntu-latest`, `macos-latest`, `windows-latest` on Python 3.14.
- Coverage now uploads **once** (ubuntu / 3.14) instead of from all three OS cells — the previous setup uploaded three reports with different `name=` values.
- Install still uses `pip install -r requirements-dev.txt` (matching the previous job; not switched to uv).

## Residual

The `lint`, `security`, `build`, `docs`, `integration-e2e` jobs still pin `actions/checkout` / `actions/setup-python`, which Renovate will still bump occasionally. This PR stops the **codecov** churn specifically.

## Validation

`yamllint` (org config) and `actionlint` clean.