### PR TITLE
fix: auto-update never bootstraps missing tools; detect pip via pip3

### DIFF
--- a/catalog/pip.json
+++ b/catalog/pip.json
@@ -6,6 +6,7 @@
   "homepage": "https://pip.pypa.io/",
   "package_name": "pip",
   "binary_name": "pip",
+  "candidates": ["pip", "pip3"],
   "script": "install_pip.sh",
   "notes": "pip is bundled with Python 3. Use python3 -m pip if pip command is not available."
 }

--- a/scripts/guide.sh
+++ b/scripts/guide.sh
@@ -18,7 +18,6 @@ IGNORE_PINS="${IGNORE_PINS:-0}"
 
 # Summary counters
 SUMMARY_UPDATED=0
-SUMMARY_INSTALLED=0
 SUMMARY_SKIPPED=0
 SUMMARY_FAILED=0
 SUMMARY_REMOVED=0
@@ -28,7 +27,6 @@ print_summary() {
   echo "================================================================================"
   echo "Summary${label:+ ($label)}"
   echo "================================================================================"
-  printf "  Installed: %d\n" "$SUMMARY_INSTALLED"
   printf "  Updated:   %d\n" "$SUMMARY_UPDATED"
   printf "  Removed:   %d\n" "$SUMMARY_REMOVED"
   printf "  Skipped:   %d\n" "$SUMMARY_SKIPPED"
@@ -348,6 +346,17 @@ process_tool() {
   # For multi-version tools the key is cycle-qualified (e.g. python@3.13), so
   # each cycle opts in independently.
   if [ "$auto_update" = "true" ]; then
+    # Auto-update keeps *existing* tools current; it must never bootstrap a
+    # missing tool. Tools like pip are intentionally left to uv/bun rather than
+    # installed on our behalf. When the tool isn't installed, report the skip
+    # and return. Deliberate installs are offered only by the interactive
+    # prompt below, which is reached when auto-update is not enabled.
+    if [ -z "$installed" ]; then
+      printf "\n==> ⏭️  %s [auto-update]\n" "$display"
+      printf "    not installed; skipping (auto-update upgrades existing tools only)\n"
+      SUMMARY_SKIPPED=$((SUMMARY_SKIPPED + 1))
+      return 0
+    fi
     printf "\n==> %s %s [auto-update]\n" "$icon" "$display"
     print_installed_status "$installed" "$method"
     # Show target; for self-managed tools (skip_upstream) show "self-managed" instead of <unknown>
@@ -360,12 +369,12 @@ process_tool() {
     check_multi_installs "$catalog_tool"
     printf "    auto-updating...\n"
 
-    # Build install command from catalog metadata (use catalog_tool for script name)
-    local install_cmd="install_tool.sh $catalog_tool"
+    # Build the upgrade command from catalog metadata (use catalog_tool for
+    # script name). The tool is guaranteed installed here, so this is always an
+    # update unless the catalog defines an explicit install_action.
+    local install_cmd="install_tool.sh $catalog_tool update"
     if [ -n "$install_action" ]; then
       install_cmd="install_tool.sh $catalog_tool $install_action"
-    elif [ -n "$installed" ]; then
-      install_cmd="install_tool.sh $catalog_tool update"
     fi
 
     # Execute the install with version-specific environment variables
@@ -391,8 +400,6 @@ process_tool() {
     rm -f "/tmp/.cli-audit/${catalog_tool}.already-current"
     if [ "$auto_update_success" = "0" ]; then
       SUMMARY_FAILED=$((SUMMARY_FAILED + 1))
-    elif [ -z "$installed" ]; then
-      SUMMARY_INSTALLED=$((SUMMARY_INSTALLED + 1))
     else
       SUMMARY_UPDATED=$((SUMMARY_UPDATED + 1))
     fi


### PR DESCRIPTION
## Problem

Running `make upgrade` (the interactive guide) silently **installed pip**,
even though pip showed as `not installed`. Two independent causes:

1. **Auto-update bootstrapped missing tools.** The global `auto_upgrade`
   default is `true`, so every tool without an explicit per-tool setting is
   auto-update-eligible. The guide treated `auto_update=true` as *install or
   upgrade*, so an absent tool (pip) was freshly installed rather than skipped.

2. **pip was misdetected as absent.** The catalog only searched for a bare
   `pip` binary; systems that expose only `pip3` reported pip as not installed,
   which is what triggered the bootstrap in the first place.

## Changes

- **`scripts/guide.sh`** — the auto-update path now guards on install state:
  if a tool is not installed it is skipped ("upgrades existing tools only"),
  never bootstrapped. Package acquisition stays with uv/bun. Removed the
  now-unreachable fresh-install branch and the `SUMMARY_INSTALLED` counter it
  was the sole feeder of (interactive installs already count as `Updated`).
- **`catalog/pip.json`** — added `"candidates": ["pip", "pip3"]` (mirroring
  `fd`/`fdfind`) so an existing pip is detected and kept current by
  auto-update.

## Net behavior

| pip state | before | after |
|-----------|--------|-------|
| present (as `pip3`) | reported not-installed | detected, auto-**upgraded** |
| absent | auto-**installed** | **skipped** |

## Verification

- `pytest`: 634 passed, 1 skipped.
- Gating flake8 (`E9,F63,F7,F82`) clean; smoke test passes; `audit.py --help` OK.
- `bash -n scripts/guide.sh` clean; added shell lines are shellcheck-clean.
- Staged a fake `pip3` (no bare `pip`) on PATH + live audit → `pip 25.3 -> 26.1.2`
  (was `not installed` before the catalog change).
- `test_guide_multi_install.sh`: the only 3 failures are pre-existing on
  unmodified `main` (nvm classification / single-install warning); no regression.

No version bump or CHANGELOG (feature-branch policy).