### PR TITLE
feat(catalog): add Jujutsu (jj) version control tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,7 @@ This repo **is** a CLI tool manager, so the word "upgrade" is overloaded:
 **AI CLI Preparation v2.0** — Tool version auditing and installation management for AI coding agents.
 
 - **Modules:** 21 Python modules under `cli_audit/` (see [`cli_audit/AGENTS.md`](./cli_audit/AGENTS.md))
-- **Catalog:** 89 JSON tool definitions under `catalog/`
+- **Catalog:** 97 JSON tool definitions under `catalog/`
 - **Installers:** 33 Bash scripts under `scripts/` (see [`scripts/AGENTS.md`](./scripts/AGENTS.md))
 - **Phase 1:** Detection & auditing (complete)
 - **Phase 2:** Installation & upgrade management (complete)

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Example (abridged):
 - Security & compliance: `semgrep`, `bandit`, `gitleaks`, `trivy`
 - Git helpers: `git-absorb`, `git-branchless`
 - Formatters & linters: `black`, `isort`, `flake8`, `eslint`, `prettier`, `shfmt`, `shellcheck`
-- VCS & platforms: `git`, `gh` (GitHub CLI), `glab` (GitLab CLI)
+- VCS & platforms: `git`, `gh` (GitHub CLI), `glab` (GitLab CLI), `jj` (Jujutsu, Git-compatible VCS)
 - Cloud & infra: `aws`, `kubectl`, `terraform`, `docker`, `dive`
 
 Note: Not all of these are expected to be installed globally; the report simply surfaces what is present and how it compares upstream.
@@ -468,7 +468,7 @@ make test-parallel     # Parallel via pytest-xdist
 
 ## Installation scripts
 
-All 89 cataloged tools can be installed, upgraded, uninstalled, or reconciled via generic Make targets:
+All 97 cataloged tools can be installed, upgraded, uninstalled, or reconciled via generic Make targets:
 
 ```bash
 # Generic pattern targets - work for ANY cataloged tool
@@ -539,7 +539,7 @@ When ambiguous, the audit may report a generic bucket (e.g., `~/.local/bin`). Th
 
 ### Actions: install, upgrade, uninstall, reconcile
 
-All pattern targets (`install-%`, `upgrade-%`, `uninstall-%`, `reconcile-%`) work for any of the 89 cataloged tools. They use a three-step fallback: dedicated script, then generic installer, then error.
+All pattern targets (`install-%`, `upgrade-%`, `uninstall-%`, `reconcile-%`) work for any of the 97 cataloged tools. They use a three-step fallback: dedicated script, then generic installer, then error.
 
 ```bash
 # Upgrade any tool

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -71,7 +71,7 @@ Install tools via system package managers (apt, brew, dnf, pacman).
 2. The tool will automatically be available via `make install-<tool>`, `make upgrade-<tool>`, `make uninstall-<tool>`, and `make reconcile-<tool>`
 3. No need to create a custom install script!
 
-Currently **89 tools** are cataloged.
+Currently **97 tools** are cataloged.
 
 ## Environment Variables
 
@@ -96,6 +96,6 @@ make upgrade
 
 ## Architecture
 
-All 89 tools have catalog entries. The generic installer (`scripts/install_tool.sh`) reads a tool's catalog JSON and delegates to the appropriate method-specific installer under `scripts/installers/`. Tools with complex installation needs (python, node, docker, rust, etc.) use `install_method: "dedicated_script"` to route to their existing bespoke scripts.
+All 97 tools have catalog entries. The generic installer (`scripts/install_tool.sh`) reads a tool's catalog JSON and delegates to the appropriate method-specific installer under `scripts/installers/`. Tools with complex installation needs (python, node, docker, rust, etc.) use `install_method: "dedicated_script"` to route to their existing bespoke scripts.
 
 See [ADR-007](../docs/adr/ADR-007-generic-tool-installation-architecture.md) for the full architectural decision record.

--- a/catalog/jj.json
+++ b/catalog/jj.json
@@ -1,0 +1,37 @@
+{
+  "name": "jj",
+  "category": "git",
+  "install_method": "auto",
+  "description": "Jujutsu - a Git-compatible VCS that is both simple and powerful",
+  "homepage": "https://github.com/jj-vcs/jj",
+  "github_repo": "jj-vcs/jj",
+  "binary_name": "jj",
+  "version_flag": "--version",
+  "download_url_template": "https://github.com/jj-vcs/jj/releases/download/{version}/jj-{version}-{arch}-unknown-linux-musl.tar.gz",
+  "arch_map": {
+    "x86_64": "x86_64",
+    "aarch64": "aarch64"
+  },
+  "available_methods": [
+    {
+      "method": "github_release_binary",
+      "priority": 1,
+      "config": {
+        "repo": "jj-vcs/jj",
+        "asset_pattern": "jj-.*-x86_64-unknown-linux-musl.tar.gz"
+      }
+    },
+    {
+      "method": "brew",
+      "priority": 2,
+      "config": {
+        "package": "jj"
+      }
+    }
+  ],
+  "notes": "Release assets keep the 'v' prefix in the filename (jj-v0.42.0-...). Only musl Linux builds are published. cargo is intentionally omitted: the 'jujutsu' crate on crates.io is abandoned (last 0.7.2); the current cargo path is a git build.",
+  "tags": [
+    "git",
+    "vcs"
+  ]
+}

--- a/catalog/jj.json
+++ b/catalog/jj.json
@@ -7,7 +7,7 @@
   "github_repo": "jj-vcs/jj",
   "binary_name": "jj",
   "version_flag": "--version",
-  "download_url_template": "https://github.com/jj-vcs/jj/releases/download/{version}/jj-{version}-{arch}-unknown-linux-musl.tar.gz",
+  "download_url_template": "https://github.com/jj-vcs/jj/releases/download/v{version_nov}/jj-v{version_nov}-{arch}-unknown-linux-musl.tar.gz",
   "arch_map": {
     "x86_64": "x86_64",
     "aarch64": "aarch64"
@@ -18,7 +18,7 @@
       "priority": 1,
       "config": {
         "repo": "jj-vcs/jj",
-        "asset_pattern": "jj-.*-x86_64-unknown-linux-musl.tar.gz"
+        "asset_pattern": "jj-.*-unknown-linux-musl.tar.gz"
       }
     },
     {

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -122,7 +122,7 @@ class ToolCatalog:
 ```python
 from cli_audit import ToolCatalog
 
-# Load catalog (73 tools)
+# Load catalog (97 tools)
 catalog = ToolCatalog()
 entries = catalog.load_all()
 
@@ -137,7 +137,7 @@ if catalog.has("fzf"):
     fzf = catalog.get("fzf")
 
 # List all tools
-all_tools = catalog.list_all()  # Returns list of 73 tool names
+all_tools = catalog.list_all()  # Returns list of 97 tool names
 ```
 
 #### `cli_audit.collectors` - Upstream Version Collection

--- a/docs/CATALOG_GUIDE.md
+++ b/docs/CATALOG_GUIDE.md
@@ -12,7 +12,7 @@ The catalog system allows tool definitions to be managed as JSON files instead o
 - **Clear Separation**: Data (JSON) vs Logic (Python)
 
 **Location**: `catalog/` directory at project root
-**Current Size**: 73 JSON tool definitions
+**Current Size**: 97 JSON tool definitions
 
 ## Quick Start
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -7,7 +7,7 @@
 
 AI CLI Preparation is a specialized environment audit tool designed to ensure AI coding agents (like Claude Code) have access to all necessary developer tools. This documentation provides comprehensive technical details for developers, contributors, and integrators.
 
-**Architecture:** Modular design with 18 specialized Python modules and 73 JSON tool catalog entries, evolved from a 3,387-line monolith to a maintainable, extensible system.
+**Architecture:** Modular design with 21 specialized Python modules and 97 JSON tool catalog entries, evolved from a 3,387-line monolith to a maintainable, extensible system.
 
 **Project Status:**
 - **Phase 1 (Detection & Auditing):** ✅ Complete - Modular refactoring complete (v2.0.0)
@@ -34,7 +34,7 @@ AI CLI Preparation is a specialized environment audit tool designed to ensure AI
 
 2. **[CATALOG_GUIDE.md](CATALOG_GUIDE.md)** - JSON Catalog System ⭐ **NEW**
    - Tool definition schema and structure
-   - 73 JSON catalog entries
+   - 97 JSON catalog entries
    - Creating and managing catalog entries
    - ToolCatalog API and usage patterns
    - Community contribution workflows

--- a/docs/TOOL_ECOSYSTEM.md
+++ b/docs/TOOL_ECOSYSTEM.md
@@ -4,7 +4,7 @@ Complete catalog of all tools tracked by AI CLI Preparation, organized by catego
 
 ## Overview
 
-AI CLI Preparation tracks **68 developer tools** across 11 categories, optimized for AI coding agent environments. Each tool is classified by installation method and tracked against upstream releases.
+AI CLI Preparation tracks **69 developer tools** across 11 categories, optimized for AI coding agent environments. Each tool is classified by installation method and tracked against upstream releases.
 
 ## Categories
 
@@ -15,7 +15,7 @@ AI CLI Preparation tracks **68 developer tools** across 11 categories, optimized
 - [HTTP Clients](#http-clients) - HTTP/API testing tools (2 tools)
 - [Automation & Watch](#automation--watch) - File watching and automation (6 tools)
 - [Security & Compliance](#security--compliance) - Security scanning tools (5 tools)
-- [Git Tools](#git-tools) - Version control and Git helpers (8 tools)
+- [Git Tools](#git-tools) - Version control and Git helpers (9 tools)
 - [Formatters & Linters](#formatters--linters) - Code formatting and linting (12 tools)
 - [Cloud & Infrastructure](#cloud--infrastructure) - Cloud and container tools (5 tools)
 - [Build Systems](#build-systems) - Build automation and compilation tools (1 tool)
@@ -462,6 +462,14 @@ make audit-offline-data-core
 - **Use Case:** Advanced git workflows
 - **Install:** `cargo install git-branchless`
 - **Upgrade:** `cargo install --force git-branchless`
+
+### jj
+- **Purpose:** Jujutsu, a Git-compatible version control system that is both simple and powerful
+- **Executable:** `jj`
+- **Upstream:** GitHub (jj-vcs/jj)
+- **Use Case:** Simpler, more powerful VCS workflow that interoperates with existing Git repositories
+- **Install:** `make install-jj` (GitHub release binary) or `brew install jj`
+- **Upgrade:** `make upgrade-jj`
 
 ### just
 - **Purpose:** Command runner for project-specific tasks

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -94,7 +94,7 @@ make scripts-perms  # Ensure all scripts are executable
 ./scripts/install_node.sh reconcile
 ```
 
-**Via Make (works for all 89 cataloged tools):**
+**Via Make (works for all 97 cataloged tools):**
 ```bash
 make install-python              # Install Python toolchain (dedicated script)
 make upgrade-python              # Upgrade Python toolchain


### PR DESCRIPTION
## Summary

- Add **Jujutsu (`jj`)**, a Git-compatible VCS, to the tool catalog (`catalog/jj.json`) — installs via GitHub release binary (`jj-vcs/jj`, musl Linux) with `brew` as a secondary method. Enables `make install-jj` / `upgrade-jj` / `uninstall-jj` / `reconcile-jj`.
- Add `jj` to the README highlights and the `docs/TOOL_ECOSYSTEM.md` Git Tools section.
- Refresh stale **current-state** catalog counts to the actual total (`97` JSON entries; `21` cli_audit modules) across `AGENTS.md`, `catalog/README.md`, `scripts/AGENTS.md`, and the `docs/` reference set.

`cargo` is intentionally omitted: the `jujutsu` crate on crates.io is abandoned (last `0.7.2`) and the current cargo path is a git build.

## Linked issues / PRs

<!-- none -->

## Type of change

- [x] New feature (`feat:`)
- [x] Docs only (`docs:`)

## Test plan

- [x] `uv run pytest` — 630 passed, 1 skipped
- [x] `uv run python -m flake8 cli_audit tests` — no new findings (pre-existing style warnings only; CI gate selects `E9,F63,F7,F82`, none present)
- [x] `./scripts/test_smoke.sh` — OK
- [x] Catalog loads `jj`; upstream resolves to `0.42.0`; release URL returns HTTP 200

## Checklist

- [x] Conventional Commits (`type(scope): description`)
- [x] Commits signed (`git commit -S --signoff`)
- [ ] `CHANGELOG.md` updated — n/a (no CHANGELOG entries in feature PRs per workflow)
- [x] Relevant `AGENTS.md` files updated (root + `scripts/`)
- [x] No secrets, credentials, or PII committed

### Note on intentionally-unchanged docs
Historical records (`docs/MIGRATION_GUIDE.md` v2.0 migration snapshot, `docs/INDEX.md` v2.0.0 changelog entry, `docs/adr/ADR-007/008`) and the pervasively-stale aggregate files `catalog/CATALOG_SUMMARY.md` / `catalog/COVERAGE.md` (already ~40 tools out of date, unrelated to `jj`) were left untouched — those warrant a separate regeneration pass rather than a misleading one-tool patch.
