### PR TITLE
feat: multi-install cleanup + upgrade discoverability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ export
 	install install-dev install-core install-python install-node install-go \
 	install-aws install-kubectl install-terraform install-ansible install-docker \
 	install-brew install-rust install-uv install-% upgrade-% uninstall-% reconcile-% \
+	reconcile-all reconcile-all-dry-run \
 	build build-dist build-wheel check-dist publish-test publish-prod \
 	clean clean-build clean-test clean-pyc clean-all \
 	scripts-perms audit-auto detect-managers upgrade-managed upgrade-dry-run \

--- a/Makefile.d/user.mk
+++ b/Makefile.d/user.mk
@@ -224,6 +224,12 @@ reconcile-%: scripts-perms ## Reconcile tool installation (e.g., make reconcile-
 		echo "Error: No installer found for '$*'" >&2; exit 1; \
 	fi
 
+reconcile-all: scripts-perms ## Remove duplicate installs across ALL tools (confirm each; keeps preferred)
+	@$(PYTHON) audit.py --reconcile --all --apply
+
+reconcile-all-dry-run: scripts-perms ## Preview duplicate-install cleanup across ALL tools (removes nothing)
+	@$(PYTHON) audit.py --reconcile --all
+
 # ----------------------------------------------------------------------------
 # SYSTEM MANAGEMENT
 # ----------------------------------------------------------------------------

--- a/audit.py
+++ b/audit.py
@@ -1371,11 +1371,26 @@ def cmd_reconcile(args: argparse.Namespace) -> int:
                 mode="explicit", tool_names=all_tools, reconcile_mode="aggressive",
                 force=force, verbose=args.verbose,
             )
+            # Report only tools that actually had duplicates — the explicit
+            # sweep visits every catalog entry, but --all is about conflicts.
+            conflicts = [r for r in result.results if len(r.installations) > 1]
             if JSON_MODE:
-                print(json.dumps(result.to_dict()))
+                print(json.dumps({
+                    "tools_checked": result.tools_checked,
+                    "conflicts_found": result.conflicts_found,
+                    "conflicts_resolved": result.conflicts_resolved,
+                    "results": [r.to_dict() for r in conflicts],
+                    "duration_seconds": result.duration_seconds,
+                }))
             else:
                 print(result.summary(), file=sys.stderr)
-            return 0 if result.conflicts_resolved == result.conflicts_found else 1
+            # Fail only on real removal errors — not on protected tools (blocked)
+            # or tools the user declined (aborted), which are expected outcomes.
+            failures = [
+                r for r in conflicts
+                if not r.success and r.action_taken not in ("blocked", "aborted", "none")
+            ]
+            return 1 if failures else 0
         # Plan-only sweep (parallel detection, no removal)
         result = bulk_reconcile(
             mode="explicit", tool_names=all_tools, reconcile_mode="parallel",
@@ -1389,7 +1404,7 @@ def cmd_reconcile(args: argparse.Namespace) -> int:
             for r in result.results if len(r.installations) > 1
         ]
         if JSON_MODE:
-            print(json.dumps({"conflicts": plans, "total": len(plans)}))
+            print(json.dumps({"results": plans, "total": len(plans)}))
         else:
             _print_reconcile_plans(plans)
         return 0
@@ -1495,6 +1510,12 @@ def main() -> int:
 
     # Setup logging
     setup_logging(verbose=args.verbose)
+
+    # Reconcile-only flags are meaningless (and silently ignored) without
+    # --reconcile — fail loudly so scripting mistakes surface.
+    if not args.reconcile and (args.all or args.apply or args.yes):
+        print("--all/--apply/--yes are only valid with --reconcile", file=sys.stderr)
+        return 2
 
     # Route to appropriate command
     if args.reconcile:

--- a/audit.py
+++ b/audit.py
@@ -1286,6 +1286,143 @@ def cmd_versions(args: argparse.Namespace) -> int:
     return 0
 
 
+def _shape_reconcile_plan(tool, installs, preferred, active, protected):
+    """Build a uniform plan dict for a tool's installations.
+
+    Each installation gets a ``preferred`` boolean (matched by path) so shell
+    consumers don't have to cross-reference the separate ``preferred`` entry.
+    """
+    pref_path = preferred.path if preferred else None
+    return {
+        "tool": tool,
+        "count": len(installs),
+        "protected": protected,
+        "preferred": preferred.to_dict() if preferred else None,
+        "active": active.to_dict() if active else None,
+        "installations": [
+            {**i.to_dict(), "preferred": bool(pref_path and i.path == pref_path)}
+            for i in installs
+        ],
+    }
+
+
+def _print_reconcile_plans(plans) -> None:
+    """Human-readable rendering of reconcile plans (non-JSON mode)."""
+    multi = [p for p in plans if p["count"] > 1]
+    if not multi:
+        print("No duplicate installations detected.", file=sys.stderr)
+        return
+    for p in multi:
+        note = " [protected]" if p["protected"] else ""
+        print(f"\n{p['tool']} — {p['count']} installations{note}:", file=sys.stderr)
+        for i in p["installations"]:
+            marks = []
+            if i.get("active"):
+                marks.append("→ active")
+            if i.get("preferred"):
+                marks.append("✓ keep")
+            suffix = ("  " + "  ".join(marks)) if marks else ""
+            ver = i.get("version") or "?"
+            print(f"   • {ver}  {i['method']}  {i['path']}{suffix}", file=sys.stderr)
+
+
+def cmd_reconcile(args: argparse.Namespace) -> int:
+    """Reconcile duplicate installations of a tool.
+
+    Without --apply this only reports the plan (which install is kept vs
+    removed, which is active on PATH). With --apply it removes the non-preferred
+    installations (aggressive mode), honoring the system-tool safelist.
+
+    Supports JSON output via CLI_AUDIT_JSON=1 for consumption by guide.sh.
+    """
+    from cli_audit.catalog import ToolCatalog
+    from cli_audit.reconcile import (
+        SYSTEM_TOOL_SAFELIST,
+        bulk_reconcile,
+        detect_installations,
+        reconcile_tool,
+    )
+
+    catalog = ToolCatalog()
+
+    def _candidates(tool):
+        try:
+            return list(catalog.get(tool).to_tool().candidates)
+        except Exception:
+            return None
+
+    def _plan(tool):
+        installs = detect_installations(tool, candidates=_candidates(tool), verbose=args.verbose)
+        preferred = installs[0] if installs else None
+        active = next((i for i in installs if i.active), None)
+        return _shape_reconcile_plan(tool, installs, preferred, active, tool in SYSTEM_TOOL_SAFELIST)
+
+    apply = getattr(args, "apply", False)
+    force = getattr(args, "yes", False)
+    do_all = getattr(args, "all", False)
+
+    # --- ALL mode ---
+    # bulk_reconcile's own "all"/"conflicts" modes only look at config.tools
+    # (a tiny user-config subset), so sweep the full catalog explicitly.
+    if do_all:
+        all_tools = list(catalog.all_tools())
+        if apply:
+            result = bulk_reconcile(
+                mode="explicit", tool_names=all_tools, reconcile_mode="aggressive",
+                force=force, verbose=args.verbose,
+            )
+            if JSON_MODE:
+                print(json.dumps(result.to_dict()))
+            else:
+                print(result.summary(), file=sys.stderr)
+            return 0 if result.conflicts_resolved == result.conflicts_found else 1
+        # Plan-only sweep (parallel detection, no removal)
+        result = bulk_reconcile(
+            mode="explicit", tool_names=all_tools, reconcile_mode="parallel",
+            verbose=args.verbose,
+        )
+        plans = [
+            _shape_reconcile_plan(
+                r.tool, list(r.installations), r.preferred, r.active,
+                r.tool in SYSTEM_TOOL_SAFELIST,
+            )
+            for r in result.results if len(r.installations) > 1
+        ]
+        if JSON_MODE:
+            print(json.dumps({"conflicts": plans, "total": len(plans)}))
+        else:
+            _print_reconcile_plans(plans)
+        return 0
+
+    # --- Explicit tools ---
+    tools = args.tools
+    if not tools:
+        print("reconcile: specify one or more tools, or use --all", file=sys.stderr)
+        return 2
+
+    if apply:
+        results = []
+        for tool in tools:
+            results.append(reconcile_tool(
+                tool, mode="aggressive", candidates=_candidates(tool),
+                force=force, verbose=args.verbose,
+            ))
+        if JSON_MODE:
+            print(json.dumps({"results": [r.to_dict() for r in results]}))
+        else:
+            for r in results:
+                extra = f" ({r.error_message})" if r.error_message else ""
+                print(f"{r.tool}: {r.action_taken}{extra}", file=sys.stderr)
+        return 0 if all(r.success for r in results) else 1
+
+    plans = [_plan(t) for t in tools]
+    if JSON_MODE:
+        print(json.dumps({"results": plans}))
+    else:
+        _print_reconcile_plans(plans)
+    return 0
+
+
 def main() -> int:
     """Main entry point for audit system."""
     parser = argparse.ArgumentParser(
@@ -1324,6 +1461,26 @@ def main() -> int:
         help="Show multi-version runtime status (PHP, Python, Node.js, Ruby, Go)",
     )
     parser.add_argument(
+        "--reconcile",
+        action="store_true",
+        help="Report (or with --apply, remove) duplicate installations of a tool",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="With --reconcile: operate on all tools that have duplicate installs",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="With --reconcile: actually remove non-preferred installs (default: plan only)",
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="With --reconcile --apply: skip confirmation prompts (honors safelist)",
+    )
+    parser.add_argument(
         "--verbose", "-v",
         action="store_true",
         help="Verbose output",
@@ -1340,7 +1497,9 @@ def main() -> int:
     setup_logging(verbose=args.verbose)
 
     # Route to appropriate command
-    if args.versions:
+    if args.reconcile:
+        return cmd_reconcile(args)
+    elif args.versions:
         return cmd_versions(args)
     elif args.update:
         # Explicit --update flag: full update of all tools

--- a/cli_audit/reconcile.py
+++ b/cli_audit/reconcile.py
@@ -9,9 +9,11 @@ and aggressive (remove non-preferred) reconciliation modes.
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 import sys
+import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from functools import cmp_to_key
@@ -21,7 +23,6 @@ from typing import Sequence
 from .common import vlog
 from .config import Config
 from .environment import Environment
-from .installer import validate_installation
 from .upgrade import compare_versions
 
 
@@ -213,20 +214,26 @@ def detect_installations(
 
             seen_paths.add(real_path)
 
-            # Get version and validate
+            # Get THIS install's own version by running its actual binary path.
+            # validate_installation(tool_name) only ever runs the PATH-active
+            # binary, so it would report the same version for every duplicate.
+            # version_command is deliberately omitted (it runs the tool by name,
+            # i.e. the active binary) to force path-based detection.
             version = None
             valid = True
             try:
-                success, _, version_str = validate_installation(tool_name, verbose=verbose)
-                if success and version_str:
-                    version = version_str
+                from .detection import get_version_line
+                from .collectors import extract_version_number
+                meta = _catalog_meta(tool_name)
+                line = get_version_line(real_path, tool_name, meta.get("version_flag"), None)
+                if line:
+                    version = extract_version_number(line) or line.strip()
                 else:
                     valid = False
             except Exception:
                 valid = False
-                version = "unknown"
 
-            if version is None:
+            if not version:
                 version = "unknown"
 
             # Classify installation method
@@ -246,6 +253,10 @@ def detect_installations(
             ))
 
             vlog(f"  Found: {real_path} ({method}, {version})", verbose)
+
+    # Sort by preference (highest first) so installations[0] is the preferred
+    # install — callers and the guide's "keep" marker rely on this ordering.
+    installations = sort_by_preference(installations)
 
     # Cache results
     _detection_cache[cache_key] = (installations, time.time())
@@ -282,8 +293,28 @@ def classify_install_method(
     return _classify_via_path(path)
 
 
+# Any of these characters in a path means it is not a plain absolute binary
+# path and must never be forwarded to a package-manager OS command.
+_UNSAFE_PATH_CHARS = re.compile(r"[\s;&|`$(){}<>*?!\"'\\]")
+
+
+def _is_safe_binary_path(path: str) -> bool:
+    """Validate a resolved binary path before passing it to OS commands.
+
+    Detected paths are os.path.realpath() of executables on PATH, so they are
+    always absolute and free of shell metacharacters — but validate explicitly
+    so untrusted-looking data never reaches a package-manager query.
+    """
+    return bool(path) and path.startswith("/") and not _UNSAFE_PATH_CHARS.search(path)
+
+
 def _classify_via_queries(path: str, tool_name: str, verbose: bool) -> str:
     """Classify via package manager queries."""
+    # Validate the path before any package-manager OS command: it must be a
+    # plain absolute path with no shell metacharacters.
+    if not _is_safe_binary_path(path):
+        return _classify_via_path(path)
+
     # dpkg (Debian/Ubuntu)
     if shutil.which('dpkg'):
         try:
@@ -527,8 +558,43 @@ def sort_by_preference(
     return sorted_installs
 
 
-_candidate_cache: dict[str, tuple[str, ...] | None] = {}
+_catalog_cache: dict[str, dict] = {}
 _catalog_instance = None
+_catalog_lock = threading.Lock()
+
+
+def _catalog_meta(tool_name: str) -> dict:
+    """Return cached catalog metadata for a tool: candidates + version command.
+
+    Thread-safe (bulk_reconcile detects tools in a ThreadPool). Returns an empty
+    dict for unknown tools so callers fall back to sane defaults.
+    """
+    global _catalog_instance
+    with _catalog_lock:
+        if tool_name in _catalog_cache:
+            return _catalog_cache[tool_name]
+        meta: dict = {}
+        try:
+            inst = _catalog_instance
+            if inst is None:
+                from .catalog import ToolCatalog
+                inst = ToolCatalog()
+                # Only cache a catalog that actually loaded, so a transiently
+                # empty/unavailable filesystem doesn't poison later calls.
+                if inst.all_tools():
+                    _catalog_instance = inst
+            entry = inst.get(tool_name)
+            if entry:
+                meta["candidates"] = tuple(entry.to_tool().candidates)
+                raw = getattr(entry, "_raw_data", None) or {}
+                meta["version_flag"] = raw.get("version_flag")
+                meta["version_command"] = raw.get("version_command")
+        except Exception:
+            meta = {}
+        # Only cache successful lookups — an empty result may be transient.
+        if meta:
+            _catalog_cache[tool_name] = meta
+        return meta
 
 
 def _resolve_candidates(tool_name: str) -> tuple[str, ...] | None:
@@ -539,19 +605,7 @@ def _resolve_candidates(tool_name: str) -> tuple[str, ...] | None:
     candidates. Returns None if the tool is unknown, so detection falls back to
     the bare tool name.
     """
-    global _catalog_instance
-    if tool_name in _candidate_cache:
-        return _candidate_cache[tool_name]
-    try:
-        if _catalog_instance is None:
-            from .catalog import ToolCatalog
-            _catalog_instance = ToolCatalog()
-        entry = _catalog_instance.get(tool_name)
-        cands = tuple(entry.to_tool().candidates) if entry else None
-    except Exception:
-        cands = None
-    _candidate_cache[tool_name] = cands
-    return cands
+    return _catalog_meta(tool_name).get("candidates")
 
 
 def reconcile_tool(

--- a/cli_audit/reconcile.py
+++ b/cli_audit/reconcile.py
@@ -527,6 +527,33 @@ def sort_by_preference(
     return sorted_installs
 
 
+_candidate_cache: dict[str, tuple[str, ...] | None] = {}
+_catalog_instance = None
+
+
+def _resolve_candidates(tool_name: str) -> tuple[str, ...] | None:
+    """Look up catalog candidates for a tool (cached).
+
+    Lets reconcile detect alternate-named duplicates (e.g. ``pip``/``pip3``,
+    ``fd``/``fdfind``) even when a caller (such as bulk_reconcile) does not pass
+    candidates. Returns None if the tool is unknown, so detection falls back to
+    the bare tool name.
+    """
+    global _catalog_instance
+    if tool_name in _candidate_cache:
+        return _candidate_cache[tool_name]
+    try:
+        if _catalog_instance is None:
+            from .catalog import ToolCatalog
+            _catalog_instance = ToolCatalog()
+        entry = _catalog_instance.get(tool_name)
+        cands = tuple(entry.to_tool().candidates) if entry else None
+    except Exception:
+        cands = None
+    _candidate_cache[tool_name] = cands
+    return cands
+
+
 def reconcile_tool(
     tool_name: str,
     mode: str = "parallel",
@@ -559,6 +586,11 @@ def reconcile_tool(
         config = load_config(verbose=verbose)
     if env is None:
         env = detect_environment(verbose=verbose)
+
+    # Resolve catalog candidates when a caller (e.g. bulk_reconcile) omits them,
+    # so alternate-named duplicates (pip/pip3, fd/fdfind) are still detected.
+    if candidates is None:
+        candidates = _resolve_candidates(tool_name)
 
     # Detect installations
     installations = detect_installations(tool_name, candidates, verbose)

--- a/cli_audit/render.py
+++ b/cli_audit/render.py
@@ -332,3 +332,16 @@ def print_summary(snapshot: dict[str, Any], tools: list[dict[str, Any]]) -> None
         f"\nReadiness{offline_tag}: {', '.join(parts)}",
         file=sys.stderr,
     )
+
+    # Discoverability hints (only when relevant)
+    if conflicts > 0:
+        print(
+            f"  → {conflicts} tool(s) with duplicate installs: "
+            "'make reconcile-all' (keeps preferred, removes the rest)",
+            file=sys.stderr,
+        )
+    if outdated > 0:
+        print(
+            "  → upgrade the package managers themselves: 'make upgrade-managed'",
+            file=sys.stderr,
+        )

--- a/docs/superpowers/specs/2026-07-08-reconcile-and-upgrade-discoverability-design.md
+++ b/docs/superpowers/specs/2026-07-08-reconcile-and-upgrade-discoverability-design.md
@@ -1,0 +1,198 @@
+# Design: Multi-install cleanup + upgrade discoverability
+
+**Date:** 2026-07-08
+**Status:** Approved (pre-implementation)
+**Related:** [ADR-009 first-class multi-install](../../adr/ADR-009-first-class-multi-install.md),
+[ADR-002 package-manager-hierarchy](../../adr/ADR-002-package-manager-hierarchy.md),
+[ADR-003 parallel-installation](../../adr/ADR-003-parallel-installation-approach.md)
+
+## Context
+
+Two user needs surfaced from real `make upgrade` runs:
+
+1. **Bulk-upgrade discoverability.** A command to run every package manager's own
+   full upgrade already exists — `make upgrade-managed` / `make upgrade-all`,
+   backed by `scripts/auto_update.sh` (18 managers incl. `gup`, `composer`,
+   `poetry`, `cargo`/`rustup`, `uv`/`pip`/`pipx`, `npm`/`pnpm`/`yarn`). It is not
+   discoverable from the `update`/`upgrade` flow, and it does not warn that
+   running managers' native upgrades moves tools past the versions this tool
+   pins (`pins.json`) and any project lockfiles.
+
+2. **Multi-install cleanup.** `guide.sh`'s `check_multi_installs()` detects
+   duplicate installs (e.g. `git-absorb` at `~/.local/bin` **and**
+   `~/.cargo/bin`) and prints a `⚠️` warning, but:
+   - the listing shows only `method: path` — no version, and no indication of
+     which install actually runs when the command is called without a path;
+   - it offers no action to remove the redundant install;
+   - the removal engine that *does* exist (`cli_audit/reconcile.py`, with
+     parallel/aggressive modes, version + `active` marker, preference ranking,
+     and a critical-tools protect list) is not reachable from the guide, and
+     `make reconcile-<tool>` calls the install-script `reconcile` action rather
+     than `reconcile.py`.
+
+ADR-009 already establishes multi-install as a first-class concern and notes
+`reconcile.py` "exists solely to delete duplicates" and re-scans from scratch.
+This design surfaces that engine and closes the discoverability gaps.
+
+## Goals
+
+- Make `reconcile.py` the single source of truth for multi-install listing,
+  the active/preferred markers, and removal planning.
+- Show version + active + preferred per install in the guide's warning.
+- Offer inline cleanup in the guide, and a `make reconcile-all` sweep.
+- Add discoverability hints and a pin/lock override warning.
+
+## Non-goals
+
+- No change to how single-install tools are audited/upgraded.
+- No new package-manager coverage in `auto_update.sh` (already comprehensive).
+- No automatic removal without explicit confirmation (see Safety model).
+- No change to ADR-002 preference policy (vendor/user-level wins); this design
+  consumes it, it does not redefine it.
+
+## Design
+
+### Component 1 — Richer multi-install listing (source of truth: reconcile.py)
+
+`reconcile.py` already computes, per install, `Installation.version`,
+`Installation.path`, `Installation.active` (the `which()`-resolved binary — the
+"default when called without a path"), and `preference_score`; `reconcile_tool()`
+yields the `preferred` install. A new JSON CLI entrypoint (Component 6) exposes
+this. `check_multi_installs()` in `guide.sh` switches from the thin shell
+`detect_all_installations` (`scripts/lib/capability.sh`) to this data and renders:
+
+```
+⚠️  Multiple installations detected (2):
+   • yq 4.44.3  manual  /home/sme/.local/bin/yq   → active  ✓ keep
+   • yq 4.40.1  manual  /usr/local/bin/yq
+```
+
+- `→ active` marks the PATH-resolved install (`Installation.active`).
+- `✓ keep` marks the preferred install reconcile would retain.
+- When `active` and `keep` are **different** installs, print one extra line:
+  `note: cleanup would change which yq runs (active → preferred).`
+- Version per install comes from reconcile's detection; if a version can't be
+  read, show `?` rather than suppressing the row.
+
+### Component 2 — Inline cleanup action in the guide (#3)
+
+When `check_multi_installs()` reports >1 install, the guide's option list gains:
+
+```
+c = clean up duplicates (keep preferred, remove the rest)
+```
+
+Selecting `c`:
+1. Prints the keep/remove plan (reuses Component 1 rendering).
+2. Confirms (per Safety model). Removing the **active** install prints an extra
+   heads-up naming the new active binary.
+3. Calls `reconcile_tool(..., mode="aggressive")` for that tool.
+4. Re-audits and reloads JSON (same pattern as the existing update path).
+
+Single-install tools never show option `c`. Critical tools (reconcile.py protect
+list) show the plan but decline to remove, with a reason line.
+
+### Component 3 — `make reconcile-all` (#4)
+
+Sweeps all installed tools, selects those with >1 install, and reconciles each
+via `bulk_reconcile()` in aggressive mode. Per the Safety model it shows the plan
+and confirms **per tool** before removing. Targets:
+
+- `make reconcile-all` — interactive confirm-each.
+- `make reconcile-all-dry-run` — preview only, removes nothing (`DRY_RUN=1`).
+
+Wraps `cli_audit/reconcile.py::bulk_reconcile`; honors the critical-tools protect
+list; reports a summary (reconciled / skipped / protected / failed).
+
+### Component 4 — Discoverability hints (#1)
+
+After the `make update` / `make upgrade` / guide summary, print 1–2 lines **only
+when relevant**:
+
+- If any tool has duplicate installs:
+  `N tool(s) have duplicate installs → make reconcile-all`
+- Always in the upgrade summary footer:
+  `Upgrade the package managers themselves → make upgrade-managed`
+
+Hints are informational, never block, and are suppressed when nothing applies
+(no duplicates → no reconcile hint).
+
+### Component 5 — Pin/lock override warning (#2)
+
+`make upgrade-managed` / `upgrade-all` print before running native manager
+upgrades:
+
+```
+⚠️  This runs each package manager's own upgrade. It moves tools PAST the
+    versions pinned in cli-audit (pins.json) and any project lockfiles —
+    pins are NOT enforced here.
+Continue? [y/N]
+```
+
+- Bypass with `FORCE=1` (non-interactive/CI) or when `--dry-run`.
+- Emitted once per invocation, before the first manager runs.
+- Lives in `scripts/auto_update.sh` (or its Make wrapper), guarded so
+  `upgrade-all-dry-run` never prompts.
+
+### Component 6 — reconcile.py JSON CLI entrypoint (enabler)
+
+Add a `reconcile` subcommand to `audit.py` exposing `reconcile.py`:
+
+- `audit.py reconcile <tool> --plan --json` → `{installations:[{version,method,
+  path,active,preferred}], preferred, active, protected}` for one tool (feeds
+  Components 1 & 2).
+- `audit.py reconcile --all --plan --json` → same, per tool with >1 install
+  (feeds Component 3).
+- `audit.py reconcile <tool> --apply [--yes]` / `--all --apply` → performs
+  aggressive reconciliation (feeds the actual removal in Components 2 & 3).
+
+`CLI_AUDIT_JSON=1` conventions and existing snapshot reuse apply. This entrypoint
+is the seam that lets shell surfaces (guide, make targets) consume the Python
+engine without re-implementing detection.
+
+## Safety model (chosen: confirm-each + dry-run)
+
+- Nothing is removed without an explicit `y`.
+- `make reconcile-all` confirms **per tool**; `reconcile-all-dry-run` previews.
+- Removing the **active** install prints an extra heads-up (what will run after).
+- Critical-tools protect list (`reconcile.py`) is always honored; protected
+  duplicates are listed but never removed.
+- `FORCE=1` / `--yes` bypass prompts for CI, but respect the protect list.
+
+## Data flow
+
+```
+reconcile.detect_installations(tool)
+  → [Installation(version, path, active, preference_score)]
+  → sort_by_preference()  → preferred
+  → audit.py reconcile --json  (Component 6)
+      → guide.sh check_multi_installs()   render (C1) + option 'c' (C2)
+      → make reconcile-all  → bulk_reconcile()  (C3)
+  → reconcile_tool(mode="aggressive")  → _uninstall_installation()  (removal)
+```
+
+## Files touched (anticipated)
+
+- `cli_audit/reconcile.py` — plan/JSON marks each install's `preferred` boolean
+  (derived from `ReconciliationResult.preferred` + `Installation.active`); no
+  engine rewrite.
+- `audit.py` — new `reconcile` subcommand (Component 6).
+- `scripts/guide.sh` — `check_multi_installs()` rendering (C1), option `c` (C2),
+  summary hints (C4).
+- `scripts/auto_update.sh` — pin/lock override warning (C5).
+- `Makefile.d/user.mk` — `reconcile-all`, `reconcile-all-dry-run` targets;
+  `.PHONY` list.
+- `docs/adr/ADR-009-*` — status note that aggressive reconcile is now
+  user-reachable (follow-up, not blocking).
+
+## Testing
+
+- **Unit (`cli_audit`):** plan output with active ≠ preferred; critical-tool
+  protection (listed, not removed); single-install → empty plan; `--all` selects
+  only multi-install tools; JSON shape.
+- **Shell (`tests/test_guide_multi_install.sh`):** listing shows version +
+  `→ active` + `✓ keep`; option `c` appears only with duplicates; confirm/decline
+  paths (mocked removal).
+- **Make target:** `reconcile-all-dry-run` removes nothing and lists a plan;
+  `FORCE=1` path is non-interactive.
+- **Regression:** existing single-install and up-to-date paths unchanged.

--- a/docs/superpowers/specs/2026-07-08-reconcile-and-upgrade-discoverability-design.md
+++ b/docs/superpowers/specs/2026-07-08-reconcile-and-upgrade-discoverability-design.md
@@ -111,8 +111,9 @@ when relevant**:
 
 - If any tool has duplicate installs:
   `N tool(s) have duplicate installs → make reconcile-all`
-- Always in the upgrade summary footer:
-  `Upgrade the package managers themselves → make upgrade-managed`
+- `Upgrade the package managers themselves → make upgrade-managed`: shown in the
+  audit summary when outdated tools exist, and always in the interactive
+  upgrade (guide) summary footer.
 
 Hints are informational, never block, and are suppressed when nothing applies
 (no duplicates → no reconcile hint).

--- a/scripts/auto_update.sh
+++ b/scripts/auto_update.sh
@@ -843,6 +843,25 @@ run_all_updates() {
   # Determine target scope
   local target_scope="${SCOPE:-$(determine_default_scope)}"
 
+  # Pin/lock override warning: this runs each package manager's own upgrade,
+  # which moves tools past the versions cli-audit pins (pins.json) and any
+  # project lockfiles. Skip the prompt in dry-run or when FORCE=1 (CI).
+  if [ "$DRY_RUN" != "1" ] && [ "${FORCE:-0}" != "1" ]; then
+    printf "[auto-update] ⚠️  This runs each package manager's own upgrade. It moves tools\n" >&2
+    printf "              PAST the versions pinned in cli-audit (pins.json) and any project\n" >&2
+    printf "              lockfiles — pins are NOT enforced here.\n" >&2
+    local ans=""
+    if [ -t 0 ]; then
+      read -r -p "[auto-update] Continue? [y/N] " ans || true
+    elif [ -r /dev/tty ]; then
+      read -r -p "[auto-update] Continue? [y/N] " ans </dev/tty || true
+    fi
+    if [ "$ans" != "y" ] && [ "$ans" != "Y" ]; then
+      log "Aborted (no changes made)."
+      return 0
+    fi
+  fi
+
   log "Starting auto-update for scope: $target_scope"
   echo ""
 

--- a/scripts/guide.sh
+++ b/scripts/guide.sh
@@ -16,6 +16,13 @@ CLI="${PYTHON:-python3}"
 # Ignore pins: IGNORE_PINS=1 to show all tools regardless of pin status
 IGNORE_PINS="${IGNORE_PINS:-0}"
 
+# Duplicate-install count for the tool most recently passed to
+# check_multi_installs(); consumed by process_tool to offer inline cleanup.
+LAST_MULTI_COUNT=0
+# Space-separated tool names seen with duplicate installs this run (for the
+# summary hint); de-duplicated when counted.
+GUIDE_DUP_LIST=""
+
 # Summary counters
 SUMMARY_UPDATED=0
 SUMMARY_SKIPPED=0
@@ -33,6 +40,14 @@ print_summary() {
   printf "  Failed:    %d\n" "$SUMMARY_FAILED"
   echo
   echo "Re-run: make audit"
+  local dup_count=0
+  if [ -n "${GUIDE_DUP_LIST// /}" ]; then
+    dup_count="$(printf '%s\n' $GUIDE_DUP_LIST | sort -u | grep -c . || true)"
+  fi
+  if [ "$dup_count" -gt 0 ]; then
+    printf "  → %d tool(s) with duplicate installs: 'make reconcile-all'\n" "$dup_count"
+  fi
+  echo "  → upgrade the package managers themselves: 'make upgrade-managed'"
 }
 
 # Category filter: CATEGORY=python,go or --category=python
@@ -221,11 +236,61 @@ check_multi_installs() {
   local binary_name
   binary_name="$(catalog_get_property "$catalog_tool" binary_name)"
   binary_name="${binary_name:-$catalog_tool}"
-  local all_installs
-  all_installs="$(detect_all_installations "$catalog_tool" "$binary_name" 2>/dev/null || true)"
+  # Cheap shell pre-check: only pay for the richer reconcile query when there
+  # actually is more than one install (the common case is a single install).
+  # Check every catalog candidate binary (e.g. pip AND pip3, fd AND fdfind) so
+  # alternate-named duplicates aren't missed here.
+  local cand_list
+  cand_list="$(jq -r '.candidates[]? // empty' "$ROOT/catalog/$catalog_tool.json" 2>/dev/null)"
+  [ -z "$cand_list" ] && cand_list="$binary_name"
+  local all_installs=""
+  local cand found
+  while IFS= read -r cand; do
+    [ -z "$cand" ] && continue
+    found="$(detect_all_installations "$catalog_tool" "$cand" 2>/dev/null || true)"
+    [ -n "$found" ] && all_installs+="${all_installs:+$'\n'}$found"
+  done <<< "$cand_list"
+  all_installs="$(printf '%s\n' "$all_installs" | grep -v '^[[:space:]]*$' | sort -u || true)"
   local install_count
   install_count="$(echo "$all_installs" | grep -c . || true)"
-  if [ "$install_count" -gt 1 ]; then
+  LAST_MULTI_COUNT="$install_count"
+  [ "$install_count" -le 1 ] && return 0
+  GUIDE_DUP_LIST="$GUIDE_DUP_LIST $catalog_tool"
+
+  # Duplicates exist — render version + active + preferred markers from the
+  # reconcile plan (the single source of truth). Fall back to the basic listing
+  # if reconcile produces nothing.
+  local recon_json rendered
+  recon_json="$(cd "$ROOT" && CLI_AUDIT_JSON=1 "$CLI" audit.py --reconcile "$catalog_tool" 2>/dev/null || true)"
+  rendered="$(RECON_JSON="$recon_json" "$CLI" - <<'PY'
+import os, json
+try:
+    doc = json.loads(os.environ.get("RECON_JSON", "").strip())
+    plan = (doc.get("results") or [None])[0]
+    installs = plan.get("installations") or []
+except Exception:
+    raise SystemExit(0)
+if len(installs) < 2:
+    raise SystemExit(0)
+active_path = (plan.get("active") or {}).get("path")
+pref_path = (plan.get("preferred") or {}).get("path")
+lines = [f"    ⚠️  Multiple installations detected ({len(installs)}):"]
+for i in installs:
+    marks = []
+    if i.get("active"):
+        marks.append("→ active")
+    if i.get("preferred"):
+        marks.append("✓ keep")
+    suffix = ("  " + "  ".join(marks)) if marks else ""
+    lines.append(f"       • {i.get('version') or '?'}  {i.get('method')}  {i.get('path')}{suffix}")
+if active_path and pref_path and active_path != pref_path:
+    lines.append(f"       note: cleanup would change which {plan.get('tool')} runs (active → preferred).")
+print("\n".join(lines))
+PY
+)"
+  if [ -n "$rendered" ]; then
+    printf '%s\n' "$rendered"
+  else
     printf "    ⚠️  Multiple installations detected (%d):\n" "$install_count"
     echo "$all_installs" | while IFS=: read -r inst_method inst_path; do
       printf "       • %s: %s\n" "$inst_method" "$inst_path"
@@ -446,6 +511,9 @@ process_tool() {
       printf "      p = Pin to %s (don't ask for upgrades)\n" "$installed"
     fi
     printf "      r = Remove/uninstall this tool\n"
+    if [ "${LAST_MULTI_COUNT:-0}" -gt 1 ]; then
+      printf "      c = Clean up duplicates (keep preferred, remove the rest)\n"
+    fi
     if [ -n "$is_multi_version" ]; then
       printf "      P = Skip ALL outdated %s cycles\n" "$catalog_tool"
     fi
@@ -469,6 +537,9 @@ process_tool() {
       prompt_text="Upgrade? [Y/a/n/s/p/r/P] "
     else
       prompt_text="Upgrade? [Y/a/n/s/p/r] "
+    fi
+    if [ "${LAST_MULTI_COUNT:-0}" -gt 1 ]; then
+      prompt_text="${prompt_text%] }/c] "
     fi
   else
     if [ -n "$is_multi_version" ]; then
@@ -704,6 +775,32 @@ process_tool() {
         fi
       else
         printf "    Tool is not installed, nothing to remove\n"
+      fi
+      ;;
+    [Cc])
+      # Clean up duplicate installations: keep the preferred, remove the rest.
+      # The plan (keep/remove, active marker) was already shown by
+      # check_multi_installs above. Confirm the destructive step, then apply.
+      if [ "${LAST_MULTI_COUNT:-0}" -gt 1 ]; then
+        local ans_c=""
+        if [ -t 0 ]; then
+          read -r -p "    Remove the non-preferred duplicate(s)? [y/N] " ans_c || true
+        elif [ -r /dev/tty ]; then
+          read -r -p "    Remove the non-preferred duplicate(s)? [y/N] " ans_c </dev/tty || true
+        fi
+        if [ "$ans_c" = "y" ] || [ "$ans_c" = "Y" ]; then
+          if (cd "$ROOT" && "$CLI" audit.py --reconcile "$catalog_tool" --apply --yes); then
+            printf "    ✓ Duplicates removed (kept preferred install)\n"
+          else
+            printf "    ⚠️  Cleanup did not complete (tool may be on the protect list)\n"
+          fi
+          CLI_AUDIT_JSON=1 CLI_AUDIT_COLLECT=1 CLI_AUDIT_MERGE=1 "$CLI" audit.py "$tool" >/dev/null 2>&1 || true
+          reload_audit_json
+        else
+          printf "    Skipped cleanup\n"
+        fi
+      else
+        printf "    No duplicate installations to clean up\n"
       fi
       ;;
     [P])

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -132,7 +132,7 @@ class TestDetectInstallations:
     """Tests for installation detection."""
 
     @skip_on_windows
-    @patch("cli_audit.reconcile.validate_installation")
+    @patch("cli_audit.detection.get_version_line")
     @patch("cli_audit.reconcile.shutil.which")
     @patch("os.path.exists")
     @patch("os.access")
@@ -143,7 +143,7 @@ class TestDetectInstallations:
         mock_access,
         mock_exists,
         mock_which,
-        mock_validate,
+        mock_version,
         monkeypatch,
     ):
         """Test detecting single installation."""
@@ -158,7 +158,8 @@ class TestDetectInstallations:
         mock_access.return_value = True
         mock_realpath.side_effect = lambda p: p
         mock_which.return_value = "/home/user/.cargo/bin/rg"
-        mock_validate.return_value = (True, "/home/user/.cargo/bin/rg", "14.1.0")
+        # get_version_line(path, tool, flag, cmd) -> version line for that path
+        mock_version.return_value = "14.1.0"
 
         # Clear cache
         clear_detection_cache()
@@ -172,7 +173,7 @@ class TestDetectInstallations:
         assert installations[0].active is True
 
     @skip_on_windows
-    @patch("cli_audit.reconcile.validate_installation")
+    @patch("cli_audit.detection.get_version_line")
     @patch("cli_audit.reconcile.shutil.which")
     @patch("os.path.exists")
     @patch("os.access")
@@ -183,7 +184,7 @@ class TestDetectInstallations:
         mock_access,
         mock_exists,
         mock_which,
-        mock_validate,
+        mock_version,
         monkeypatch,
     ):
         """Test detecting multiple installations."""
@@ -201,15 +202,11 @@ class TestDetectInstallations:
         mock_realpath.side_effect = lambda p: p
         mock_which.return_value = "/home/user/.cargo/bin/rg"
 
-        def validate_side_effect(tool, verbose=False):
-            # Return different versions for different paths
-            which_result = mock_which.return_value
-            if "cargo" in which_result:
-                return (True, "/home/user/.cargo/bin/rg", "14.1.0")
-            else:
-                return (True, "/usr/bin/rg", "13.0.0")
+        def version_side_effect(path, *args, **kwargs):
+            # Each install reports its OWN version, keyed on its real path.
+            return "14.1.0" if "cargo" in path else "13.0.0"
 
-        mock_validate.side_effect = validate_side_effect
+        mock_version.side_effect = version_side_effect
 
         # Clear cache
         clear_detection_cache()
@@ -218,6 +215,32 @@ class TestDetectInstallations:
         installations = detect_installations("ripgrep", ["rg"])
 
         assert len(installations) == 2
+        # Each install must report its OWN version (not the active binary's).
+        versions = {i.path: i.version for i in installations}
+        assert versions["/home/user/.cargo/bin/rg"] == "14.1.0"
+        assert versions["/usr/bin/rg"] == "13.0.0"
+
+    @skip_on_windows
+    @patch("cli_audit.detection.get_version_line")
+    @patch("cli_audit.reconcile.shutil.which")
+    @patch("os.path.exists")
+    @patch("os.access")
+    @patch("os.path.realpath")
+    def test_detect_version_probe_failure_marks_unknown(
+        self, mock_realpath, mock_access, mock_exists, mock_which, mock_version, monkeypatch
+    ):
+        """A version probe that raises leaves the install detected but 'unknown'."""
+        monkeypatch.setenv("PATH", "/home/user/.cargo/bin")
+        mock_exists.side_effect = lambda p: p == "/home/user/.cargo/bin/rg"
+        mock_access.return_value = True
+        mock_realpath.side_effect = lambda p: p
+        mock_which.return_value = "/home/user/.cargo/bin/rg"
+        mock_version.side_effect = Exception("probe failed")
+        clear_detection_cache()
+
+        installations = detect_installations("ripgrep", ["rg"])
+        assert len(installations) == 1
+        assert installations[0].version == "unknown"
 
     def test_detect_no_installations(self, monkeypatch):
         """Test detecting when tool not installed."""

--- a/tests/test_reconcile_cli.py
+++ b/tests/test_reconcile_cli.py
@@ -1,0 +1,138 @@
+"""Tests for the `audit.py --reconcile` entrypoint and its helpers.
+
+Covers plan shaping (active vs preferred markers), catalog candidate
+resolution, and the JSON output for plan/apply/protected/divergence cases.
+"""
+import argparse
+import io
+import json
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+import audit
+from cli_audit.reconcile import Installation, ReconciliationResult
+
+
+def _ns(**kw):
+    """Build an args namespace with reconcile defaults."""
+    base = {"verbose": False, "apply": False, "yes": False, "all": False, "tools": []}
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+def _inst(path, version="1.0.0", method="manual", active=False):
+    return Installation("demo", version, method, path, active)
+
+
+class TestShapeReconcilePlan:
+    def test_marks_preferred_and_active_on_same_install(self):
+        a = _inst("/home/u/.local/bin/demo", active=True)
+        b = _inst("/usr/local/bin/demo")
+        plan = audit._shape_reconcile_plan("demo", [a, b], preferred=a, active=a, protected=False)
+
+        assert plan["count"] == 2
+        assert plan["protected"] is False
+        assert plan["installations"][0]["preferred"] is True
+        assert plan["installations"][0]["active"] is True
+        assert plan["installations"][1]["preferred"] is False
+
+    def test_active_differs_from_preferred(self):
+        pref = _inst("/home/u/.local/bin/demo")            # preferred, not active
+        act = _inst("/usr/local/bin/demo", active=True)     # active, not preferred
+        plan = audit._shape_reconcile_plan("demo", [pref, act], preferred=pref, active=act, protected=False)
+
+        assert plan["preferred"]["path"] == "/home/u/.local/bin/demo"
+        assert plan["active"]["path"] == "/usr/local/bin/demo"
+        # exactly one preferred, one active, and they are different installs
+        prefs = [i for i in plan["installations"] if i["preferred"]]
+        acts = [i for i in plan["installations"] if i["active"]]
+        assert len(prefs) == 1 and len(acts) == 1
+        assert prefs[0]["path"] != acts[0]["path"]
+
+    def test_protected_flag(self):
+        a = _inst("/usr/bin/demo", active=True)
+        plan = audit._shape_reconcile_plan("demo", [a], preferred=a, active=a, protected=True)
+        assert plan["protected"] is True
+
+
+class TestResolveCandidates:
+    def test_returns_catalog_candidates(self):
+        from cli_audit.reconcile import _resolve_candidates
+        # pip declares candidates ["pip", "pip3"] in the catalog
+        cands = _resolve_candidates("pip")
+        assert cands is not None
+        assert "pip3" in cands
+
+    def test_unknown_tool_returns_none(self):
+        from cli_audit.reconcile import _resolve_candidates, _candidate_cache
+        _candidate_cache.pop("not-a-real-tool-xyz", None)
+        assert _resolve_candidates("not-a-real-tool-xyz") is None
+
+    def test_result_is_cached(self):
+        from cli_audit.reconcile import _resolve_candidates, _candidate_cache
+        _resolve_candidates("pip")
+        assert "pip" in _candidate_cache
+
+
+class TestCmdReconcilePlanJSON:
+    def test_single_tool_plan_json(self):
+        pref = _inst("/home/u/.local/bin/demo", active=True)
+        other = _inst("/usr/local/bin/demo")
+        with patch("cli_audit.reconcile.detect_installations", return_value=[pref, other]), \
+                patch.object(audit, "JSON_MODE", True):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = audit.cmd_reconcile(_ns(tools=["demo"]))
+        assert rc == 0
+        doc = json.loads(buf.getvalue())
+        plan = doc["results"][0]
+        assert plan["count"] == 2
+        assert plan["installations"][0]["preferred"] is True
+
+    def test_no_tools_and_no_all_errors(self):
+        rc = audit.cmd_reconcile(_ns(tools=[]))
+        assert rc == 2
+
+
+class TestCmdReconcileApplyJSON:
+    def test_apply_reports_removed(self):
+        removed = _inst("/usr/local/bin/demo")
+        kept = _inst("/home/u/.local/bin/demo", active=True)
+        result = ReconciliationResult(
+            tool="demo",
+            installations=(kept, removed),
+            preferred=kept,
+            active=kept,
+            path_issues=(),
+            action_taken="removed",
+            removed_installations=(removed,),
+            success=True,
+        )
+        with patch("cli_audit.reconcile.reconcile_tool", return_value=result), \
+                patch.object(audit, "JSON_MODE", True):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = audit.cmd_reconcile(_ns(tools=["demo"], apply=True, yes=True))
+        assert rc == 0
+        doc = json.loads(buf.getvalue())
+        assert doc["results"][0]["action_taken"] == "removed"
+        assert doc["results"][0]["removed_installations"][0]["path"] == "/usr/local/bin/demo"
+
+    def test_apply_protected_returns_nonzero(self):
+        kept = _inst("/usr/bin/demo", active=True)
+        result = ReconciliationResult(
+            tool="demo",
+            installations=(kept,),
+            preferred=kept,
+            active=kept,
+            path_issues=(),
+            action_taken="blocked",
+            success=False,
+            error_message="on system safelist",
+        )
+        with patch("cli_audit.reconcile.reconcile_tool", return_value=result), \
+                patch.object(audit, "JSON_MODE", True):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = audit.cmd_reconcile(_ns(tools=["demo"], apply=True, yes=True))
+        assert rc == 1

--- a/tests/test_reconcile_cli.py
+++ b/tests/test_reconcile_cli.py
@@ -64,14 +64,34 @@ class TestResolveCandidates:
         assert "pip3" in cands
 
     def test_unknown_tool_returns_none(self):
-        from cli_audit.reconcile import _resolve_candidates, _candidate_cache
-        _candidate_cache.pop("not-a-real-tool-xyz", None)
+        from cli_audit.reconcile import _resolve_candidates, _catalog_cache
+        _catalog_cache.pop("not-a-real-tool-xyz", None)
         assert _resolve_candidates("not-a-real-tool-xyz") is None
 
     def test_result_is_cached(self):
-        from cli_audit.reconcile import _resolve_candidates, _candidate_cache
+        from cli_audit.reconcile import _resolve_candidates, _catalog_cache
         _resolve_candidates("pip")
-        assert "pip" in _candidate_cache
+        assert "pip" in _catalog_cache
+
+
+class TestSafeBinaryPath:
+    def test_accepts_normal_absolute_paths(self):
+        from cli_audit.reconcile import _is_safe_binary_path
+        assert _is_safe_binary_path("/usr/bin/rg")
+        assert _is_safe_binary_path("/home/u/.cargo/bin/fd")
+
+    def test_rejects_shell_metacharacters_and_relative(self):
+        from cli_audit.reconcile import _is_safe_binary_path
+        assert not _is_safe_binary_path("/opt/x; rm -rf /")
+        assert not _is_safe_binary_path("/opt/a$(id)")
+        assert not _is_safe_binary_path("rg")
+        assert not _is_safe_binary_path("")
+
+    def test_classify_via_queries_short_circuits_unsafe_path(self):
+        # An unsafe path must never reach a package-manager OS query; it falls
+        # back to path-based classification instead.
+        from cli_audit.reconcile import _classify_via_queries
+        assert isinstance(_classify_via_queries("/opt/x; rm -rf /", "demo", False), str)
 
 
 class TestCmdReconcilePlanJSON:

--- a/tests/test_reconcile_dryrun.sh
+++ b/tests/test_reconcile_dryrun.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Guards the safety-critical reconcile invariants at the shell/CLI boundary:
+#   - the dry-run make target must NEVER pass --apply (no removals)
+#   - the real target must pass --apply
+#   - the CLI requires an explicit tool or --all
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$DIR/.." && pwd)"
+PYTHON="${PYTHON:-python3}"
+cd "$ROOT"
+
+pass=0
+fail=0
+check() { # desc, condition-exit-code
+  if [ "$2" -eq 0 ]; then echo "  PASS: $1"; pass=$((pass + 1));
+  else echo "  FAIL: $1"; fail=$((fail + 1)); fi
+}
+
+echo "=== Test: reconcile-all-dry-run never applies ==="
+dryrun_recipe="$(grep -A1 '^reconcile-all-dry-run:' Makefile.d/user.mk | tail -1)"
+echo "$dryrun_recipe" | grep -q -- '--reconcile'; check "dry-run uses --reconcile" $?
+echo "$dryrun_recipe" | grep -q -- '--all'; check "dry-run uses --all" $?
+if echo "$dryrun_recipe" | grep -q -- '--apply'; then check "dry-run must NOT use --apply" 1; else check "dry-run must NOT use --apply" 0; fi
+
+echo "=== Test: reconcile-all applies ==="
+apply_recipe="$(grep -A1 '^reconcile-all:' Makefile.d/user.mk | tail -1)"
+echo "$apply_recipe" | grep -q -- '--apply'; check "reconcile-all uses --apply" $?
+
+echo "=== Test: CLI contract ==="
+"$PYTHON" audit.py --reconcile >/dev/null 2>&1; rc=$?
+[ "$rc" -ne 0 ]; check "reconcile without tool/--all exits non-zero" $?
+
+"$PYTHON" audit.py --apply >/dev/null 2>&1; rc=$?
+[ "$rc" -ne 0 ]; check "reconcile-only flags without --reconcile exit non-zero" $?
+
+"$PYTHON" audit.py --help 2>&1 | grep -q -- '--reconcile'
+check "--reconcile listed in --help" $?
+
+echo ""
+echo "Results: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -11,7 +11,7 @@ from typing import Any
 import pytest
 
 from cli_audit import pins as pins_module
-from cli_audit.render import render_table
+from cli_audit.render import render_table, print_summary
 
 
 @pytest.fixture(autouse=True)
@@ -357,3 +357,24 @@ class TestAutoMarker:
 
 # (Env-var override of DEFAULT_PINS_PATH is covered by
 # ``tests/test_pins.py::TestDefaultPath::test_env_override``.)
+
+
+class TestSummaryHints:
+    """Discoverability hints in print_summary (Component 4)."""
+
+    def test_hints_shown_when_conflicts_and_outdated(self, capsys):
+        tools = [
+            {"tool": "a", "status": "CONFLICT", "installed": "1.0"},
+            {"tool": "b", "status": "OUTDATED", "installed": "1.0"},
+        ]
+        print_summary({"__meta__": {"count": 2}}, tools)
+        err = capsys.readouterr().err
+        assert "make reconcile-all" in err
+        assert "make upgrade-managed" in err
+
+    def test_no_hints_when_all_clean(self, capsys):
+        tools = [{"tool": "a", "status": "UP-TO-DATE", "installed": "1.0"}]
+        print_summary({"__meta__": {"count": 1}}, tools)
+        err = capsys.readouterr().err
+        assert "make reconcile-all" not in err
+        assert "make upgrade-managed" not in err

--- a/tmux-client-988175.log
+++ b/tmux-client-988175.log
@@ -1,0 +1,111 @@
+1783499626.080425 client started (988175): version 3.4, socket /tmp/tmux-1000/default, protocol 8
+1783499626.080475 on Linux 6.18.35.2-microsoft-standard-WSL2 #1 SMP PREEMPT_DYNAMIC Wed Jun 17 23:14:00 UTC 2026
+1783499626.080480 using libevent 2.1.12-stable poll
+1783499626.080482 using ncurses 6.4 20240113
+1783499626.080592 flags are 0x18010000
+1783499626.080747 socket is /tmp/tmux-1000/default
+1783499626.080768 trying connect
+1783499626.080827 connect failed: Connection refused
+1783499626.080839 lock file is /tmp/tmux-1000/default.lock
+1783499626.081743 flock succeeded
+1783499626.081754 got lock (6)
+1783499626.081765 trying connect
+1783499626.081782 connect failed: Connection refused
+1783499626.082647 add peer 0x58e4724b0830: 7 ((nil))
+1783499626.083291 sending message 100 to peer 0x58e4724b0830 (4 bytes)
+1783499626.083390 sending message 111 to peer 0x58e4724b0830 (8 bytes)
+1783499626.083400 sending message 101 to peer 0x58e4724b0830 (5 bytes)
+1783499626.083403 sending message 109 to peer 0x58e4724b0830 (4 bytes)
+1783499626.083405 sending message 102 to peer 0x58e4724b0830 (1 bytes)
+1783499626.083407 sending message 108 to peer 0x58e4724b0830 (37 bytes)
+1783499626.083410 sending message 104 to peer 0x58e4724b0830 (0 bytes)
+1783499626.083412 sending message 110 to peer 0x58e4724b0830 (0 bytes)
+1783499626.083415 sending message 107 to peer 0x58e4724b0830 (4 bytes)
+1783499626.083418 sending message 105 to peer 0x58e4724b0830 (35 bytes)
+1783499626.083420 sending message 105 to peer 0x58e4724b0830 (50 bytes)
+1783499626.083421 sending message 105 to peer 0x58e4724b0830 (37 bytes)
+1783499626.083423 sending message 105 to peer 0x58e4724b0830 (47 bytes)
+1783499626.083425 sending message 105 to peer 0x58e4724b0830 (14 bytes)
+1783499626.083427 sending message 105 to peer 0x58e4724b0830 (23 bytes)
+1783499626.083428 sending message 105 to peer 0x58e4724b0830 (27 bytes)
+1783499626.083430 sending message 105 to peer 0x58e4724b0830 (13 bytes)
+1783499626.083432 sending message 105 to peer 0x58e4724b0830 (63 bytes)
+1783499626.083433 sending message 105 to peer 0x58e4724b0830 (28 bytes)
+1783499626.083435 sending message 105 to peer 0x58e4724b0830 (27 bytes)
+1783499626.083437 sending message 105 to peer 0x58e4724b0830 (68 bytes)
+1783499626.083439 sending message 105 to peer 0x58e4724b0830 (39 bytes)
+1783499626.083441 sending message 105 to peer 0x58e4724b0830 (60 bytes)
+1783499626.083442 sending message 105 to peer 0x58e4724b0830 (31 bytes)
+1783499626.083444 sending message 105 to peer 0x58e4724b0830 (19 bytes)
+1783499626.083446 sending message 105 to peer 0x58e4724b0830 (17 bytes)
+1783499626.083447 sending message 105 to peer 0x58e4724b0830 (27 bytes)
+1783499626.083450 sending message 105 to peer 0x58e4724b0830 (481 bytes)
+1783499626.083452 sending message 105 to peer 0x58e4724b0830 (49 bytes)
+1783499626.083454 sending message 105 to peer 0x58e4724b0830 (56 bytes)
+1783499626.083456 sending message 105 to peer 0x58e4724b0830 (256 bytes)
+1783499626.083458 sending message 105 to peer 0x58e4724b0830 (11 bytes)
+1783499626.083460 sending message 105 to peer 0x58e4724b0830 (11 bytes)
+1783499626.083461 sending message 105 to peer 0x58e4724b0830 (31 bytes)
+1783499626.083463 sending message 105 to peer 0x58e4724b0830 (16 bytes)
+1783499626.083465 sending message 105 to peer 0x58e4724b0830 (24 bytes)
+1783499626.083467 sending message 105 to peer 0x58e4724b0830 (15 bytes)
+1783499626.083468 sending message 105 to peer 0x58e4724b0830 (50 bytes)
+1783499626.083470 sending message 105 to peer 0x58e4724b0830 (43 bytes)
+1783499626.083472 sending message 105 to peer 0x58e4724b0830 (56 bytes)
+1783499626.083473 sending message 105 to peer 0x58e4724b0830 (16 bytes)
+1783499626.083475 sending message 105 to peer 0x58e4724b0830 (48 bytes)
+1783499626.083476 sending message 105 to peer 0x58e4724b0830 (13 bytes)
+1783499626.083478 sending message 105 to peer 0x58e4724b0830 (34 bytes)
+1783499626.083480 sending message 105 to peer 0x58e4724b0830 (32 bytes)
+1783499626.083481 sending message 105 to peer 0x58e4724b0830 (12 bytes)
+1783499626.083484 sending message 105 to peer 0x58e4724b0830 (1817 bytes)
+1783499626.083520 sending message 105 to peer 0x58e4724b0830 (17 bytes)
+1783499626.083522 sending message 105 to peer 0x58e4724b0830 (49 bytes)
+1783499626.083524 sending message 105 to peer 0x58e4724b0830 (14 bytes)
+1783499626.083526 sending message 105 to peer 0x58e4724b0830 (23 bytes)
+1783499626.083528 sending message 105 to peer 0x58e4724b0830 (58 bytes)
+1783499626.083529 sending message 105 to peer 0x58e4724b0830 (37 bytes)
+1783499626.083531 sending message 105 to peer 0x58e4724b0830 (44 bytes)
+1783499626.083534 sending message 105 to peer 0x58e4724b0830 (8256 bytes)
+1783499626.083548 sending message 105 to peer 0x58e4724b0830 (50 bytes)
+1783499626.083552 sending message 105 to peer 0x58e4724b0830 (38 bytes)
+1783499626.083554 sending message 105 to peer 0x58e4724b0830 (38 bytes)
+1783499626.083556 sending message 105 to peer 0x58e4724b0830 (40 bytes)
+1783499626.083557 sending message 105 to peer 0x58e4724b0830 (41 bytes)
+1783499626.083559 sending message 105 to peer 0x58e4724b0830 (17 bytes)
+1783499626.083561 sending message 105 to peer 0x58e4724b0830 (16 bytes)
+1783499626.083562 sending message 105 to peer 0x58e4724b0830 (8 bytes)
+1783499626.083564 sending message 105 to peer 0x58e4724b0830 (18 bytes)
+1783499626.083566 sending message 105 to peer 0x58e4724b0830 (46 bytes)
+1783499626.083567 sending message 105 to peer 0x58e4724b0830 (38 bytes)
+1783499626.083569 sending message 105 to peer 0x58e4724b0830 (20 bytes)
+1783499626.083570 sending message 105 to peer 0x58e4724b0830 (10 bytes)
+1783499626.083572 sending message 105 to peer 0x58e4724b0830 (9 bytes)
+1783499626.083574 sending message 105 to peer 0x58e4724b0830 (27 bytes)
+1783499626.083575 sending message 105 to peer 0x58e4724b0830 (25 bytes)
+1783499626.083577 sending message 105 to peer 0x58e4724b0830 (55 bytes)
+1783499626.083579 sending message 105 to peer 0x58e4724b0830 (23 bytes)
+1783499626.083580 sending message 105 to peer 0x58e4724b0830 (11 bytes)
+1783499626.083582 sending message 105 to peer 0x58e4724b0830 (26 bytes)
+1783499626.083583 sending message 105 to peer 0x58e4724b0830 (24 bytes)
+1783499626.083585 sending message 105 to peer 0x58e4724b0830 (33 bytes)
+1783499626.083587 sending message 105 to peer 0x58e4724b0830 (23 bytes)
+1783499626.083588 sending message 105 to peer 0x58e4724b0830 (36 bytes)
+1783499626.083590 sending message 105 to peer 0x58e4724b0830 (53 bytes)
+1783499626.083591 sending message 105 to peer 0x58e4724b0830 (48 bytes)
+1783499626.083593 sending message 105 to peer 0x58e4724b0830 (38 bytes)
+1783499626.083595 sending message 105 to peer 0x58e4724b0830 (19 bytes)
+1783499626.083596 sending message 106 to peer 0x58e4724b0830 (0 bytes)
+1783499626.083695 sending message 200 to peer 0x58e4724b0830 (4 bytes)
+1783499626.083706 client loop enter
+1783499626.083818 client_signal: Child exited
+1783499626.150036 peer 0x58e4724b0830 message 303
+1783499626.150086 open write file 2 -
+1783499626.150182 sending message 305 to peer 0x58e4724b0830 (8 bytes)
+1783499626.150246 write check file 2
+1783499626.150669 peer 0x58e4724b0830 message 304
+1783499626.150676 write 37 to file 2
+1783499626.150681 peer 0x58e4724b0830 message 203
+1783499626.150684 file 2 37 bytes left
+1783499626.150759 write check file 2
+1783499626.150765 client loop exit

--- a/tmux-server-988184.log
+++ b/tmux-server-988184.log
@@ -1,0 +1,16448 @@
+1783499626.083799 server started (988184): version 3.4, socket /tmp/tmux-1000/default, protocol 8
+1783499626.083836 on Linux 6.18.35.2-microsoft-standard-WSL2 #1 SMP PREEMPT_DYNAMIC Wed Jun 17 23:14:00 UTC 2026
+1783499626.083849 using libevent 2.1.12-stable poll
+1783499626.083852 using ncurses 6.4 20240113
+1783499626.084341 input_key_build: 0x10e003 (PasteStart) is \033[200~
+1783499626.084361 input_key_build: 0x10e004 (PasteEnd) is \033[201~
+1783499626.084365 input_key_build: 0x10e195 (F1) is \033OP
+1783499626.084368 input_key_build: 0x10e196 (F2) is \033OQ
+1783499626.084372 input_key_build: 0x10e197 (F3) is \033OR
+1783499626.084374 input_key_build: 0x10e198 (F4) is \033OS
+1783499626.084377 input_key_build: 0x10e199 (F5) is \033[15~
+1783499626.084379 input_key_build: 0x10e19a (F6) is \033[17~
+1783499626.084387 input_key_build: 0x10e19b (F7) is \033[18~
+1783499626.084389 input_key_build: 0x10e19c (F8) is \033[19~
+1783499626.084392 input_key_build: 0x10e19d (F9) is \033[20~
+1783499626.084395 input_key_build: 0x10e19e (F10) is \033[21~
+1783499626.084397 input_key_build: 0x10e19f (F11) is \033[23~
+1783499626.084400 input_key_build: 0x10e1a0 (F12) is \033[24~
+1783499626.084402 input_key_build: 0x10e1a1 (IC) is \033[2~
+1783499626.084405 input_key_build: 0x10e1a2 (DC) is \033[3~
+1783499626.084408 input_key_build: 0x10e1a3 (Home) is \033[1~
+1783499626.084410 input_key_build: 0x10e1a4 (End) is \033[4~
+1783499626.084413 input_key_build: 0x10e1a5 (NPage) is \033[6~
+1783499626.084416 input_key_build: 0x10e1a6 (PPage) is \033[5~
+1783499626.084423 input_key_build: 0x10e1a7 (BTab) is \033[Z
+1783499626.084429 input_key_build: 0x10e1a8 (Up) is \033[A
+1783499626.084431 input_key_build: 0x10e1a9 (Down) is \033[B
+1783499626.084434 input_key_build: 0x10e1aa (Left) is \033[D
+1783499626.084437 input_key_build: 0x10e1ab (Right) is \033[C
+1783499626.084439 input_key_build: 0x10e1ac (KP/) is /
+1783499626.084442 input_key_build: 0x10e1ad (KP*) is *
+1783499626.084445 input_key_build: 0x10e1ae (KP-) is -
+1783499626.084448 input_key_build: 0x10e1af (KP7) is 7
+1783499626.084450 input_key_build: 0x10e1b0 (KP8) is 8
+1783499626.084453 input_key_build: 0x10e1b1 (KP9) is 9
+1783499626.084455 input_key_build: 0x10e1b2 (KP+) is +
+1783499626.084458 input_key_build: 0x10e1b3 (KP4) is 4
+1783499626.084464 input_key_build: 0x10e1b4 (KP5) is 5
+1783499626.084467 input_key_build: 0x10e1b5 (KP6) is 6
+1783499626.084470 input_key_build: 0x10e1b6 (KP1) is 1
+1783499626.084472 input_key_build: 0x10e1b7 (KP2) is 2
+1783499626.084475 input_key_build: 0x10e1b8 (KP3) is 3
+1783499626.084478 input_key_build: 0x10e1b9 (KPEnter) is \n
+1783499626.084480 input_key_build: 0x10e1ba (KP0) is 0
+1783499626.084483 input_key_build: 0x10e1bb (KP.) is .
+1783499626.084486 input_key_build: 0x200000000009 (C-Tab) is \t
+1783499626.084489 input_key_build: 0x20000010e195 (C-F1) is \033[1;5P
+1783499626.084491 input_key_build: 0x20000010e196 (C-F2) is \033[1;5Q
+1783499626.084494 input_key_build: 0x20000010e197 (C-F3) is \033[1;5R
+1783499626.084497 input_key_build: 0x20000010e198 (C-F4) is \033[1;5S
+1783499626.084500 input_key_build: 0x20000010e199 (C-F5) is \033[15;5~
+1783499626.084503 input_key_build: 0x20000010e19a (C-F6) is \033[17;5~
+1783499626.084506 input_key_build: 0x20000010e19b (C-F7) is \033[18;5~
+1783499626.084508 input_key_build: 0x20000010e19c (C-F8) is \033[19;5~
+1783499626.084511 input_key_build: 0x20000010e19d (C-F9) is \033[20;5~
+1783499626.084514 input_key_build: 0x20000010e19e (C-F10) is \033[21;5~
+1783499626.084517 input_key_build: 0x20000010e19f (C-F11) is \033[23;5~
+1783499626.084520 input_key_build: 0x20000010e1a0 (C-F12) is \033[24;5~
+1783499626.084523 input_key_build: 0x20000010e1a1 (C-IC) is \033[2;5~
+1783499626.084525 input_key_build: 0x20000010e1a2 (C-DC) is \033[3;5~
+1783499626.084528 input_key_build: 0x20000010e1a3 (C-Home) is \033[1;5H
+1783499626.084531 input_key_build: 0x20000010e1a4 (C-End) is \033[1;5F
+1783499626.084537 input_key_build: 0x20000010e1a5 (C-NPage) is \033[6;5~
+1783499626.084540 input_key_build: 0x20000010e1a6 (C-PPage) is \033[5;5~
+1783499626.084544 input_key_build: 0x20000010e1a8 (C-Up) is \033[1;5A
+1783499626.084556 input_key_build: 0x20000010e1a9 (C-Down) is \033[1;5B
+1783499626.084559 input_key_build: 0x20000010e1aa (C-Left) is \033[1;5D
+1783499626.084563 input_key_build: 0x20000010e1ab (C-Right) is \033[1;5C
+1783499626.084565 input_key_build: 0x40000010e195 (S-F1) is \033[1;2P
+1783499626.084569 input_key_build: 0x40000010e196 (S-F2) is \033[1;2Q
+1783499626.084572 input_key_build: 0x40000010e197 (S-F3) is \033[1;2R
+1783499626.084574 input_key_build: 0x40000010e198 (S-F4) is \033[1;2S
+1783499626.084577 input_key_build: 0x40000010e199 (S-F5) is \033[15;2~
+1783499626.084580 input_key_build: 0x40000010e19a (S-F6) is \033[17;2~
+1783499626.084583 input_key_build: 0x40000010e19b (S-F7) is \033[18;2~
+1783499626.084586 input_key_build: 0x40000010e19c (S-F8) is \033[19;2~
+1783499626.084589 input_key_build: 0x40000010e19d (S-F9) is \033[20;2~
+1783499626.084592 input_key_build: 0x40000010e19e (S-F10) is \033[21;2~
+1783499626.084595 input_key_build: 0x40000010e19f (S-F11) is \033[23;2~
+1783499626.084597 input_key_build: 0x40000010e1a0 (S-F12) is \033[24;2~
+1783499626.084600 input_key_build: 0x40000010e1a1 (S-IC) is \033[2;2~
+1783499626.084603 input_key_build: 0x40000010e1a2 (S-DC) is \033[3;2~
+1783499626.084605 input_key_build: 0x40000010e1a3 (S-Home) is \033[1;2H
+1783499626.084608 input_key_build: 0x40000010e1a4 (S-End) is \033[1;2F
+1783499626.084610 input_key_build: 0x40000010e1a5 (S-NPage) is \033[6;2~
+1783499626.084613 input_key_build: 0x40000010e1a6 (S-PPage) is \033[5;2~
+1783499626.084615 input_key_build: 0x40000010e1a8 (S-Up) is \033[1;2A
+1783499626.084618 input_key_build: 0x40000010e1a9 (S-Down) is \033[1;2B
+1783499626.084621 input_key_build: 0x40000010e1aa (S-Left) is \033[1;2D
+1783499626.084624 input_key_build: 0x40000010e1ab (S-Right) is \033[1;2C
+1783499626.084626 input_key_build: 0x600000000009 (C-S-Tab) is \033[Z
+1783499626.084629 input_key_build: 0x60000010e195 (C-S-F1) is \033[1;6P
+1783499626.084631 input_key_build: 0x60000010e196 (C-S-F2) is \033[1;6Q
+1783499626.084634 input_key_build: 0x60000010e197 (C-S-F3) is \033[1;6R
+1783499626.084637 input_key_build: 0x60000010e198 (C-S-F4) is \033[1;6S
+1783499626.084639 input_key_build: 0x60000010e199 (C-S-F5) is \033[15;6~
+1783499626.084642 input_key_build: 0x60000010e19a (C-S-F6) is \033[17;6~
+1783499626.084645 input_key_build: 0x60000010e19b (C-S-F7) is \033[18;6~
+1783499626.084647 input_key_build: 0x60000010e19c (C-S-F8) is \033[19;6~
+1783499626.084650 input_key_build: 0x60000010e19d (C-S-F9) is \033[20;6~
+1783499626.084653 input_key_build: 0x60000010e19e (C-S-F10) is \033[21;6~
+1783499626.084655 input_key_build: 0x60000010e19f (C-S-F11) is \033[23;6~
+1783499626.084658 input_key_build: 0x60000010e1a0 (C-S-F12) is \033[24;6~
+1783499626.084661 input_key_build: 0x60000010e1a1 (C-S-IC) is \033[2;6~
+1783499626.084664 input_key_build: 0x60000010e1a2 (C-S-DC) is \033[3;6~
+1783499626.084666 input_key_build: 0x60000010e1a3 (C-S-Home) is \033[1;6H
+1783499626.084669 input_key_build: 0x60000010e1a4 (C-S-End) is \033[1;6F
+1783499626.084672 input_key_build: 0x60000010e1a5 (C-S-NPage) is \033[6;6~
+1783499626.084675 input_key_build: 0x60000010e1a6 (C-S-PPage) is \033[5;6~
+1783499626.084678 input_key_build: 0x60000010e1a8 (C-S-Up) is \033[1;6A
+1783499626.084681 input_key_build: 0x60000010e1a9 (C-S-Down) is \033[1;6B
+1783499626.084683 input_key_build: 0x60000010e1aa (C-S-Left) is \033[1;6D
+1783499626.084686 input_key_build: 0x60000010e1ab (C-S-Right) is \033[1;6C
+1783499626.084689 input_key_build: 0x200000010e1ac (KP/[K]) is \033Oo
+1783499626.084692 input_key_build: 0x200000010e1ad (KP*[K]) is \033Oj
+1783499626.084695 input_key_build: 0x200000010e1ae (KP-[K]) is \033Om
+1783499626.084698 input_key_build: 0x200000010e1af (KP7[K]) is \033Ow
+1783499626.084701 input_key_build: 0x200000010e1b0 (KP8[K]) is \033Ox
+1783499626.084703 input_key_build: 0x200000010e1b1 (KP9[K]) is \033Oy
+1783499626.084706 input_key_build: 0x200000010e1b2 (KP+[K]) is \033Ok
+1783499626.084709 input_key_build: 0x200000010e1b3 (KP4[K]) is \033Ot
+1783499626.084712 input_key_build: 0x200000010e1b4 (KP5[K]) is \033Ou
+1783499626.084719 input_key_build: 0x200000010e1b5 (KP6[K]) is \033Ov
+1783499626.084721 input_key_build: 0x200000010e1b6 (KP1[K]) is \033Oq
+1783499626.084724 input_key_build: 0x200000010e1b7 (KP2[K]) is \033Or
+1783499626.084727 input_key_build: 0x200000010e1b8 (KP3[K]) is \033Os
+1783499626.084730 input_key_build: 0x200000010e1b9 (KPEnter[K]) is \033OM
+1783499626.084733 input_key_build: 0x200000010e1ba (KP0[K]) is \033Op
+1783499626.084735 input_key_build: 0x200000010e1bb (KP.[K]) is \033On
+1783499626.084738 input_key_build: 0x400000010e1a8 (Up[C]) is \033OA
+1783499626.084741 input_key_build: 0x400000010e1a9 (Down[C]) is \033OB
+1783499626.084743 input_key_build: 0x400000010e1aa (Left[C]) is \033OD
+1783499626.084746 input_key_build: 0x400000010e1ab (Right[C]) is \033OC
+1783499626.084750 input_key_build: 0x810000010e195 (M-F1[I]) is \033[1;3P
+1783499626.084752 input_key_build: 0x810000010e196 (M-F2[I]) is \033[1;3Q
+1783499626.084755 input_key_build: 0x810000010e197 (M-F3[I]) is \033[1;3R
+1783499626.084758 input_key_build: 0x810000010e198 (M-F4[I]) is \033[1;3S
+1783499626.084761 input_key_build: 0x810000010e199 (M-F5[I]) is \033[15;3~
+1783499626.084765 input_key_build: 0x810000010e19a (M-F6[I]) is \033[17;3~
+1783499626.084767 input_key_build: 0x810000010e19b (M-F7[I]) is \033[18;3~
+1783499626.084770 input_key_build: 0x810000010e19c (M-F8[I]) is \033[19;3~
+1783499626.084773 input_key_build: 0x810000010e19d (M-F9[I]) is \033[20;3~
+1783499626.084776 input_key_build: 0x810000010e19e (M-F10[I]) is \033[21;3~
+1783499626.084811 input_key_build: 0x810000010e19f (M-F11[I]) is \033[23;3~
+1783499626.084817 input_key_build: 0x810000010e1a0 (M-F12[I]) is \033[24;3~
+1783499626.084821 input_key_build: 0x810000010e1a1 (M-IC[I]) is \033[2;3~
+1783499626.084825 input_key_build: 0x810000010e1a2 (M-DC[I]) is \033[3;3~
+1783499626.084831 input_key_build: 0x810000010e1a3 (M-Home[I]) is \033[1;3H
+1783499626.084834 input_key_build: 0x810000010e1a4 (M-End[I]) is \033[1;3F
+1783499626.084837 input_key_build: 0x810000010e1a5 (M-NPage[I]) is \033[6;3~
+1783499626.084840 input_key_build: 0x810000010e1a6 (M-PPage[I]) is \033[5;3~
+1783499626.084843 input_key_build: 0x810000010e1a8 (M-Up[I]) is \033[1;3A
+1783499626.084846 input_key_build: 0x810000010e1a9 (M-Down[I]) is \033[1;3B
+1783499626.084848 input_key_build: 0x810000010e1aa (M-Left[I]) is \033[1;3D
+1783499626.084852 input_key_build: 0x810000010e1ab (M-Right[I]) is \033[1;3C
+1783499626.084855 input_key_build: 0x830000010e195 (C-M-F1[I]) is \033[1;7P
+1783499626.084858 input_key_build: 0x830000010e196 (C-M-F2[I]) is \033[1;7Q
+1783499626.084861 input_key_build: 0x830000010e197 (C-M-F3[I]) is \033[1;7R
+1783499626.084864 input_key_build: 0x830000010e198 (C-M-F4[I]) is \033[1;7S
+1783499626.084867 input_key_build: 0x830000010e199 (C-M-F5[I]) is \033[15;7~
+1783499626.084870 input_key_build: 0x830000010e19a (C-M-F6[I]) is \033[17;7~
+1783499626.084873 input_key_build: 0x830000010e19b (C-M-F7[I]) is \033[18;7~
+1783499626.084876 input_key_build: 0x830000010e19c (C-M-F8[I]) is \033[19;7~
+1783499626.084878 input_key_build: 0x830000010e19d (C-M-F9[I]) is \033[20;7~
+1783499626.084881 input_key_build: 0x830000010e19e (C-M-F10[I]) is \033[21;7~
+1783499626.084884 input_key_build: 0x830000010e19f (C-M-F11[I]) is \033[23;7~
+1783499626.084887 input_key_build: 0x830000010e1a0 (C-M-F12[I]) is \033[24;7~
+1783499626.084890 input_key_build: 0x830000010e1a1 (C-M-IC[I]) is \033[2;7~
+1783499626.084893 input_key_build: 0x830000010e1a2 (C-M-DC[I]) is \033[3;7~
+1783499626.084896 input_key_build: 0x830000010e1a3 (C-M-Home[I]) is \033[1;7H
+1783499626.084899 input_key_build: 0x830000010e1a4 (C-M-End[I]) is \033[1;7F
+1783499626.084903 input_key_build: 0x830000010e1a5 (C-M-NPage[I]) is \033[6;7~
+1783499626.084906 input_key_build: 0x830000010e1a6 (C-M-PPage[I]) is \033[5;7~
+1783499626.084909 input_key_build: 0x830000010e1a8 (C-M-Up[I]) is \033[1;7A
+1783499626.084912 input_key_build: 0x830000010e1a9 (C-M-Down[I]) is \033[1;7B
+1783499626.084915 input_key_build: 0x830000010e1aa (C-M-Left[I]) is \033[1;7D
+1783499626.084923 input_key_build: 0x830000010e1ab (C-M-Right[I]) is \033[1;7C
+1783499626.084926 input_key_build: 0x850000010e195 (M-S-F1[I]) is \033[1;4P
+1783499626.084929 input_key_build: 0x850000010e196 (M-S-F2[I]) is \033[1;4Q
+1783499626.084932 input_key_build: 0x850000010e197 (M-S-F3[I]) is \033[1;4R
+1783499626.084935 input_key_build: 0x850000010e198 (M-S-F4[I]) is \033[1;4S
+1783499626.084938 input_key_build: 0x850000010e199 (M-S-F5[I]) is \033[15;4~
+1783499626.084941 input_key_build: 0x850000010e19a (M-S-F6[I]) is \033[17;4~
+1783499626.084944 input_key_build: 0x850000010e19b (M-S-F7[I]) is \033[18;4~
+1783499626.084947 input_key_build: 0x850000010e19c (M-S-F8[I]) is \033[19;4~
+1783499626.084950 input_key_build: 0x850000010e19d (M-S-F9[I]) is \033[20;4~
+1783499626.084953 input_key_build: 0x850000010e19e (M-S-F10[I]) is \033[21;4~
+1783499626.084956 input_key_build: 0x850000010e19f (M-S-F11[I]) is \033[23;4~
+1783499626.084959 input_key_build: 0x850000010e1a0 (M-S-F12[I]) is \033[24;4~
+1783499626.084962 input_key_build: 0x850000010e1a1 (M-S-IC[I]) is \033[2;4~
+1783499626.084965 input_key_build: 0x850000010e1a2 (M-S-DC[I]) is \033[3;4~
+1783499626.084968 input_key_build: 0x850000010e1a3 (M-S-Home[I]) is \033[1;4H
+1783499626.084971 input_key_build: 0x850000010e1a4 (M-S-End[I]) is \033[1;4F
+1783499626.084974 input_key_build: 0x850000010e1a5 (M-S-NPage[I]) is \033[6;4~
+1783499626.084977 input_key_build: 0x850000010e1a6 (M-S-PPage[I]) is \033[5;4~
+1783499626.084980 input_key_build: 0x850000010e1a8 (M-S-Up[I]) is \033[1;4A
+1783499626.084984 input_key_build: 0x850000010e1a9 (M-S-Down[I]) is \033[1;4B
+1783499626.084987 input_key_build: 0x850000010e1aa (M-S-Left[I]) is \033[1;4D
+1783499626.084990 input_key_build: 0x850000010e1ab (M-S-Right[I]) is \033[1;4C
+1783499626.084993 input_key_build: 0x870000010e195 (C-M-S-F1[I]) is \033[1;8P
+1783499626.084996 input_key_build: 0x870000010e196 (C-M-S-F2[I]) is \033[1;8Q
+1783499626.084999 input_key_build: 0x870000010e197 (C-M-S-F3[I]) is \033[1;8R
+1783499626.085004 input_key_build: 0x870000010e198 (C-M-S-F4[I]) is \033[1;8S
+1783499626.085008 input_key_build: 0x870000010e199 (C-M-S-F5[I]) is \033[15;8~
+1783499626.085011 input_key_build: 0x870000010e19a (C-M-S-F6[I]) is \033[17;8~
+1783499626.085014 input_key_build: 0x870000010e19b (C-M-S-F7[I]) is \033[18;8~
+1783499626.085017 input_key_build: 0x870000010e19c (C-M-S-F8[I]) is \033[19;8~
+1783499626.085020 input_key_build: 0x870000010e19d (C-M-S-F9[I]) is \033[20;8~
+1783499626.085023 input_key_build: 0x870000010e19e (C-M-S-F10[I]) is \033[21;8~
+1783499626.085026 input_key_build: 0x870000010e19f (C-M-S-F11[I]) is \033[23;8~
+1783499626.085029 input_key_build: 0x870000010e1a0 (C-M-S-F12[I]) is \033[24;8~
+1783499626.085031 input_key_build: 0x870000010e1a1 (C-M-S-IC[I]) is \033[2;8~
+1783499626.085035 input_key_build: 0x870000010e1a2 (C-M-S-DC[I]) is \033[3;8~
+1783499626.085037 input_key_build: 0x870000010e1a3 (C-M-S-Home[I]) is \033[1;8H
+1783499626.085040 input_key_build: 0x870000010e1a4 (C-M-S-End[I]) is \033[1;8F
+1783499626.085043 input_key_build: 0x870000010e1a5 (C-M-S-NPage[I]) is \033[6;8~
+1783499626.085046 input_key_build: 0x870000010e1a6 (C-M-S-PPage[I]) is \033[5;8~
+1783499626.085049 input_key_build: 0x870000010e1a8 (C-M-S-Up[I]) is \033[1;8A
+1783499626.085052 input_key_build: 0x870000010e1a9 (C-M-S-Down[I]) is \033[1;8B
+1783499626.085055 input_key_build: 0x870000010e1aa (C-M-S-Left[I]) is \033[1;8D
+1783499626.085058 input_key_build: 0x870000010e1ab (C-M-S-Right[I]) is \033[1;8C
+1783499626.085061 input_key_build: 0x40200000000009 (C-Tab[E]) is \033[9;5u
+1783499626.085065 input_key_build: 0x40600000000009 (C-S-Tab[E]) is \033[1;5Z
+1783499626.085434 yylex_token: end at WS
+1783499626.085446 yylex_token: bind
+1783499626.085497 yylex_token: end at WS
+1783499626.085502 yylex_token: -N
+1783499626.085507 yylex_token: end at WS
+1783499626.085510 yylex_token: Send the prefix key
+1783499626.085513 yylex_token: end at WS
+1783499626.085515 yylex_token: C-b
+1783499626.085518 yylex_token: end at WS
+1783499626.085520 yylex_token: send-prefix
+1783499626.085632 cmd_parse_build_commands 0:0: bind
+1783499626.085646 cmd_parse_build_commands 0:1: -N
+1783499626.085650 cmd_parse_build_commands 0:2: Send the prefix key
+1783499626.085654 cmd_parse_build_commands 0:3: C-b
+1783499626.085658 cmd_parse_build_commands 0:4 0:0: send-prefix
+1783499626.085732 cmd_parse_build_commands 0:0: send-prefix
+1783499626.085747 args_parse: flags end at 1 of 1
+1783499626.085827 cmd_parse_build_commands: send-prefix
+1783499626.085832 args_parse_flags: next -N
+1783499626.085836 args_parse_flag_argument: -N = Send the prefix key
+1783499626.085880 args_parse_flags: next C-b
+1783499626.085885 args_parse: flags end at 3 of 5
+1783499626.085889 args_parse: 3 = C-b (type STRING)
+1783499626.085895 args_parse: 4 = send-prefix (type COMMANDS)
+1783499626.085995 cmd_parse_build_commands: bind-key -N "Send the prefix key" C-b { send-prefix }
+1783499626.086045 cmdq_get_command: [bind-key/0x58e4724b71a0] group 2
+1783499626.086080 cmdq_append <global>: [bind-key/0x58e4724b71a0]
+1783499626.086086 yylex_token: end at WS
+1783499626.086089 yylex_token: bind
+1783499626.086094 yylex_token: end at WS
+1783499626.086096 yylex_token: -N
+1783499626.086101 yylex_token: end at WS
+1783499626.086104 yylex_token: Rotate through the panes
+1783499626.086107 yylex_token: end at WS
+1783499626.086109 yylex_token: C-o
+1783499626.086113 yylex_token: end at WS
+1783499626.086115 yylex_token: rotate-window
+1783499626.086121 cmd_parse_build_commands 0:0: bind
+1783499626.086125 cmd_parse_build_commands 0:1: -N
+1783499626.086128 cmd_parse_build_commands 0:2: Rotate through the panes
+1783499626.086131 cmd_parse_build_commands 0:3: C-o
+1783499626.086134 cmd_parse_build_commands 0:4 0:0: rotate-window
+1783499626.086142 cmd_parse_build_commands 0:0: rotate-window
+1783499626.086149 args_parse: flags end at 1 of 1
+1783499626.086153 cmd_parse_build_commands: rotate-window
+1783499626.086156 args_parse_flags: next -N
+1783499626.086160 args_parse_flag_argument: -N = Rotate through the panes
+1783499626.086163 args_parse_flags: next C-o
+1783499626.086166 args_parse: flags end at 3 of 5
+1783499626.086169 args_parse: 3 = C-o (type STRING)
+1783499626.086173 args_parse: 4 = rotate-window (type COMMANDS)
+1783499626.086184 cmd_parse_build_commands: bind-key -N "Rotate through the panes" C-o { rotate-window }
+1783499626.086191 cmdq_get_command: [bind-key/0x58e4724b7500] group 10
+1783499626.086194 cmdq_append <global>: [bind-key/0x58e4724b7500]
+1783499626.086203 yylex_token: end at WS
+1783499626.086205 yylex_token: bind
+1783499626.086207 yylex_token: end at WS
+1783499626.086209 yylex_token: -N
+1783499626.086213 yylex_token: end at WS
+1783499626.086216 yylex_token: Suspend the current client
+1783499626.086220 yylex_token: end at WS
+1783499626.086223 yylex_token: C-z
+1783499626.086227 yylex_token: end at WS
+1783499626.086230 yylex_token: suspend-client
+1783499626.086234 cmd_parse_build_commands 0:0: bind
+1783499626.086237 cmd_parse_build_commands 0:1: -N
+1783499626.086240 cmd_parse_build_commands 0:2: Suspend the current client
+1783499626.086243 cmd_parse_build_commands 0:3: C-z
+1783499626.086247 cmd_parse_build_commands 0:4 0:0: suspend-client
+1783499626.086251 cmd_parse_build_commands 0:0: suspend-client
+1783499626.086259 args_parse: flags end at 1 of 1
+1783499626.086262 cmd_parse_build_commands: suspend-client
+1783499626.086265 args_parse_flags: next -N
+1783499626.086268 args_parse_flag_argument: -N = Suspend the current client
+1783499626.086270 args_parse_flags: next C-z
+1783499626.086273 args_parse: flags end at 3 of 5
+1783499626.086276 args_parse: 3 = C-z (type STRING)
+1783499626.086279 args_parse: 4 = suspend-client (type COMMANDS)
+1783499626.086289 cmd_parse_build_commands: bind-key -N "Suspend the current client" C-z { suspend-client }
+1783499626.086294 cmdq_get_command: [bind-key/0x58e4724b7ba0] group 18
+1783499626.086297 cmdq_append <global>: [bind-key/0x58e4724b7ba0]
+1783499626.086300 yylex_token: end at WS
+1783499626.086302 yylex_token: bind
+1783499626.086304 yylex_token: end at WS
+1783499626.086306 yylex_token: -N
+1783499626.086310 yylex_token: end at WS
+1783499626.086319 yylex_token: Select next layout
+1783499626.086322 yylex_token: end at WS
+1783499626.086324 yylex_token: Space
+1783499626.086327 yylex_token: end at WS
+1783499626.086329 yylex_token: next-layout
+1783499626.086332 cmd_parse_build_commands 0:0: bind
+1783499626.086335 cmd_parse_build_commands 0:1: -N
+1783499626.086338 cmd_parse_build_commands 0:2: Select next layout
+1783499626.086341 cmd_parse_build_commands 0:3: Space
+1783499626.086344 cmd_parse_build_commands 0:4 0:0: next-layout
+1783499626.086347 cmd_parse_build_commands 0:0: next-layout
+1783499626.086353 args_parse: flags end at 1 of 1
+1783499626.086356 cmd_parse_build_commands: next-layout
+1783499626.086359 args_parse_flags: next -N
+1783499626.086362 args_parse_flag_argument: -N = Select next layout
+1783499626.086365 args_parse_flags: next Space
+1783499626.086367 args_parse: flags end at 3 of 5
+1783499626.086370 args_parse: 3 = Space (type STRING)
+1783499626.086373 args_parse: 4 = next-layout (type COMMANDS)
+1783499626.086381 cmd_parse_build_commands: bind-key -N "Select next layout" Space { next-layout }
+1783499626.086386 cmdq_get_command: [bind-key/0x58e4724b8150] group 26
+1783499626.086389 cmdq_append <global>: [bind-key/0x58e4724b8150]
+1783499626.086392 yylex_token: end at WS
+1783499626.086394 yylex_token: bind
+1783499626.086396 yylex_token: end at WS
+1783499626.086399 yylex_token: -N
+1783499626.086402 yylex_token: end at WS
+1783499626.086405 yylex_token: Break pane to a new window
+1783499626.086407 yylex_token: end at WS
+1783499626.086409 yylex_token: !
+1783499626.086412 yylex_token: end at WS
+1783499626.086414 yylex_token: break-pane
+1783499626.086418 cmd_parse_build_commands 0:0: bind
+1783499626.086421 cmd_parse_build_commands 0:1: -N
+1783499626.086424 cmd_parse_build_commands 0:2: Break pane to a new window
+1783499626.086426 cmd_parse_build_commands 0:3: !
+1783499626.086429 cmd_parse_build_commands 0:4 0:0: break-pane
+1783499626.086433 cmd_parse_build_commands 0:0: break-pane
+1783499626.086436 args_parse: flags end at 1 of 1
+1783499626.086440 cmd_parse_build_commands: break-pane
+1783499626.086442 args_parse_flags: next -N
+1783499626.086446 args_parse_flag_argument: -N = Break pane to a new window
+1783499626.086448 args_parse_flags: next !
+1783499626.086451 args_parse: flags end at 3 of 5
+1783499626.086453 args_parse: 3 = ! (type STRING)
+1783499626.086456 args_parse: 4 = break-pane (type COMMANDS)
+1783499626.086465 cmd_parse_build_commands: bind-key -N "Break pane to a new window" ! { break-pane }
+1783499626.086470 cmdq_get_command: [bind-key/0x58e4724b8670] group 34
+1783499626.086473 cmdq_append <global>: [bind-key/0x58e4724b8670]
+1783499626.086479 yylex_token: end at WS
+1783499626.086482 yylex_token: bind
+1783499626.086484 yylex_token: end at WS
+1783499626.086486 yylex_token: -N
+1783499626.086490 yylex_token: end at WS
+1783499626.086492 yylex_token: Split window vertically
+1783499626.086495 yylex_token: end at WS
+1783499626.086498 yylex_token: "
+1783499626.086511 yylex_token: end at WS
+1783499626.086514 yylex_token: split-window
+1783499626.086518 cmd_parse_build_commands 0:0: bind
+1783499626.086522 cmd_parse_build_commands 0:1: -N
+1783499626.086526 cmd_parse_build_commands 0:2: Split window vertically
+1783499626.086529 cmd_parse_build_commands 0:3: "
+1783499626.086532 cmd_parse_build_commands 0:4 0:0: split-window
+1783499626.086537 cmd_parse_build_commands 0:0: split-window
+1783499626.086543 args_parse: flags end at 1 of 1
+1783499626.086546 cmd_parse_build_commands: split-window
+1783499626.086549 args_parse_flags: next -N
+1783499626.086552 args_parse_flag_argument: -N = Split window vertically
+1783499626.086555 args_parse_flags: next "
+1783499626.086558 args_parse: flags end at 3 of 5
+1783499626.086560 args_parse: 3 = " (type STRING)
+1783499626.086564 args_parse: 4 = split-window (type COMMANDS)
+1783499626.086572 cmd_parse_build_commands: bind-key -N "Split window vertically" \\" { split-window }
+1783499626.086577 cmdq_get_command: [bind-key/0x58e4724b8cb0] group 42
+1783499626.086581 cmdq_append <global>: [bind-key/0x58e4724b8cb0]
+1783499626.086584 yylex_token: end at WS
+1783499626.086592 yylex_token: bind
+1783499626.086594 yylex_token: end at WS
+1783499626.086597 yylex_token: -N
+1783499626.086600 yylex_token: end at WS
+1783499626.086603 yylex_token: List all paste buffers
+1783499626.086605 yylex_token: end at WS
+1783499626.086607 yylex_token: #
+1783499626.086610 yylex_token: end at WS
+1783499626.086612 yylex_token: list-buffers
+1783499626.086617 cmd_parse_build_commands 0:0: bind
+1783499626.086619 cmd_parse_build_commands 0:1: -N
+1783499626.086622 cmd_parse_build_commands 0:2: List all paste buffers
+1783499626.086625 cmd_parse_build_commands 0:3: #
+1783499626.086628 cmd_parse_build_commands 0:4 0:0: list-buffers
+1783499626.086632 cmd_parse_build_commands 0:0: list-buffers
+1783499626.086636 args_parse: flags end at 1 of 1
+1783499626.086639 cmd_parse_build_commands: list-buffers
+1783499626.086642 args_parse_flags: next -N
+1783499626.086645 args_parse_flag_argument: -N = List all paste buffers
+1783499626.086647 args_parse_flags: next #
+1783499626.086650 args_parse: flags end at 3 of 5
+1783499626.086652 args_parse: 3 = # (type STRING)
+1783499626.086655 args_parse: 4 = list-buffers (type COMMANDS)
+1783499626.086664 cmd_parse_build_commands: bind-key -N "List all paste buffers" \\# { list-buffers }
+1783499626.086669 cmdq_get_command: [bind-key/0x58e4724b92e0] group 50
+1783499626.086672 cmdq_append <global>: [bind-key/0x58e4724b92e0]
+1783499626.086679 yylex_token: end at WS
+1783499626.086681 yylex_token: bind
+1783499626.086684 yylex_token: end at WS
+1783499626.086686 yylex_token: -N
+1783499626.086690 yylex_token: end at WS
+1783499626.086692 yylex_token: Rename current session
+1783499626.086695 yylex_token: end at WS
+1783499626.086697 yylex_token: $
+1783499626.086700 yylex_token: end at WS
+1783499626.086702 yylex_token: command-prompt
+1783499626.086705 yylex_token: end at WS
+1783499626.086708 yylex_token: -I#S
+1783499626.086712 yylex_token: end at WS
+1783499626.086714 yylex_token: rename-session
+1783499626.086717 yylex_token: end at WS
+1783499626.086719 yylex_token: --
+1783499626.086722 yylex_token: end at WS
+1783499626.086724 yylex_token: %%
+1783499626.086728 cmd_parse_build_commands 0:0: bind
+1783499626.086731 cmd_parse_build_commands 0:1: -N
+1783499626.086733 cmd_parse_build_commands 0:2: Rename current session
+1783499626.086736 cmd_parse_build_commands 0:3: $
+1783499626.086739 cmd_parse_build_commands 0:4 0:0: command-prompt
+1783499626.086742 cmd_parse_build_commands 0:4 0:1: -I#S
+1783499626.086745 cmd_parse_build_commands 0:4 0:2 0:0: rename-session
+1783499626.086748 cmd_parse_build_commands 0:4 0:2 0:1: --
+1783499626.086751 cmd_parse_build_commands 0:4 0:2 0:2: %%
+1783499626.086755 cmd_parse_build_commands 0:0: command-prompt
+1783499626.086757 cmd_parse_build_commands 0:1: -I#S
+1783499626.086760 cmd_parse_build_commands 0:2 0:0: rename-session
+1783499626.086763 cmd_parse_build_commands 0:2 0:1: --
+1783499626.086765 cmd_parse_build_commands 0:2 0:2: %%
+1783499626.086769 cmd_parse_build_commands 0:0: rename-session
+1783499626.086772 cmd_parse_build_commands 0:1: --
+1783499626.086774 cmd_parse_build_commands 0:2: %%
+1783499626.086779 args_parse_flags: next --
+1783499626.086782 args_parse: flags end at 2 of 3
+1783499626.086784 args_parse: 2 = %% (type STRING)
+1783499626.086790 cmd_parse_build_commands: rename-session "%%"
+1783499626.086793 args_parse_flags: next -I#S
+1783499626.086796 args_parse_flag_argument: -I = #S
+1783499626.086799 args_parse: flags end at 2 of 3
+1783499626.086804 args_parse: 2 = rename-session "%%" (type COMMANDS)
+1783499626.086813 cmd_parse_build_commands: command-prompt -I "#S" { rename-session "%%" }
+1783499626.086816 args_parse_flags: next -N
+1783499626.086819 args_parse_flag_argument: -N = Rename current session
+1783499626.086821 args_parse_flags: next $
+1783499626.086824 args_parse: flags end at 3 of 5
+1783499626.086827 args_parse: 3 = $ (type STRING)
+1783499626.086834 args_parse: 4 = command-prompt -I "#S" { rename-session "%%" } (type COMMANDS)
+1783499626.086846 cmd_parse_build_commands: bind-key -N "Rename current session" \\$ { command-prompt -I "#S" { rename-session "%%" } }
+1783499626.086856 cmdq_get_command: [bind-key/0x58e4724b9c30] group 58
+1783499626.086860 cmdq_append <global>: [bind-key/0x58e4724b9c30]
+1783499626.086863 yylex_token: end at WS
+1783499626.086865 yylex_token: bind
+1783499626.086867 yylex_token: end at WS
+1783499626.086869 yylex_token: -N
+1783499626.086872 yylex_token: end at WS
+1783499626.086875 yylex_token: Split window horizontally
+1783499626.086878 yylex_get_word: %
+1783499626.086881 yylex_token: end at WS
+1783499626.086883 yylex_token: split-window
+1783499626.086885 yylex_token: end at WS
+1783499626.086887 yylex_token: -h
+1783499626.086891 cmd_parse_build_commands 0:0: bind
+1783499626.086894 cmd_parse_build_commands 0:1: -N
+1783499626.086896 cmd_parse_build_commands 0:2: Split window horizontally
+1783499626.086899 cmd_parse_build_commands 0:3: %
+1783499626.086902 cmd_parse_build_commands 0:4 0:0: split-window
+1783499626.086904 cmd_parse_build_commands 0:4 0:1: -h
+1783499626.086908 cmd_parse_build_commands 0:0: split-window
+1783499626.086910 cmd_parse_build_commands 0:1: -h
+1783499626.086917 args_parse_flags: next -h
+1783499626.086920 args_parse_flags: -h
+1783499626.086922 args_parse: flags end at 2 of 2
+1783499626.086928 cmd_parse_build_commands: split-window -h
+1783499626.086931 args_parse_flags: next -N
+1783499626.086934 args_parse_flag_argument: -N = Split window horizontally
+1783499626.086937 args_parse_flags: next %
+1783499626.086940 args_parse: flags end at 3 of 5
+1783499626.086944 args_parse: 3 = % (type STRING)
+1783499626.086948 args_parse: 4 = split-window -h (type COMMANDS)
+1783499626.086958 cmd_parse_build_commands: bind-key -N "Split window horizontally" \\% { split-window -h }
+1783499626.086962 cmdq_get_command: [bind-key/0x58e4724ba520] group 70
+1783499626.086966 cmdq_append <global>: [bind-key/0x58e4724ba520]
+1783499626.086973 yylex_token: end at WS
+1783499626.086976 yylex_token: bind
+1783499626.086978 yylex_token: end at WS
+1783499626.086980 yylex_token: -N
+1783499626.086984 yylex_token: end at WS
+1783499626.086986 yylex_token: Kill current window
+1783499626.086988 yylex_token: end at WS
+1783499626.086990 yylex_token: &
+1783499626.086993 yylex_token: end at WS
+1783499626.086995 yylex_token: confirm-before
+1783499626.087005 yylex_token: end at WS
+1783499626.087010 yylex_token: -pkill-window #W? (y/n)
+1783499626.087013 yylex_token: end at WS
+1783499626.087016 yylex_token: kill-window
+1783499626.087020 cmd_parse_build_commands 0:0: bind
+1783499626.087023 cmd_parse_build_commands 0:1: -N
+1783499626.087026 cmd_parse_build_commands 0:2: Kill current window
+1783499626.087030 cmd_parse_build_commands 0:3: &
+1783499626.087033 cmd_parse_build_commands 0:4 0:0: confirm-before
+1783499626.087036 cmd_parse_build_commands 0:4 0:1: -pkill-window #W? (y/n)
+1783499626.087039 cmd_parse_build_commands 0:4 0:2: kill-window
+1783499626.087043 cmd_parse_build_commands 0:0: confirm-before
+1783499626.087046 cmd_parse_build_commands 0:1: -pkill-window #W? (y/n)
+1783499626.087049 cmd_parse_build_commands 0:2: kill-window
+1783499626.087054 args_parse_flags: next -pkill-window #W? (y/n)
+1783499626.087058 args_parse_flag_argument: -p = kill-window #W? (y/n)
+1783499626.087061 args_parse_flags: next kill-window
+1783499626.087063 args_parse: flags end at 2 of 3
+1783499626.087066 args_parse: 2 = kill-window (type STRING)
+1783499626.087074 cmd_parse_build_commands: confirm-before -p "kill-window #W? (y/n)" kill-window
+1783499626.087077 args_parse_flags: next -N
+1783499626.087080 args_parse_flag_argument: -N = Kill current window
+1783499626.087083 args_parse_flags: next &
+1783499626.087085 args_parse: flags end at 3 of 5
+1783499626.087088 args_parse: 3 = & (type STRING)
+1783499626.087096 args_parse: 4 = confirm-before -p "kill-window #W? (y/n)" kill-window (type COMMANDS)
+1783499626.087108 cmd_parse_build_commands: bind-key -N "Kill current window" & { confirm-before -p "kill-window #W? (y/n)" kill-window }
+1783499626.087114 cmdq_get_command: [bind-key/0x58e4724bac40] group 78
+1783499626.087118 cmdq_append <global>: [bind-key/0x58e4724bac40]
+1783499626.087127 yylex_token: end at WS
+1783499626.087130 yylex_token: bind
+1783499626.087132 yylex_token: end at WS
+1783499626.087134 yylex_token: -N
+1783499626.087139 yylex_token: end at WS
+1783499626.087143 yylex_token: Prompt for window index to select
+1783499626.087146 yylex_token: end at WS
+1783499626.087148 yylex_token: '
+1783499626.087151 yylex_token: end at WS
+1783499626.087153 yylex_token: command-prompt
+1783499626.087156 yylex_token: end at WS
+1783499626.087158 yylex_token: -T
+1783499626.087161 yylex_token: end at WS
+1783499626.087164 yylex_token: window-target
+1783499626.087168 yylex_token: end at WS
+1783499626.087170 yylex_token: -pindex
+1783499626.087174 yylex_token: end at WS
+1783499626.087177 yylex_token: select-window
+1783499626.087179 yylex_token: end at WS
+1783499626.087181 yylex_token: -t
+1783499626.087183 yylex_token: end at WS
+1783499626.087185 yylex_token: :%%
+1783499626.087190 cmd_parse_build_commands 0:0: bind
+1783499626.087193 cmd_parse_build_commands 0:1: -N
+1783499626.087196 cmd_parse_build_commands 0:2: Prompt for window index to select
+1783499626.087198 cmd_parse_build_commands 0:3: '
+1783499626.087202 cmd_parse_build_commands 0:4 0:0: command-prompt
+1783499626.087204 cmd_parse_build_commands 0:4 0:1: -T
+1783499626.087207 cmd_parse_build_commands 0:4 0:2: window-target
+1783499626.087210 cmd_parse_build_commands 0:4 0:3: -pindex
+1783499626.087214 cmd_parse_build_commands 0:4 0:4 0:0: select-window
+1783499626.087216 cmd_parse_build_commands 0:4 0:4 0:1: -t
+1783499626.087219 cmd_parse_build_commands 0:4 0:4 0:2: :%%
+1783499626.087223 cmd_parse_build_commands 0:0: command-prompt
+1783499626.087225 cmd_parse_build_commands 0:1: -T
+1783499626.087228 cmd_parse_build_commands 0:2: window-target
+1783499626.087230 cmd_parse_build_commands 0:3: -pindex
+1783499626.087233 cmd_parse_build_commands 0:4 0:0: select-window
+1783499626.087236 cmd_parse_build_commands 0:4 0:1: -t
+1783499626.087238 cmd_parse_build_commands 0:4 0:2: :%%
+1783499626.087242 cmd_parse_build_commands 0:0: select-window
+1783499626.087245 cmd_parse_build_commands 0:1: -t
+1783499626.087247 cmd_parse_build_commands 0:2: :%%
+1783499626.087253 args_parse_flags: next -t
+1783499626.087257 args_parse_flag_argument: -t = :%%
+1783499626.087259 args_parse: flags end at 3 of 3
+1783499626.087267 cmd_parse_build_commands: select-window -t ":%%"
+1783499626.087270 args_parse_flags: next -T
+1783499626.087273 args_parse_flag_argument: -T = window-target
+1783499626.087275 args_parse_flags: next -pindex
+1783499626.087277 args_parse_flag_argument: -p = index
+1783499626.087280 args_parse: flags end at 4 of 5
+1783499626.087285 args_parse: 4 = select-window -t ":%%" (type COMMANDS)
+1783499626.087357 cmd_parse_build_commands: command-prompt -T window-target -p index { select-window -t ":%%" }
+1783499626.087370 args_parse_flags: next -N
+1783499626.087373 args_parse_flag_argument: -N = Prompt for window index to select
+1783499626.087375 args_parse_flags: next '
+1783499626.087376 args_parse: flags end at 3 of 5
+1783499626.087378 args_parse: 3 = ' (type STRING)
+1783499626.087384 args_parse: 4 = command-prompt -T window-target -p index { select-window -t ":%%" } (type COMMANDS)
+1783499626.087393 cmd_parse_build_commands: bind-key -N "Prompt for window index to select" \\' { command-prompt -T window-target -p index { select-window -t ":%%" } }
+1783499626.087400 cmdq_get_command: [bind-key/0x58e4724bbc30] group 86
+1783499626.087403 cmdq_append <global>: [bind-key/0x58e4724bbc30]
+1783499626.087413 yylex_token: end at WS
+1783499626.087416 yylex_token: bind
+1783499626.087418 yylex_token: end at WS
+1783499626.087419 yylex_token: -N
+1783499626.087421 yylex_token: end at WS
+1783499626.087423 yylex_token: Switch to previous client
+1783499626.087424 yylex_token: end at WS
+1783499626.087425 yylex_token: (
+1783499626.087427 yylex_token: end at WS
+1783499626.087428 yylex_token: switch-client
+1783499626.087430 yylex_token: end at WS
+1783499626.087431 yylex_token: -p
+1783499626.087435 cmd_parse_build_commands 0:0: bind
+1783499626.087437 cmd_parse_build_commands 0:1: -N
+1783499626.087439 cmd_parse_build_commands 0:2: Switch to previous client
+1783499626.087448 cmd_parse_build_commands 0:3: (
+1783499626.087450 cmd_parse_build_commands 0:4 0:0: switch-client
+1783499626.087451 cmd_parse_build_commands 0:4 0:1: -p
+1783499626.087455 cmd_parse_build_commands 0:0: switch-client
+1783499626.087456 cmd_parse_build_commands 0:1: -p
+1783499626.087461 args_parse_flags: next -p
+1783499626.087462 args_parse_flags: -p
+1783499626.087464 args_parse: flags end at 2 of 2
+1783499626.087467 cmd_parse_build_commands: switch-client -p
+1783499626.087468 args_parse_flags: next -N
+1783499626.087471 args_parse_flag_argument: -N = Switch to previous client
+1783499626.087472 args_parse_flags: next (
+1783499626.087474 args_parse: flags end at 3 of 5
+1783499626.087475 args_parse: 3 = ( (type STRING)
+1783499626.087477 args_parse: 4 = switch-client -p (type COMMANDS)
+1783499626.087483 cmd_parse_build_commands: bind-key -N "Switch to previous client" ( { switch-client -p }
+1783499626.087487 cmdq_get_command: [bind-key/0x58e4724bbff0] group 98
+1783499626.087489 cmdq_append <global>: [bind-key/0x58e4724bbff0]
+1783499626.087491 yylex_token: end at WS
+1783499626.087492 yylex_token: bind
+1783499626.087493 yylex_token: end at WS
+1783499626.087495 yylex_token: -N
+1783499626.087497 yylex_token: end at WS
+1783499626.087498 yylex_token: Switch to next client
+1783499626.087499 yylex_token: end at WS
+1783499626.087500 yylex_token: )
+1783499626.087502 yylex_token: end at WS
+1783499626.087503 yylex_token: switch-client
+1783499626.087504 yylex_token: end at WS
+1783499626.087505 yylex_token: -n
+1783499626.087508 cmd_parse_build_commands 0:0: bind
+1783499626.087509 cmd_parse_build_commands 0:1: -N
+1783499626.087511 cmd_parse_build_commands 0:2: Switch to next client
+1783499626.087512 cmd_parse_build_commands 0:3: )
+1783499626.087514 cmd_parse_build_commands 0:4 0:0: switch-client
+1783499626.087515 cmd_parse_build_commands 0:4 0:1: -n
+1783499626.087517 cmd_parse_build_commands 0:0: switch-client
+1783499626.087518 cmd_parse_build_commands 0:1: -n
+1783499626.087521 args_parse_flags: next -n
+1783499626.087522 args_parse_flags: -n
+1783499626.087524 args_parse: flags end at 2 of 2
+1783499626.087526 cmd_parse_build_commands: switch-client -n
+1783499626.087527 args_parse_flags: next -N
+1783499626.087528 args_parse_flag_argument: -N = Switch to next client
+1783499626.087530 args_parse_flags: next )
+1783499626.087531 args_parse: flags end at 3 of 5
+1783499626.087532 args_parse: 3 = ) (type STRING)
+1783499626.087534 args_parse: 4 = switch-client -n (type COMMANDS)
+1783499626.087539 cmd_parse_build_commands: bind-key -N "Switch to next client" ) { switch-client -n }
+1783499626.087542 cmdq_get_command: [bind-key/0x58e4724bc290] group 106
+1783499626.087543 cmdq_append <global>: [bind-key/0x58e4724bc290]
+1783499626.087550 yylex_token: end at WS
+1783499626.087553 yylex_token: bind
+1783499626.087555 yylex_token: end at WS
+1783499626.087556 yylex_token: -N
+1783499626.087557 yylex_token: end at WS
+1783499626.087558 yylex_token: Rename current window
+1783499626.087560 yylex_token: end at WS
+1783499626.087561 yylex_token: ,
+1783499626.087562 yylex_token: end at WS
+1783499626.087563 yylex_token: command-prompt
+1783499626.087564 yylex_token: end at WS
+1783499626.087565 yylex_token: -I#W
+1783499626.087567 yylex_token: end at WS
+1783499626.087568 yylex_token: rename-window
+1783499626.087569 yylex_token: end at WS
+1783499626.087570 yylex_token: --
+1783499626.087571 yylex_token: end at WS
+1783499626.087572 yylex_token: %%
+1783499626.087575 cmd_parse_build_commands 0:0: bind
+1783499626.087576 cmd_parse_build_commands 0:1: -N
+1783499626.087577 cmd_parse_build_commands 0:2: Rename current window
+1783499626.087579 cmd_parse_build_commands 0:3: ,
+1783499626.087580 cmd_parse_build_commands 0:4 0:0: command-prompt
+1783499626.087581 cmd_parse_build_commands 0:4 0:1: -I#W
+1783499626.087583 cmd_parse_build_commands 0:4 0:2 0:0: rename-window
+1783499626.087584 cmd_parse_build_commands 0:4 0:2 0:1: --
+1783499626.087586 cmd_parse_build_commands 0:4 0:2 0:2: %%
+1783499626.087588 cmd_parse_build_commands 0:0: command-prompt
+1783499626.087593 cmd_parse_build_commands 0:1: -I#W
+1783499626.087594 cmd_parse_build_commands 0:2 0:0: rename-window
+1783499626.087595 cmd_parse_build_commands 0:2 0:1: --
+1783499626.087597 cmd_parse_build_commands 0:2 0:2: %%
+1783499626.087599 cmd_parse_build_commands 0:0: rename-window
+1783499626.087600 cmd_parse_build_commands 0:1: --
+1783499626.087601 cmd_parse_build_commands 0:2: %%
+1783499626.087604 args_parse_flags: next --
+1783499626.087605 args_parse: flags end at 2 of 3
+1783499626.087607 args_parse: 2 = %% (type STRING)
+1783499626.087609 cmd_parse_build_commands: rename-window "%%"
+1783499626.087611 args_parse_flags: next -I#W
+1783499626.087612 args_parse_flag_argument: -I = #W
+1783499626.087614 args_parse: flags end at 2 of 3
+1783499626.087617 args_parse: 2 = rename-window "%%" (type COMMANDS)
+1783499626.087621 cmd_parse_build_commands: command-prompt -I "#W" { rename-window "%%" }
+1783499626.087622 args_parse_flags: next -N
+1783499626.087624 args_parse_flag_argument: -N = Rename current window
+1783499626.087625 args_parse_flags: next ,
+1783499626.087626 args_parse: flags end at 3 of 5
+1783499626.087628 args_parse: 3 = , (type STRING)
+1783499626.087631 args_parse: 4 = command-prompt -I "#W" { rename-window "%%" } (type COMMANDS)
+1783499626.087636 cmd_parse_build_commands: bind-key -N "Rename current window" , { command-prompt -I "#W" { rename-window "%%" } }
+1783499626.087640 cmdq_get_command: [bind-key/0x58e4724bcca0] group 114
+1783499626.087641 cmdq_append <global>: [bind-key/0x58e4724bcca0]
+1783499626.087648 yylex_token: end at WS
+1783499626.087651 yylex_token: bind
+1783499626.087652 yylex_token: end at WS
+1783499626.087653 yylex_token: -N
+1783499626.087655 yylex_token: end at WS
+1783499626.087657 yylex_token: Delete the most recent paste buffer
+1783499626.087658 yylex_token: end at WS
+1783499626.087659 yylex_token: -
+1783499626.087661 yylex_token: end at WS
+1783499626.087662 yylex_token: delete-buffer
+1783499626.087664 cmd_parse_build_commands 0:0: bind
+1783499626.087665 cmd_parse_build_commands 0:1: -N
+1783499626.087667 cmd_parse_build_commands 0:2: Delete the most recent paste buffer
+1783499626.087668 cmd_parse_build_commands 0:3: -
+1783499626.087670 cmd_parse_build_commands 0:4 0:0: delete-buffer
+1783499626.087672 cmd_parse_build_commands 0:0: delete-buffer
+1783499626.087675 args_parse: flags end at 1 of 1
+1783499626.087677 cmd_parse_build_commands: delete-buffer
+1783499626.087678 args_parse_flags: next -N
+1783499626.087679 args_parse_flag_argument: -N = Delete the most recent paste buffer
+1783499626.087681 args_parse_flags: next -
+1783499626.087682 args_parse: flags end at 3 of 5
+1783499626.087683 args_parse: 3 = - (type STRING)
+1783499626.087685 args_parse: 4 = delete-buffer (type COMMANDS)
+1783499626.087689 cmd_parse_build_commands: bind-key -N "Delete the most recent paste buffer" - { delete-buffer }
+1783499626.087691 cmdq_get_command: [bind-key/0x58e4724bd9a0] group 126
+1783499626.087693 cmdq_append <global>: [bind-key/0x58e4724bd9a0]
+1783499626.087695 yylex_token: end at WS
+1783499626.087696 yylex_token: bind
+1783499626.087697 yylex_token: end at WS
+1783499626.087698 yylex_token: -N
+1783499626.087700 yylex_token: end at WS
+1783499626.087701 yylex_token: Move the current window
+1783499626.087702 yylex_token: end at WS
+1783499626.087703 yylex_token: .
+1783499626.087705 yylex_token: end at WS
+1783499626.087706 yylex_token: command-prompt
+1783499626.087707 yylex_token: end at WS
+1783499626.087708 yylex_token: -T
+1783499626.087709 yylex_token: end at WS
+1783499626.087710 yylex_token: target
+1783499626.087712 yylex_token: end at WS
+1783499626.087713 yylex_token: move-window
+1783499626.087714 yylex_token: end at WS
+1783499626.087715 yylex_token: -t
+1783499626.087717 yylex_token: end at WS
+1783499626.087717 yylex_token: %%
+1783499626.087720 cmd_parse_build_commands 0:0: bind
+1783499626.087721 cmd_parse_build_commands 0:1: -N
+1783499626.087723 cmd_parse_build_commands 0:2: Move the current window
+1783499626.087724 cmd_parse_build_commands 0:3: .
+1783499626.087726 cmd_parse_build_commands 0:4 0:0: command-prompt
+1783499626.087730 cmd_parse_build_commands 0:4 0:1: -T
+1783499626.087731 cmd_parse_build_commands 0:4 0:2: target
+1783499626.087733 cmd_parse_build_commands 0:4 0:3 0:0: move-window
+1783499626.087734 cmd_parse_build_commands 0:4 0:3 0:1: -t
+1783499626.087736 cmd_parse_build_commands 0:4 0:3 0:2: %%
+1783499626.087738 cmd_parse_build_commands 0:0: command-prompt
+1783499626.087740 cmd_parse_build_commands 0:1: -T
+1783499626.087741 cmd_parse_build_commands 0:2: target
+1783499626.087743 cmd_parse_build_commands 0:3 0:0: move-window
+1783499626.087744 cmd_parse_build_commands 0:3 0:1: -t
+1783499626.087745 cmd_parse_build_commands 0:3 0:2: %%
+1783499626.087748 cmd_parse_build_commands 0:0: move-window
+1783499626.087749 cmd_parse_build_commands 0:1: -t
+1783499626.087750 cmd_parse_build_commands 0:2: %%
+1783499626.087752 args_parse_flags: next -t
+1783499626.087754 args_parse_flag_argument: -t = %%
+1783499626.087755 args_parse: flags end at 3 of 3
+1783499626.087757 cmd_parse_build_commands: move-window -t "%%"
+1783499626.087759 args_parse_flags: next -T
+1783499626.087760 args_parse_flag_argument: -T = target
+1783499626.087762 args_parse: flags end at 3 of 4
+1783499626.087765 args_parse: 3 = move-window -t "%%" (type COMMANDS)
+1783499626.087769 cmd_parse_build_commands: command-prompt -T target { move-window -t "%%" }
+1783499626.087770 args_parse_flags: next -N
+1783499626.087772 args_parse_flag_argument: -N = Move the current window
+1783499626.087773 args_parse_flags: next .
+1783499626.087774 args_parse: flags end at 3 of 5
+1783499626.087776 args_parse: 3 = . (type STRING)
+1783499626.087779 args_parse: 4 = command-prompt -T target { move-window -t "%%" } (type COMMANDS)
+1783499626.087785 cmd_parse_build_commands: bind-key -N "Move the current window" . { command-prompt -T target { move-window -t "%%" } }
+1783499626.087788 cmdq_get_command: [bind-key/0x58e4724bdd70] group 134
+1783499626.087789 cmdq_append <global>: [bind-key/0x58e4724bdd70]
+1783499626.087803 yylex_token: end at WS
+1783499626.087807 yylex_token: bind
+1783499626.087808 yylex_token: end at WS
+1783499626.087809 yylex_token: -N
+1783499626.087810 yylex_token: end at WS
+1783499626.087812 yylex_token: Describe key binding
+1783499626.087813 yylex_token: end at WS
+1783499626.087814 yylex_token: /
+1783499626.087816 yylex_token: end at WS
+1783499626.087817 yylex_token: command-prompt
+1783499626.087818 yylex_token: end at WS
+1783499626.087819 yylex_token: -kpkey
+1783499626.087821 yylex_token: end at WS
+1783499626.087822 yylex_token: list-keys
+1783499626.087824 yylex_token: end at WS
+1783499626.087825 yylex_token: -1N
+1783499626.087826 yylex_token: end at WS
+1783499626.087828 yylex_token: %%
+1783499626.087830 cmd_parse_build_commands 0:0: bind
+1783499626.087832 cmd_parse_build_commands 0:1: -N
+1783499626.087833 cmd_parse_build_commands 0:2: Describe key binding
+1783499626.087834 cmd_parse_build_commands 0:3: /
+1783499626.087836 cmd_parse_build_commands 0:4 0:0: command-prompt
+1783499626.087837 cmd_parse_build_commands 0:4 0:1: -kpkey
+1783499626.087839 cmd_parse_build_commands 0:4 0:2 0:0: list-keys
+1783499626.087841 cmd_parse_build_commands 0:4 0:2 0:1: -1N
+1783499626.087842 cmd_parse_build_commands 0:4 0:2 0:2: %%
+1783499626.087844 cmd_parse_build_commands 0:0: command-prompt
+1783499626.087846 cmd_parse_build_commands 0:1: -kpkey
+1783499626.087847 cmd_parse_build_commands 0:2 0:0: list-keys
+1783499626.087848 cmd_parse_build_commands 0:2 0:1: -1N
+1783499626.087849 cmd_parse_build_commands 0:2 0:2: %%
+1783499626.087851 cmd_parse_build_commands 0:0: list-keys
+1783499626.087852 cmd_parse_build_commands 0:1: -1N
+1783499626.087854 cmd_parse_build_commands 0:2: %%
+1783499626.087856 args_parse_flags: next -1N
+1783499626.087857 args_parse_flags: -1
+1783499626.087858 args_parse_flags: -N
+1783499626.087860 args_parse_flags: next %%
+1783499626.087861 args_parse: flags end at 2 of 3
+1783499626.087862 args_parse: 2 = %% (type STRING)
+1783499626.087865 cmd_parse_build_commands: list-keys -1N "%%"
+1783499626.087866 args_parse_flags: next -kpkey
+1783499626.087867 args_parse_flags: -k
+1783499626.087872 args_parse_flag_argument: -p = key
+1783499626.087873 args_parse: flags end at 2 of 3
+1783499626.087876 args_parse: 2 = list-keys -1N "%%" (type COMMANDS)
+1783499626.087880 cmd_parse_build_commands: command-prompt -k -p key { list-keys -1N "%%" }
+1783499626.087882 args_parse_flags: next -N
+1783499626.087883 args_parse_flag_argument: -N = Describe key binding
+1783499626.087885 args_parse_flags: next /
+1783499626.087886 args_parse: flags end at 3 of 5
+1783499626.087887 args_parse: 3 = / (type STRING)
+1783499626.087891 args_parse: 4 = command-prompt -k -p key { list-keys -1N "%%" } (type COMMANDS)
+1783499626.087897 cmd_parse_build_commands: bind-key -N "Describe key binding" / { command-prompt -k -p key { list-keys -1N "%%" } }
+1783499626.087899 cmdq_get_command: [bind-key/0x58e4724bf000] group 146
+1783499626.087900 cmdq_append <global>: [bind-key/0x58e4724bf000]
+1783499626.087903 yylex_token: end at WS
+1783499626.087904 yylex_token: bind
+1783499626.087905 yylex_token: end at WS
+1783499626.087906 yylex_token: -N
+1783499626.087908 yylex_token: end at WS
+1783499626.087909 yylex_token: Select window 0
+1783499626.087910 yylex_token: end at WS
+1783499626.087911 yylex_token: 0
+1783499626.087912 yylex_token: end at WS
+1783499626.087913 yylex_token: select-window
+1783499626.087915 yylex_token: end at WS
+1783499626.087916 yylex_token: -t:=0
+1783499626.087918 cmd_parse_build_commands 0:0: bind
+1783499626.087919 cmd_parse_build_commands 0:1: -N
+1783499626.087920 cmd_parse_build_commands 0:2: Select window 0
+1783499626.087921 cmd_parse_build_commands 0:3: 0
+1783499626.087923 cmd_parse_build_commands 0:4 0:0: select-window
+1783499626.087924 cmd_parse_build_commands 0:4 0:1: -t:=0
+1783499626.087926 cmd_parse_build_commands 0:0: select-window
+1783499626.087927 cmd_parse_build_commands 0:1: -t:=0
+1783499626.087930 args_parse_flags: next -t:=0
+1783499626.087931 args_parse_flag_argument: -t = :=0
+1783499626.087933 args_parse: flags end at 2 of 2
+1783499626.087935 cmd_parse_build_commands: select-window -t :=0
+1783499626.087937 args_parse_flags: next -N
+1783499626.087938 args_parse_flag_argument: -N = Select window 0
+1783499626.087939 args_parse_flags: next 0
+1783499626.087941 args_parse: flags end at 3 of 5
+1783499626.087942 args_parse: 3 = 0 (type STRING)
+1783499626.087945 args_parse: 4 = select-window -t :=0 (type COMMANDS)
+1783499626.087949 cmd_parse_build_commands: bind-key -N "Select window 0" 0 { select-window -t :=0 }
+1783499626.087951 cmdq_get_command: [bind-key/0x58e4724bf1a0] group 158
+1783499626.087953 cmdq_append <global>: [bind-key/0x58e4724bf1a0]
+1783499626.087955 yylex_token: end at WS
+1783499626.087956 yylex_token: bind
+1783499626.087957 yylex_token: end at WS
+1783499626.087958 yylex_token: -N
+1783499626.087959 yylex_token: end at WS
+1783499626.087961 yylex_token: Select window 1
+1783499626.087962 yylex_token: end at WS
+1783499626.087963 yylex_token: 1
+1783499626.087965 yylex_token: end at WS
+1783499626.087966 yylex_token: select-window
+1783499626.087967 yylex_token: end at WS
+1783499626.087968 yylex_token: -t:=1
+1783499626.087970 cmd_parse_build_commands 0:0: bind
+1783499626.087972 cmd_parse_build_commands 0:1: -N
+1783499626.087973 cmd_parse_build_commands 0:2: Select window 1
+1783499626.087974 cmd_parse_build_commands 0:3: 1
+1783499626.087976 cmd_parse_build_commands 0:4 0:0: select-window
+1783499626.087977 cmd_parse_build_commands 0:4 0:1: -t:=1
+1783499626.087979 cmd_parse_build_commands 0:0: select-window
+1783499626.087980 cmd_parse_build_commands 0:1: -t:=1
+1783499626.087983 args_parse_flags: next -t:=1
+1783499626.087984 args_parse_flag_argument: -t = :=1
+1783499626.087985 args_parse: flags end at 2 of 2
+1783499626.087988 cmd_parse_build_commands: select-window -t :=1
+1783499626.087989 args_parse_flags: next -N
+1783499626.087991 args_parse_flag_argument: -N = Select window 1
+1783499626.087992 args_parse_flags: next 1
+1783499626.087994 args_parse: flags end at 3 of 5
+1783499626.087995 args_parse: 3 = 1 (type STRING)
+1783499626.087997 args_parse: 4 = select-window -t :=1 (type COMMANDS)
+1783499626.088004 cmd_parse_build_commands: bind-key -N "Select window 1" 1 { select-window -t :=1 }
+1783499626.088007 cmdq_get_command: [bind-key/0x58e4724bf5b0] group 166
+1783499626.088008 cmdq_append <global>: [bind-key/0x58e4724bf5b0]
+1783499626.088016 yylex_token: end at WS
+1783499626.088019 yylex_token: bind
+1783499626.088020 yylex_token: end at WS
+1783499626.088021 yylex_token: -N
+1783499626.088023 yylex_token: end at WS
+1783499626.088024 yylex_token: Select window 2
+1783499626.088025 yylex_token: end at WS
+1783499626.088026 yylex_token: 2
+1783499626.088027 yylex_token: end at WS
+1783499626.088028 yylex_token: select-window
+1783499626.088030 yylex_token: end at WS
+1783499626.088031 yylex_token: -t:=2
+1783499626.088033 cmd_parse_build_commands 0:0: bind
+1783499626.088034 cmd_parse_build_commands 0:1: -N
+1783499626.088035 cmd_parse_build_commands 0:2: Select window 2
+1783499626.088037 cmd_parse_build_commands 0:3: 2
+1783499626.088038 cmd_parse_build_commands 0:4 0:0: select-window
+1783499626.088040 cmd_parse_build_commands 0:4 0:1: -t:=2
+1783499626.088042 cmd_parse_build_commands 0:0: select-window
+1783499626.088043 cmd_parse_build_commands 0:1: -t:=2
+1783499626.088046 args_parse_flags: next -t:=2
+1783499626.088047 args_parse_flag_argument: -t = :=2
+1783499626.088048 args_parse: flags end at 2 of 2
+1783499626.088051 cmd_parse_build_commands: select-window -t :=2
+1783499626.088053 args_parse_flags: next -N
+1783499626.088054 args_parse_flag_argument: -N = Select window 2
+1783499626.088055 args_parse_flags: next 2
+1783499626.088056 args_parse: flags end at 3 of 5
+1783499626.088057 args_parse: 3 = 2 (type STRING)
+1783499626.088060 args_parse: 4 = select-window -t :=2 (type COMMANDS)
+1783499626.088064 cmd_parse_build_commands: bind-key -N "Select window 2" 2 { select-window -t :=2 }
+1783499626.088067 cmdq_get_command: [bind-key/0x58e4724bf9e0] group 174
+1783499626.088068 cmdq_append <global>: [bind-key/0x58e4724bf9e0]
+1783499626.088070 yylex_token: end at WS
+1783499626.088071 yylex_token: bind
+1783499626.088072 yylex_token: end at WS
+1783499626.088073 yylex_token: -N
+1783499626.088074 yylex_token: end at WS
+1783499626.088075 yylex_token: Select window 3
+1783499626.088077 yylex_token: end at WS
+1783499626.088078 yylex_token: 3
+1783499626.088079 yylex_token: end at WS
+1783499626.088080 yylex_token: select-window
+1783499626.088081 yylex_token: end at WS
+1783499626.088082 yylex_token: -t:=3
+1783499626.088085 cmd_parse_build_commands 0:0: bind
+1783499626.088086 cmd_parse_build_commands 0:1: -N
+1783499626.088087 cmd_parse_build_commands 0:2: Select window 3
+1783499626.088088 cmd_parse_build_commands 0:3: 3
+1783499626.088090 cmd_parse_build_commands 0:4 0:0: select-window
+1783499626.088091 cmd_parse_build_commands 0:4 0:1: -t:=3
+1783499626.088093 cmd_parse_build_commands 0:0: select-window
+1783499626.088094 cmd_parse_build_commands 0:1: -t:=3
+1783499626.088097 args_parse_flags: next -t:=3
+1783499626.088098 args_parse_flag_argument: -t = :=3
+1783499626.088099 args_parse: flags end at 2 of 2
+1783499626.088102 cmd_parse_build_commands: select-window -t :=3
+1783499626.088103 args_parse_flags: next -N
+1783499626.088105 args_parse_flag_argument: -N = Select window 3
+1783499626.088106 args_parse_flags: next 3
+1783499626.088107 args_parse: flags end at 3 of 5
+1783499626.088108 args_parse: 3 = 3 (type STRING)
+1783499626.088111 args_parse: 4 = select-window -t :=3 (type COMMANDS)
+1783499626.088115 cmd_parse_build_commands: bind-key -N "Select window 3" 3 { select-window -t :=3 }
+1783499626.088117 cmdq_get_command: [bind-key/0x58e4724bffb0] group 182
+1783499626.088119 cmdq_append <global>: [bind-key/0x58e4724bffb0]
+1783499626.088120 yylex_token: end at WS
+1783499626.088121 yylex_token: bind
+1783499626.088122 yylex_token: end at WS
+1783499626.088123 yylex_token: -N
+1783499626.088125 yylex_token: end at WS
+1783499626.088126 yylex_token: Select window 4
+1783499626.088127 yylex_token: end at WS
+1783499626.088128 yylex_token: 4
+1783499626.088129 yylex_token: end at WS
+1783499626.088131 yylex_token: select-window
+1783499626.088132 yylex_token: end at WS
+1783499626.088135 yylex_token: -t:=4
+1783499626.088138 cmd_parse_build_commands 0:0: bind
+1783499626.088139 cmd_parse_build_commands 0:1: -N
+1783499626.088140 cmd_parse_build_commands 0:2: Select window 4
+1783499626.088141 cmd_parse_build_commands 0:3: 4
+1783499626.088143 cmd_parse_build_commands 0:4 0:0: select-window
+1783499626.088144 cmd_parse_build_commands 0:4 0:1: -t:=4
+1783499626.088146 cmd_parse_build_commands 0:0: select-window
+1783499626.088147 cmd_parse_build_commands 0:1: -t:=4
+1783499626.088150 args_parse_flags: next -t:=4
+1783499626.088152 args_parse_flag_argument: -t = :=4
+1783499626.088153 args_parse: flags end at 2 of 2
+1783499626.088155 cmd_parse_build_commands: select-window -t :=4
+1783499626.088157 args_parse_flags: next -N
+1783499626.088158 args_parse_flag_argument: -N = Select window 4
+1783499626.088159 args_parse_flags: next 4
+1783499626.088160 args_parse: flags end at 3 of 5
+1783499626.088161 args_parse: 3 = 4 (type STRING)
+1783499626.088164 args_parse: 4 = select-window -t :=4 (type COMMANDS)
+1783499626.088168 cmd_parse_build_commands: bind-key -N "Select window 4" 4 { select-window -t :=4 }
+1783499626.088170 cmdq_get_command: [bind-key/0x58e4724c0a40] group 190
+1783499626.088172 cmdq_append <global>: [bind-key/0x58e4724c0a40]
+1783499626.088180 yylex_token: end at WS
+1783499626.088183 yylex_token: bind
+1783499626.088184 yylex_token: end at WS
+1783499626.088185 yylex_token: -N
+1783499626.088186 yylex_token: end at WS
+1783499626.088188 yylex_token: Select window 5
+1783499626.088189 yylex_token: end at WS
+1783499626.088190 yylex_token: 5
+1783499626.088191 yylex_token: end at WS
+1783499626.088192 yylex_token: select-window
+1783499626.088193 yylex_token: end at WS
+1783499626.088194 yylex_token: -t:=5
+1783499626.088197 cmd_parse_build_commands 0:0: bind
+1783499626.088198 cmd_parse_build_commands 0:1: -N
+1783499626.088199 cmd_parse_build_commands 0:2: Select window 5
+1783499626.088200 cmd_parse_build_commands 0:3: 5
+1783499626.088202 cmd_parse_build_commands 0:4 0:0: select-window
+1783499626.088203 cmd_parse_build_commands 0:4 0:1: -t:=5
+1783499626.088205 cmd_parse_build_commands 0:0: select-window
+1783499626.088207 cmd_parse_build_commands 0:1: -t:=5
+1783499626.088209 args_parse_flags: next -t:=5
+1783499626.088211 args_parse_flag_argument: -t = :=5
+1783499626.088212 args_parse: flags end at 2 of 2
+1783499626.088216 cmd_parse_build_commands: select-window -t :=5
+1783499626.088217 args_parse_flags: next -N
+1783499626.088218 args_parse_flag_argument: -N = Select window 5
+1783499626.088220 args_parse_flags: next 5
+1783499626.088222 args_parse: flags end at 3 of 5
+1783499626.088223 args_parse: 3 = 5 (type STRING)
+1783499626.088226 args_parse: 4 = select-window -t :=5 (type COMMANDS)
+1783499626.088230 cmd_parse_build_commands: bind-key -N "Select window 5" 5 { select-window -t :=5 }
+1783499626.088233 cmdq_get_command: [bind-key/0x58e4724c07d0] group 198
+1783499626.088235 cmdq_append <global>: [bind-key/0x58e4724c07d0]
+1783499626.088236 yylex_token: end at WS
+1783499626.088237 yylex_token: bind
+1783499626.088238 yylex_token: end at WS
+1783499626.088239 yylex_token: -N
+1783499626.088241 yylex_token: end at WS
+1783499626.088242 yylex_token: Select window 6
+1783499626.088243 yylex_token: end at WS
+1783499626.088244 yylex_token: 6
+1783499626.088245 yylex_token: end at WS
+1783499626.088247 yylex_token: select-window
+1783499626.088248 yylex_token: end at WS
+1783499626.088249 yylex_token: -t:=6
+1783499626.088251 cmd_parse_build_commands 0:0: bind
+1783499626.088252 cmd_parse_build_commands 0:1: -N
+1783499626.088254 cmd_parse_build_commands 0:2: Select window 6
+1783499626.088255 cmd_parse_build_commands 0:3: 6
+1783499626.088256 cmd_parse_build_commands 0:4 0:0: select-window
+1783499626.088258 cmd_parse_build_commands 0:4 0:1: -t:=6
+1783499626.088259 cmd_parse_build_commands 0:0: select-window
+1783499626.088261 cmd_parse_build_commands 0:1: -t:=6
+1783499626.088264 args_parse_flags: next -t:=6
+1783499626.088265 args_parse_flag_argument: -t = :=6
+1783499626.088266 args_parse: flags end at 2 of 2
+1783499626.088269 cmd_parse_build_commands: select-window -t :=6
+1783499626.088352 args_parse_flags: next -N
+1783499626.088358 args_parse_flag_argument: -N = Select window 6
+1783499626.088360 args_parse_flags: next 6
+1783499626.088362 args_parse: flags end at 3 of 5
+1783499626.088364 args_parse: 3 = 6 (type STRING)
+1783499626.088369 args_parse: 4 = select-window -t :=6 (type COMMANDS)
+1783499626.088375 cmd_parse_build_commands: bind-key -N "Select window 6" 6 { select-window -t :=6 }
+1783499626.088378 cmdq_get_command: [bind-key/0x58e4724c11e0] group 206
+1783499626.088380 cmdq_append <global>: [bind-key/0x58e4724c11e0]
+1783499626.088383 yylex_token: end at WS
+1783499626.088384 yylex_token: bind
+1783499626.088386 yylex_token: end at WS
+1783499626.088387 yylex_token: -N
+1783499626.088389 yylex_token: end at WS
+1783499626.088390 yylex_token: Select window 7
+1783499626.088391 yylex_token: end at WS
+1783499626.088393 yylex_token: 7
+1783499626.088394 yylex_token: end at WS
+1783499626.088396 yylex_token: select-window
+1783499626.088403 yylex_token: end at WS
+1783499626.088407 yylex_token: -t:=7
+1783499626.088411 cmd_parse_build_commands 0:0: bind
+1783499626.088412 cmd_parse_build_commands 0:1: -N
+1783499626.088414 cmd_parse_build_commands 0:2: Select window 7
+1783499626.088415 cmd_parse_build_commands 0:3: 7
+1783499626.088417 cmd_parse_build_commands 0:4 0:0: select-window
+1783499626.088418 cmd_parse_build_commands 0:4 0:1: -t:=7
+1783499626.088421 cmd_parse_build_commands 0:0: select-window
+1783499626.088423 cmd_parse_build_commands 0:1: -t:=7
+1783499626.088426 args_parse_flags: next -t:=7
+1783499626.088428 args_parse_flag_argument: -t = :=7
+1783499626.088429 args_parse: flags end at 2 of 2
+1783499626.088433 cmd_parse_build_commands: select-window -t :=7
+1783499626.088434 args_parse_flags: next -N
+1783499626.088436 args_parse_flag_argument: -N = Select window 7
+1783499626.088437 args_parse_flags: next 7
+1783499626.088439 args_parse: flags end at 3 of 5
+1783499626.088440 args_parse: 3 = 7 (type STRING)
+1783499626.088443 args_parse: 4 = select-window -t :=7 (type COMMANDS)
+1783499626.088448 cmd_parse_build_commands: bind-key -N "Select window 7" 7 { select-window -t :=7 }
+1783499626.088450 cmdq_get_command: [bind-key/0x58e4724c1c70] group 214
+1783499626.088452 cmdq_append <global>: [bind-key/0x58e4724c1c70]
+1783499626.088455 yylex_token: end at WS
+1783499626.088456 yylex_token: bind
+1783499626.088457 yylex_token: end at WS
+1783499626.088459 yylex_token: -N
+1783499626.088461 yylex_token: end at WS
+1783499626.088462 yylex_token: Select window 8
+1783499626.088463 yylex_token: end at WS
+1783499626.088464 yylex_token: 8
+1783499626.088466 yylex_token: end at WS
+1783499626.088467 yylex_token: select-window
+1783499626.088468 yylex_token: end at WS
+1783499626.088469 yylex_token: -t:=8
+1783499626.088472 cmd_parse_build_commands 0:0: bind
+1783499626.088474 cmd_parse_build_commands 0:1: -N
+1783499626.088475 cmd_parse_build_commands 0:2: Select window 8
+1783499626.088476 cmd_parse_build_commands 0:3: 8
+1783499626.088478 cmd_parse_build_commands 0:4 0:0: select-window
+1783499626.088480 cmd_parse_build_commands 0:4 0:1: -t:=8
+1783499626.088482 cmd_parse_build_commands 0:0: select-window
+1783499626.088483 cmd_parse_build_commands 0:1: -t:=8
+1783499626.088486 args_parse_flags: next -t:=8
+1783499626.088487 args_parse_flag_argument: -t = :=8
+1783499626.088488 args_parse: flags end at 2 of 2
+1783499626.088492 cmd_parse_build_commands: select-window -t :=8
+1783499626.088493 args_parse_flags: next -N
+1783499626.088494 args_parse_flag_argument: -N = Select window 8
+1783499626.088496 args_parse_flags: next 8
+1783499626.088497 args_parse: flags end at 3 of 5
+1783499626.088498 args_parse: 3 = 8 (type STRING)
+1783499626.088501 args_parse: 4 = select-window -t :=8 (type COMMANDS)
+1783499626.088506 cmd_parse_build_commands: bind-key -N "Select window 8" 8 { select-window -t :=8 }
+1783499626.088508 cmdq_get_command: [bind-key/0x58e4724c1a00] group 222
+1783499626.088510 cmdq_append <global>: [bind-key/0x58e4724c1a00]
+1783499626.088512 yylex_token: end at WS
+1783499626.088513 yylex_token: bind
+1783499626.088520 yylex_token: end at WS
+1783499626.088521 yylex_token: -N
+1783499626.088523 yylex_token: end at WS
+1783499626.088524 yylex_token: Select window 9
+1783499626.088525 yylex_token: end at WS
+1783499626.088526 yylex_token: 9
+1783499626.088527 yylex_token: end at WS
+1783499626.088529 yylex_token: select-window
+1783499626.088530 yylex_token: end at WS
+1783499626.088531 yylex_token: -t:=9
+1783499626.088534 cmd_parse_build_commands 0:0: bind
+1783499626.088535 cmd_parse_build_commands 0:1: -N
+1783499626.088536 cmd_parse_build_commands 0:2: Select window 9
+1783499626.088538 cmd_parse_build_commands 0:3: 9
+1783499626.088540 cmd_parse_build_commands 0:4 0:0: select-window
+1783499626.088541 cmd_parse_build_commands 0:4 0:1: -t:=9
+1783499626.088543 cmd_parse_build_commands 0:0: select-window
+1783499626.088545 cmd_parse_build_commands 0:1: -t:=9
+1783499626.088547 args_parse_flags: next -t:=9
+1783499626.088549 args_parse_flag_argument: -t = :=9
+1783499626.088550 args_parse: flags end at 2 of 2
+1783499626.088553 cmd_parse_build_commands: select-window -t :=9
+1783499626.088554 args_parse_flags: next -N
+1783499626.088556 args_parse_flag_argument: -N = Select window 9
+1783499626.088558 args_parse_flags: next 9
+1783499626.088559 args_parse: flags end at 3 of 5
+1783499626.088560 args_parse: 3 = 9 (type STRING)
+1783499626.088563 args_parse: 4 = select-window -t :=9 (type COMMANDS)
+1783499626.088568 cmd_parse_build_commands: bind-key -N "Select window 9" 9 { select-window -t :=9 }
+1783499626.088571 cmdq_get_command: [bind-key/0x58e4724c2490] group 230
+1783499626.088573 cmdq_append <global>: [bind-key/0x58e4724c2490]
+1783499626.088580 yylex_token: end at WS
+1783499626.088584 yylex_token: bind
+1783499626.088585 yylex_token: end at WS
+1783499626.088586 yylex_token: -N
+1783499626.088588 yylex_token: end at WS
+1783499626.088589 yylex_token: Prompt for a command
+1783499626.088591 yylex_token: end at WS
+1783499626.088592 yylex_token: :
+1783499626.088593 yylex_token: end at WS
+1783499626.088594 yylex_token: command-prompt
+1783499626.088597 cmd_parse_build_commands 0:0: bind
+1783499626.088598 cmd_parse_build_commands 0:1: -N
+1783499626.088600 cmd_parse_build_commands 0:2: Prompt for a command
+1783499626.088601 cmd_parse_build_commands 0:3: :
+1783499626.088602 cmd_parse_build_commands 0:4 0:0: command-prompt
+1783499626.088605 cmd_parse_build_commands 0:0: command-prompt
+1783499626.088607 args_parse: flags end at 1 of 1
+1783499626.088609 cmd_parse_build_commands: command-prompt
+1783499626.088610 args_parse_flags: next -N
+1783499626.088612 args_parse_flag_argument: -N = Prompt for a command
+1783499626.088613 args_parse_flags: next :
+1783499626.088614 args_parse: flags end at 3 of 5
+1783499626.088616 args_parse: 3 = : (type STRING)
+1783499626.088618 args_parse: 4 = command-prompt (type COMMANDS)
+1783499626.088622 cmd_parse_build_commands: bind-key -N "Prompt for a command" : { command-prompt }
+1783499626.088625 cmdq_get_command: [bind-key/0x58e4724c2830] group 238
+1783499626.088627 cmdq_append <global>: [bind-key/0x58e4724c2830]
+1783499626.088629 yylex_token: end at WS
+1783499626.088630 yylex_token: bind
+1783499626.088631 yylex_token: end at WS
+1783499626.088632 yylex_token: -N
+1783499626.088634 yylex_token: end at WS
+1783499626.088636 yylex_token: Move to the previously active pane
+1783499626.088637 yylex_token: end at WS
+1783499626.088638 yylex_token: ;
+1783499626.088640 yylex_token: end at WS
+1783499626.088641 yylex_token: last-pane
+1783499626.088643 cmd_parse_build_commands 0:0: bind
+1783499626.088644 cmd_parse_build_commands 0:1: -N
+1783499626.088646 cmd_parse_build_commands 0:2: Move to the previously active pane
+1783499626.088647 cmd_parse_build_commands 0:3: ;
+1783499626.088649 cmd_parse_build_commands 0:4 0:0: last-pane
+1783499626.088651 cmd_parse_build_commands 0:0: last-pane
+1783499626.088653 args_parse: flags end at 1 of 1
+1783499626.088655 cmd_parse_build_commands: last-pane
+1783499626.088656 args_parse_flags: next -N
+1783499626.088658 args_parse_flag_argument: -N = Move to the previously active pane
+1783499626.088663 args_parse_flags: next ;
+1783499626.088664 args_parse: flags end at 3 of 5
+1783499626.088665 args_parse: 3 = ; (type STRING)
+1783499626.088667 args_parse: 4 = last-pane (type COMMANDS)
+1783499626.088673 cmd_parse_build_commands: bind-key -N "Move to the previously active pane" \\; { last-pane }
+1783499626.088675 cmdq_get_command: [bind-key/0x58e4724c33e0] group 246
+1783499626.088678 cmdq_append <global>: [bind-key/0x58e4724c33e0]
+1783499626.088685 yylex_token: end at WS
+1783499626.088689 yylex_token: bind
+1783499626.088690 yylex_token: end at WS
+1783499626.088691 yylex_token: -N
+1783499626.088693 yylex_token: end at WS
+1783499626.088694 yylex_token: Choose a paste buffer from a list
+1783499626.088696 yylex_token: end at WS
+1783499626.088697 yylex_token: =
+1783499626.088698 yylex_token: end at WS
+1783499626.088699 yylex_token: choose-buffer
+1783499626.088701 yylex_token: end at WS
+1783499626.088702 yylex_token: -Z
+1783499626.088704 cmd_parse_build_commands 0:0: bind
+1783499626.088706 cmd_parse_build_commands 0:1: -N
+1783499626.088707 cmd_parse_build_commands 0:2: Choose a paste buffer from a list
+1783499626.088709 cmd_parse_build_commands 0:3: =
+1783499626.088710 cmd_parse_build_commands 0:4 0:0: choose-buffer
+1783499626.088711 cmd_parse_build_commands 0:4 0:1: -Z
+1783499626.088714 cmd_parse_build_commands 0:0: choose-buffer
+1783499626.088715 cmd_parse_build_commands 0:1: -Z
+1783499626.088717 args_parse_flags: next -Z
+1783499626.088718 args_parse_flags: -Z
+1783499626.088719 args_parse: flags end at 2 of 2
+1783499626.088722 cmd_parse_build_commands: choose-buffer -Z
+1783499626.088723 args_parse_flags: next -N
+1783499626.088725 args_parse_flag_argument: -N = Choose a paste buffer from a list
+1783499626.088726 args_parse_flags: next =
+1783499626.088727 args_parse: flags end at 3 of 5
+1783499626.088729 args_parse: 3 = = (type STRING)
+1783499626.088731 args_parse: 4 = choose-buffer -Z (type COMMANDS)
+1783499626.088736 cmd_parse_build_commands: bind-key -N "Choose a paste buffer from a list" = { choose-buffer -Z }
+1783499626.088739 cmdq_get_command: [bind-key/0x58e4724c3610] group 254
+1783499626.088741 cmdq_append <global>: [bind-key/0x58e4724c3610]
+1783499626.088742 yylex_token: end at WS
+1783499626.088743 yylex_token: bind
+1783499626.088744 yylex_token: end at WS
+1783499626.088746 yylex_token: -N
+1783499626.088747 yylex_token: end at WS
+1783499626.088748 yylex_token: List key bindings
+1783499626.088749 yylex_token: end at WS
+1783499626.088751 yylex_token: ?
+1783499626.088752 yylex_token: end at WS
+1783499626.088753 yylex_token: list-keys
+1783499626.088754 yylex_token: end at WS
+1783499626.088755 yylex_token: -N
+1783499626.088786 cmd_parse_build_commands 0:0: bind
+1783499626.088792 cmd_parse_build_commands 0:1: -N
+1783499626.088795 cmd_parse_build_commands 0:2: List key bindings
+1783499626.088797 cmd_parse_build_commands 0:3: ?
+1783499626.088799 cmd_parse_build_commands 0:4 0:0: list-keys
+1783499626.088800 cmd_parse_build_commands 0:4 0:1: -N
+1783499626.088803 cmd_parse_build_commands 0:0: list-keys
+1783499626.088805 cmd_parse_build_commands 0:1: -N
+1783499626.088808 args_parse_flags: next -N
+1783499626.088809 args_parse_flags: -N
+1783499626.088811 args_parse: flags end at 2 of 2
+1783499626.088814 cmd_parse_build_commands: list-keys -N
+1783499626.088816 args_parse_flags: next -N
+1783499626.088818 args_parse_flag_argument: -N = List key bindings
+1783499626.088819 args_parse_flags: next ?
+1783499626.088821 args_parse: flags end at 3 of 5
+1783499626.088822 args_parse: 3 = ? (type STRING)
+1783499626.088825 args_parse: 4 = list-keys -N (type COMMANDS)
+1783499626.088830 cmd_parse_build_commands: bind-key -N "List key bindings" ? { list-keys -N }
+1783499626.088833 cmdq_get_command: [bind-key/0x58e4724c3e00] group 262
+1783499626.088835 cmdq_append <global>: [bind-key/0x58e4724c3e00]
+1783499626.088837 yylex_token: end at WS
+1783499626.088838 yylex_token: bind
+1783499626.088840 yylex_token: end at WS
+1783499626.088841 yylex_token: -N
+1783499626.088843 yylex_token: end at WS
+1783499626.088845 yylex_token: Choose and detach a client from a list
+1783499626.088852 yylex_token: end at WS
+1783499626.088854 yylex_token: D
+1783499626.088855 yylex_token: end at WS
+1783499626.088857 yylex_token: choose-client
+1783499626.088858 yylex_token: end at WS
+1783499626.088859 yylex_token: -Z
+1783499626.088862 cmd_parse_build_commands 0:0: bind
+1783499626.088863 cmd_parse_build_commands 0:1: -N
+1783499626.088865 cmd_parse_build_commands 0:2: Choose and detach a client from a list
+1783499626.088866 cmd_parse_build_commands 0:3: D
+1783499626.088868 cmd_parse_build_commands 0:4 0:0: choose-client
+1783499626.088869 cmd_parse_build_commands 0:4 0:1: -Z
+1783499626.088871 cmd_parse_build_commands 0:0: choose-client
+1783499626.088873 cmd_parse_build_commands 0:1: -Z
+1783499626.088875 args_parse_flags: next -Z
+1783499626.088876 args_parse_flags: -Z
+1783499626.088877 args_parse: flags end at 2 of 2
+1783499626.088879 cmd_parse_build_commands: choose-client -Z
+1783499626.088881 args_parse_flags: next -N
+1783499626.088882 args_parse_flag_argument: -N = Choose and detach a client from a list
+1783499626.088884 args_parse_flags: next D
+1783499626.088885 args_parse: flags end at 3 of 5
+1783499626.088886 args_parse: 3 = D (type STRING)
+1783499626.088888 args_parse: 4 = choose-client -Z (type COMMANDS)
+1783499626.088894 cmd_parse_build_commands: bind-key -N "Choose and detach a client from a list" D { choose-client -Z }
+1783499626.088896 cmdq_get_command: [bind-key/0x58e4724c4830] group 270
+1783499626.088897 cmdq_append <global>: [bind-key/0x58e4724c4830]
+1783499626.088907 yylex_token: end at WS
+1783499626.088911 yylex_token: bind
+1783499626.088913 yylex_token: end at WS
+1783499626.088917 yylex_token: -N
+1783499626.088923 yylex_token: end at WS
+1783499626.088924 yylex_token: Spread panes out evenly
+1783499626.088925 yylex_token: end at WS
+1783499626.088927 yylex_token: E
+1783499626.088928 yylex_token: end at WS
+1783499626.088929 yylex_token: select-layout
+1783499626.088930 yylex_token: end at WS
+1783499626.088931 yylex_token: -E
+1783499626.088934 cmd_parse_build_commands 0:0: bind
+1783499626.088936 cmd_parse_build_commands 0:1: -N
+1783499626.088937 cmd_parse_build_commands 0:2: Spread panes out evenly
+1783499626.088938 cmd_parse_build_commands 0:3: E
+1783499626.088940 cmd_parse_build_commands 0:4 0:0: select-layout
+1783499626.088941 cmd_parse_build_commands 0:4 0:1: -E
+1783499626.088943 cmd_parse_build_commands 0:0: select-layout
+1783499626.088945 cmd_parse_build_commands 0:1: -E
+1783499626.088948 args_parse_flags: next -E
+1783499626.088949 args_parse_flags: -E
+1783499626.088950 args_parse: flags end at 2 of 2
+1783499626.088953 cmd_parse_build_commands: select-layout -E
+1783499626.088954 args_parse_flags: next -N
+1783499626.088955 args_parse_flag_argument: -N = Spread panes out evenly
+1783499626.088957 args_parse_flags: next E
+1783499626.088958 args_parse: flags end at 3 of 5
+1783499626.088959 args_parse: 3 = E (type STRING)
+1783499626.088962 args_parse: 4 = select-layout -E (type COMMANDS)
+1783499626.088967 cmd_parse_build_commands: bind-key -N "Spread panes out evenly" E { select-layout -E }
+1783499626.088969 cmdq_get_command: [bind-key/0x58e4724c4930] group 278
+1783499626.088971 cmdq_append <global>: [bind-key/0x58e4724c4930]
+1783499626.089045 yylex_token: end at WS
+1783499626.089053 yylex_token: bind
+1783499626.089056 yylex_token: end at WS
+1783499626.089057 yylex_token: -N
+1783499626.089060 yylex_token: end at WS
+1783499626.089062 yylex_token: Switch to the last client
+1783499626.089063 yylex_token: end at WS
+1783499626.089065 yylex_token: L
+1783499626.089066 yylex_token: end at WS
+1783499626.089068 yylex_token: switch-client
+1783499626.089069 yylex_token: end at WS
+1783499626.089070 yylex_token: -l
+1783499626.089074 cmd_parse_build_commands 0:0: bind
+1783499626.089076 cmd_parse_build_commands 0:1: -N
+1783499626.089077 cmd_parse_build_commands 0:2: Switch to the last client
+1783499626.089079 cmd_parse_build_commands 0:3: L
+1783499626.089081 cmd_parse_build_commands 0:4 0:0: switch-client
+1783499626.089082 cmd_parse_build_commands 0:4 0:1: -l
+1783499626.089086 cmd_parse_build_commands 0:0: switch-client
+1783499626.089093 cmd_parse_build_commands 0:1: -l
+1783499626.089098 args_parse_flags: next -l
+1783499626.089100 args_parse_flags: -l
+1783499626.089102 args_parse: flags end at 2 of 2
+1783499626.089105 cmd_parse_build_commands: switch-client -l
+1783499626.089106 args_parse_flags: next -N
+1783499626.089108 args_parse_flag_argument: -N = Switch to the last client
+1783499626.089110 args_parse_flags: next L
+1783499626.089111 args_parse: flags end at 3 of 5
+1783499626.089112 args_parse: 3 = L (type STRING)
+1783499626.089115 args_parse: 4 = switch-client -l (type COMMANDS)
+1783499626.089121 cmd_parse_build_commands: bind-key -N "Switch to the last client" L { switch-client -l }
+1783499626.089124 cmdq_get_command: [bind-key/0x58e4724c4f40] group 286
+1783499626.089126 cmdq_append <global>: [bind-key/0x58e4724c4f40]
+1783499626.089128 yylex_token: end at WS
+1783499626.089129 yylex_token: bind
+1783499626.089131 yylex_token: end at WS
+1783499626.089132 yylex_token: -N
+1783499626.089134 yylex_token: end at WS
+1783499626.089135 yylex_token: Clear the marked pane
+1783499626.089137 yylex_token: end at WS
+1783499626.089138 yylex_token: M
+1783499626.089139 yylex_token: end at WS
+1783499626.089141 yylex_token: select-pane
+1783499626.089142 yylex_token: end at WS
+1783499626.089143 yylex_token: -M
+1783499626.089146 cmd_parse_build_commands 0:0: bind
+1783499626.089147 cmd_parse_build_commands 0:1: -N
+1783499626.089149 cmd_parse_build_commands 0:2: Clear the marked pane
+1783499626.089150 cmd_parse_build_commands 0:3: M
+1783499626.089152 cmd_parse_build_commands 0:4 0:0: select-pane
+1783499626.089153 cmd_parse_build_commands 0:4 0:1: -M
+1783499626.089156 cmd_parse_build_commands 0:0: select-pane
+1783499626.089157 cmd_parse_build_commands 0:1: -M
+1783499626.089161 args_parse_flags: next -M
+1783499626.089162 args_parse_flags: -M
+1783499626.089163 args_parse: flags end at 2 of 2
+1783499626.089166 cmd_parse_build_commands: select-pane -M
+1783499626.089167 args_parse_flags: next -N
+1783499626.089169 args_parse_flag_argument: -N = Clear the marked pane
+1783499626.089171 args_parse_flags: next M
+1783499626.089172 args_parse: flags end at 3 of 5
+1783499626.089173 args_parse: 3 = M (type STRING)
+1783499626.089176 args_parse: 4 = select-pane -M (type COMMANDS)
+1783499626.089181 cmd_parse_build_commands: bind-key -N "Clear the marked pane" M { select-pane -M }
+1783499626.089202 cmdq_get_command: [bind-key/0x58e4724c51c0] group 294
+1783499626.089205 cmdq_append <global>: [bind-key/0x58e4724c51c0]
+1783499626.089215 yylex_token: end at WS
+1783499626.089218 yylex_token: bind
+1783499626.089220 yylex_token: end at WS
+1783499626.089221 yylex_token: -N
+1783499626.089223 yylex_token: end at WS
+1783499626.089224 yylex_token: Enter copy mode
+1783499626.089225 yylex_token: end at WS
+1783499626.089227 yylex_token: [
+1783499626.089228 yylex_token: end at WS
+1783499626.089229 yylex_token: copy-mode
+1783499626.089232 cmd_parse_build_commands 0:0: bind
+1783499626.089234 cmd_parse_build_commands 0:1: -N
+1783499626.089235 cmd_parse_build_commands 0:2: Enter copy mode
+1783499626.089237 cmd_parse_build_commands 0:3: [
+1783499626.089238 cmd_parse_build_commands 0:4 0:0: copy-mode
+1783499626.089241 cmd_parse_build_commands 0:0: copy-mode
+1783499626.089243 args_parse: flags end at 1 of 1
+1783499626.089245 cmd_parse_build_commands: copy-mode
+1783499626.089258 args_parse_flags: next -N
+1783499626.089261 args_parse_flag_argument: -N = Enter copy mode
+1783499626.089262 args_parse_flags: next [
+1783499626.089264 args_parse: flags end at 3 of 5
+1783499626.089265 args_parse: 3 = [ (type STRING)
+1783499626.089267 args_parse: 4 = copy-mode (type COMMANDS)
+1783499626.089273 cmd_parse_build_commands: bind-key -N "Enter copy mode" [ { copy-mode }
+1783499626.089276 cmdq_get_command: [bind-key/0x58e4724c57f0] group 302
+1783499626.089278 cmdq_append <global>: [bind-key/0x58e4724c57f0]
+1783499626.089280 yylex_token: end at WS
+1783499626.089281 yylex_token: bind
+1783499626.089282 yylex_token: end at WS
+1783499626.089283 yylex_token: -N
+1783499626.089285 yylex_token: end at WS
+1783499626.089291 yylex_token: Paste the most recent paste buffer
+1783499626.089293 yylex_token: end at WS
+1783499626.089294 yylex_token: ]
+1783499626.089296 yylex_token: end at WS
+1783499626.089297 yylex_token: paste-buffer
+1783499626.089298 yylex_token: end at WS
+1783499626.089299 yylex_token: -p
+1783499626.089301 cmd_parse_build_commands 0:0: bind
+1783499626.089303 cmd_parse_build_commands 0:1: -N
+1783499626.089304 cmd_parse_build_commands 0:2: Paste the most recent paste buffer
+1783499626.089306 cmd_parse_build_commands 0:3: ]
+1783499626.089307 cmd_parse_build_commands 0:4 0:0: paste-buffer
+1783499626.089309 cmd_parse_build_commands 0:4 0:1: -p
+1783499626.089311 cmd_parse_build_commands 0:0: paste-buffer
+1783499626.089313 cmd_parse_build_commands 0:1: -p
+1783499626.089316 args_parse_flags: next -p
+1783499626.089317 args_parse_flags: -p
+1783499626.089318 args_parse: flags end at 2 of 2
+1783499626.089320 cmd_parse_build_commands: paste-buffer -p
+1783499626.089322 args_parse_flags: next -N
+1783499626.089323 args_parse_flag_argument: -N = Paste the most recent paste buffer
+1783499626.089324 args_parse_flags: next ]
+1783499626.089326 args_parse: flags end at 3 of 5
+1783499626.089327 args_parse: 3 = ] (type STRING)
+1783499626.089329 args_parse: 4 = paste-buffer -p (type COMMANDS)
+1783499626.089334 cmd_parse_build_commands: bind-key -N "Paste the most recent paste buffer" ] { paste-buffer -p }
+1783499626.089336 cmdq_get_command: [bind-key/0x58e4724c6180] group 310
+1783499626.089338 cmdq_append <global>: [bind-key/0x58e4724c6180]
+1783499626.089341 yylex_token: end at WS
+1783499626.089342 yylex_token: bind
+1783499626.089343 yylex_token: end at WS
+1783499626.089344 yylex_token: -N
+1783499626.089346 yylex_token: end at WS
+1783499626.089347 yylex_token: Create a new window
+1783499626.089348 yylex_token: end at WS
+1783499626.089349 yylex_token: c
+1783499626.089351 yylex_token: end at WS
+1783499626.089352 yylex_token: new-window
+1783499626.089354 cmd_parse_build_commands 0:0: bind
+1783499626.089355 cmd_parse_build_commands 0:1: -N
+1783499626.089357 cmd_parse_build_commands 0:2: Create a new window
+1783499626.089358 cmd_parse_build_commands 0:3: c
+1783499626.089360 cmd_parse_build_commands 0:4 0:0: new-window
+1783499626.089362 cmd_parse_build_commands 0:0: new-window
+1783499626.089365 args_parse: flags end at 1 of 1
+1783499626.089367 cmd_parse_build_commands: new-window
+1783499626.089369 args_parse_flags: next -N
+1783499626.089371 args_parse_flag_argument: -N = Create a new window
+1783499626.089372 args_parse_flags: next c
+1783499626.089373 args_parse: flags end at 3 of 5
+1783499626.089374 args_parse: 3 = c (type STRING)
+1783499626.089376 args_parse: 4 = new-window (type COMMANDS)
+1783499626.089380 cmd_parse_build_commands: bind-key -N "Create a new window" c { new-window }
+1783499626.089383 cmdq_get_command: [bind-key/0x58e4724c6580] group 318
+1783499626.089385 cmdq_append <global>: [bind-key/0x58e4724c6580]
+1783499626.089393 yylex_token: end at WS
+1783499626.089398 yylex_token: bind
+1783499626.089399 yylex_token: end at WS
+1783499626.089400 yylex_token: -N
+1783499626.089402 yylex_token: end at WS
+1783499626.089404 yylex_token: Detach the current client
+1783499626.089405 yylex_token: end at WS
+1783499626.089406 yylex_token: d
+1783499626.089408 yylex_token: end at WS
+1783499626.089409 yylex_token: detach-client
+1783499626.089411 cmd_parse_build_commands 0:0: bind
+1783499626.089412 cmd_parse_build_commands 0:1: -N
+1783499626.089414 cmd_parse_build_commands 0:2: Detach the current client
+1783499626.089415 cmd_parse_build_commands 0:3: d
+1783499626.089417 cmd_parse_build_commands 0:4 0:0: detach-client
+1783499626.089419 cmd_parse_build_commands 0:0: detach-client
+1783499626.089422 args_parse: flags end at 1 of 1
+1783499626.089424 cmd_parse_build_commands: detach-client
+1783499626.089425 args_parse_flags: next -N
+1783499626.089427 args_parse_flag_argument: -N = Detach the current client
+1783499626.089428 args_parse_flags: next d
+1783499626.089429 args_parse: flags end at 3 of 5
+1783499626.089431 args_parse: 3 = d (type STRING)
+1783499626.089436 args_parse: 4 = detach-client (type COMMANDS)
+1783499626.089441 cmd_parse_build_commands: bind-key -N "Detach the current client" d { detach-client }
+1783499626.089444 cmdq_get_command: [bind-key/0x58e4724c6930] group 326
+1783499626.089446 cmdq_append <global>: [bind-key/0x58e4724c6930]
+1783499626.089448 yylex_token: end at WS
+1783499626.089449 yylex_token: bind
+1783499626.089450 yylex_token: end at WS
+1783499626.089451 yylex_token: -N
+1783499626.089453 yylex_token: end at WS
+1783499626.089454 yylex_token: Search for a pane
+1783499626.089456 yylex_token: end at WS
+1783499626.089457 yylex_token: f
+1783499626.089458 yylex_token: end at WS
+1783499626.089459 yylex_token: command-prompt
+1783499626.089461 yylex_token: end at WS
+1783499626.089462 yylex_token: find-window
+1783499626.089463 yylex_token: end at WS
+1783499626.089464 yylex_token: -Z
+1783499626.089466 yylex_token: end at WS
+1783499626.089467 yylex_token: --
+1783499626.089468 yylex_token: end at WS
+1783499626.089469 yylex_token: %%
+1783499626.089472 cmd_parse_build_commands 0:0: bind
+1783499626.089473 cmd_parse_build_commands 0:1: -N
+1783499626.089474 cmd_parse_build_commands 0:2: Search for a pane
+1783499626.089476 cmd_parse_build_commands 0:3: f
+1783499626.089477 cmd_parse_build_commands 0:4 0:0: command-prompt
+1783499626.089479 cmd_parse_build_commands 0:4 0:1 0:0: find-window
+1783499626.089481 cmd_parse_build_commands 0:4 0:1 0:1: -Z
+1783499626.089482 cmd_parse_build_commands 0:4 0:1 0:2: --
+1783499626.089483 cmd_parse_build_commands 0:4 0:1 0:3: %%
+1783499626.089485 cmd_parse_build_commands 0:0: command-prompt
+1783499626.089487 cmd_parse_build_commands 0:1 0:0: find-window
+1783499626.089488 cmd_parse_build_commands 0:1 0:1: -Z
+1783499626.089489 cmd_parse_build_commands 0:1 0:2: --
+1783499626.089491 cmd_parse_build_commands 0:1 0:3: %%
+1783499626.089492 cmd_parse_build_commands 0:0: find-window
+1783499626.089494 cmd_parse_build_commands 0:1: -Z
+1783499626.089495 cmd_parse_build_commands 0:2: --
+1783499626.089496 cmd_parse_build_commands 0:3: %%
+1783499626.089499 args_parse_flags: next -Z
+1783499626.089500 args_parse_flags: -Z
+1783499626.089501 args_parse_flags: next --
+1783499626.089503 args_parse: flags end at 3 of 4
+1783499626.089504 args_parse: 3 = %% (type STRING)
+1783499626.089507 cmd_parse_build_commands: find-window -Z "%%"
+1783499626.089508 args_parse: flags end at 1 of 2
+1783499626.089511 args_parse: 1 = find-window -Z "%%" (type COMMANDS)
+1783499626.089515 cmd_parse_build_commands: command-prompt { find-window -Z "%%" }
+1783499626.089516 args_parse_flags: next -N
+1783499626.089517 args_parse_flag_argument: -N = Search for a pane
+1783499626.089519 args_parse_flags: next f
+1783499626.089520 args_parse: flags end at 3 of 5
+1783499626.089521 args_parse: 3 = f (type STRING)
+1783499626.089524 args_parse: 4 = command-prompt { find-window -Z "%%" } (type COMMANDS)
+1783499626.089529 cmd_parse_build_commands: bind-key -N "Search for a pane" f { command-prompt { find-window -Z "%%" } }
+1783499626.089532 cmdq_get_command: [bind-key/0x58e4724c78f0] group 334
+1783499626.089533 cmdq_append <global>: [bind-key/0x58e4724c78f0]
+1783499626.089543 yylex_token: end at WS
+1783499626.089546 yylex_token: bind
+1783499626.089548 yylex_token: end at WS
+1783499626.089549 yylex_token: -N
+1783499626.089551 yylex_token: end at WS
+1783499626.089552 yylex_token: Display window information
+1783499626.089554 yylex_token: end at WS
+1783499626.089555 yylex_token: i
+1783499626.089556 yylex_token: end at WS
+1783499626.089557 yylex_token: display-message
+1783499626.089560 cmd_parse_build_commands 0:0: bind
+1783499626.089561 cmd_parse_build_commands 0:1: -N
+1783499626.089562 cmd_parse_build_commands 0:2: Display window information
+1783499626.089564 cmd_parse_build_commands 0:3: i
+1783499626.089565 cmd_parse_build_commands 0:4 0:0: display-message
+1783499626.089568 cmd_parse_build_commands 0:0: display-message
+1783499626.089570 args_parse: flags end at 1 of 1
+1783499626.089572 cmd_parse_build_commands: display-message
+1783499626.089573 args_parse_flags: next -N
+1783499626.089575 args_parse_flag_argument: -N = Display window information
+1783499626.089579 args_parse_flags: next i
+1783499626.089581 args_parse: flags end at 3 of 5
+1783499626.089582 args_parse: 3 = i (type STRING)
+1783499626.089584 args_parse: 4 = display-message (type COMMANDS)
+1783499626.089589 cmd_parse_build_commands: bind-key -N "Display window information" i { display-message }
+1783499626.089591 cmdq_get_command: [bind-key/0x58e4724c6cb0] group 346
+1783499626.089592 cmdq_append <global>: [bind-key/0x58e4724c6cb0]
+1783499626.089595 yylex_token: end at WS
+1783499626.089596 yylex_token: bind
+1783499626.089598 yylex_token: end at WS
+1783499626.089599 yylex_token: -N
+1783499626.089601 yylex_token: end at WS
+1783499626.089602 yylex_token: Select the previously current window
+1783499626.089604 yylex_token: end at WS
+1783499626.089605 yylex_token: l
+1783499626.089606 yylex_token: end at WS
+1783499626.089607 yylex_token: last-window
+1783499626.089609 cmd_parse_build_commands 0:0: bind
+1783499626.089611 cmd_parse_build_commands 0:1: -N
+1783499626.089612 cmd_parse_build_commands 0:2: Select the previously current window
+1783499626.089613 cmd_parse_build_commands 0:3: l
+1783499626.089615 cmd_parse_build_commands 0:4 0:0: last-window
+1783499626.089617 cmd_parse_build_commands 0:0: last-window
+1783499626.089619 args_parse: flags end at 1 of 1
+1783499626.089621 cmd_parse_build_commands: last-window
+1783499626.089622 args_parse_flags: next -N
+1783499626.089624 args_parse_flag_argument: -N = Select the previously current window
+1783499626.089625 args_parse_flags: next l
+1783499626.089627 args_parse: flags end at 3 of 5
+1783499626.089628 args_parse: 3 = l (type STRING)
+1783499626.089630 args_parse: 4 = last-window (type COMMANDS)
+1783499626.089634 cmd_parse_build_commands: bind-key -N "Select the previously current window" l { last-window }
+1783499626.089637 cmdq_get_command: [bind-key/0x58e4724c7e40] group 354
+1783499626.089638 cmdq_append <global>: [bind-key/0x58e4724c7e40]
+1783499626.089640 yylex_token: end at WS
+1783499626.089641 yylex_token: bind
+1783499626.089643 yylex_token: end at WS
+1783499626.089644 yylex_token: -N
+1783499626.089645 yylex_token: end at WS
+1783499626.089647 yylex_token: Toggle the marked pane
+1783499626.089648 yylex_token: end at WS
+1783499626.089649 yylex_token: m
+1783499626.089650 yylex_token: end at WS
+1783499626.089652 yylex_token: select-pane
+1783499626.089653 yylex_token: end at WS
+1783499626.089654 yylex_token: -m
+1783499626.089656 cmd_parse_build_commands 0:0: bind
+1783499626.089657 cmd_parse_build_commands 0:1: -N
+1783499626.089658 cmd_parse_build_commands 0:2: Toggle the marked pane
+1783499626.089660 cmd_parse_build_commands 0:3: m
+1783499626.089661 cmd_parse_build_commands 0:4 0:0: select-pane
+1783499626.089663 cmd_parse_build_commands 0:4 0:1: -m
+1783499626.089665 cmd_parse_build_commands 0:0: select-pane
+1783499626.089666 cmd_parse_build_commands 0:1: -m
+1783499626.089669 args_parse_flags: next -m
+1783499626.089670 args_parse_flags: -m
+1783499626.089672 args_parse: flags end at 2 of 2
+1783499626.089674 cmd_parse_build_commands: select-pane -m
+1783499626.089675 args_parse_flags: next -N
+1783499626.089676 args_parse_flag_argument: -N = Toggle the marked pane
+1783499626.089678 args_parse_flags: next m
+1783499626.089679 args_parse: flags end at 3 of 5
+1783499626.089680 args_parse: 3 = m (type STRING)
+1783499626.089682 args_parse: 4 = select-pane -m (type COMMANDS)
+1783499626.089686 cmd_parse_build_commands: bind-key -N "Toggle the marked pane" m { select-pane -m }
+1783499626.089689 cmdq_get_command: [bind-key/0x58e4724c8550] group 362
+1783499626.089690 cmdq_append <global>: [bind-key/0x58e4724c8550]
+1783499626.089700 yylex_token: end at WS
+1783499626.089703 yylex_token: bind
+1783499626.089705 yylex_token: end at WS
+1783499626.089706 yylex_token: -N
+1783499626.089708 yylex_token: end at WS
+1783499626.089709 yylex_token: Select the next window
+1783499626.089711 yylex_token: end at WS
+1783499626.089712 yylex_token: n
+1783499626.089713 yylex_token: end at WS
+1783499626.089714 yylex_token: next-window
+1783499626.089719 cmd_parse_build_commands 0:0: bind
+1783499626.089721 cmd_parse_build_commands 0:1: -N
+1783499626.089722 cmd_parse_build_commands 0:2: Select the next window
+1783499626.089723 cmd_parse_build_commands 0:3: n
+1783499626.089725 cmd_parse_build_commands 0:4 0:0: next-window
+1783499626.089728 cmd_parse_build_commands 0:0: next-window
+1783499626.089731 args_parse: flags end at 1 of 1
+1783499626.089733 cmd_parse_build_commands: next-window
+1783499626.089735 args_parse_flags: next -N
+1783499626.089736 args_parse_flag_argument: -N = Select the next window
+1783499626.089738 args_parse_flags: next n
+1783499626.089739 args_parse: flags end at 3 of 5
+1783499626.089740 args_parse: 3 = n (type STRING)
+1783499626.089742 args_parse: 4 = next-window (type COMMANDS)
+1783499626.089746 cmd_parse_build_commands: bind-key -N "Select the next window" n { next-window }
+1783499626.089749 cmdq_get_command: [bind-key/0x58e4724c8760] group 370
+1783499626.089750 cmdq_append <global>: [bind-key/0x58e4724c8760]
+1783499626.089753 yylex_token: end at WS
+1783499626.089754 yylex_token: bind
+1783499626.089755 yylex_token: end at WS
+1783499626.089756 yylex_token: -N
+1783499626.089758 yylex_token: end at WS
+1783499626.089759 yylex_token: Select the next pane
+1783499626.089760 yylex_token: end at WS
+1783499626.089762 yylex_token: o
+1783499626.089763 yylex_token: end at WS
+1783499626.089764 yylex_token: select-pane
+1783499626.089766 yylex_token: end at WS
+1783499626.089767 yylex_token: -t:.+
+1783499626.089769 cmd_parse_build_commands 0:0: bind
+1783499626.089770 cmd_parse_build_commands 0:1: -N
+1783499626.089771 cmd_parse_build_commands 0:2: Select the next pane
+1783499626.089773 cmd_parse_build_commands 0:3: o
+1783499626.089774 cmd_parse_build_commands 0:4 0:0: select-pane
+1783499626.089775 cmd_parse_build_commands 0:4 0:1: -t:.+
+1783499626.089777 cmd_parse_build_commands 0:0: select-pane
+1783499626.089778 cmd_parse_build_commands 0:1: -t:.+
+1783499626.089782 args_parse_flags: next -t:.+
+1783499626.089783 args_parse_flag_argument: -t = :.+
+1783499626.089784 args_parse: flags end at 2 of 2
+1783499626.089787 cmd_parse_build_commands: select-pane -t :.+
+1783499626.089788 args_parse_flags: next -N
+1783499626.089789 args_parse_flag_argument: -N = Select the next pane
+1783499626.089791 args_parse_flags: next o
+1783499626.089792 args_parse: flags end at 3 of 5
+1783499626.089793 args_parse: 3 = o (type STRING)
+1783499626.089796 args_parse: 4 = select-pane -t :.+ (type COMMANDS)
+1783499626.089801 cmd_parse_build_commands: bind-key -N "Select the next pane" o { select-pane -t :.+ }
+1783499626.089803 cmdq_get_command: [bind-key/0x58e4724c8dc0] group 378
+1783499626.089804 cmdq_append <global>: [bind-key/0x58e4724c8dc0]
+1783499626.089807 yylex_token: end at WS
+1783499626.089808 yylex_token: bind
+1783499626.089809 yylex_token: end at WS
+1783499626.089810 yylex_token: -N
+1783499626.089812 yylex_token: end at WS
+1783499626.089813 yylex_token: Customize options
+1783499626.089814 yylex_token: end at WS
+1783499626.089816 yylex_token: C
+1783499626.089817 yylex_token: end at WS
+1783499626.089818 yylex_token: customize-mode
+1783499626.089819 yylex_token: end at WS
+1783499626.089820 yylex_token: -Z
+1783499626.089822 cmd_parse_build_commands 0:0: bind
+1783499626.089824 cmd_parse_build_commands 0:1: -N
+1783499626.089825 cmd_parse_build_commands 0:2: Customize options
+1783499626.089827 cmd_parse_build_commands 0:3: C
+1783499626.089828 cmd_parse_build_commands 0:4 0:0: customize-mode
+1783499626.089830 cmd_parse_build_commands 0:4 0:1: -Z
+1783499626.089831 cmd_parse_build_commands 0:0: customize-mode
+1783499626.089833 cmd_parse_build_commands 0:1: -Z
+1783499626.089834 args_parse_flags: next -Z
+1783499626.089836 args_parse_flags: -Z
+1783499626.089837 args_parse: flags end at 2 of 2
+1783499626.089839 cmd_parse_build_commands: customize-mode -Z
+1783499626.089840 args_parse_flags: next -N
+1783499626.089842 args_parse_flag_argument: -N = Customize options
+1783499626.089843 args_parse_flags: next C
+1783499626.089844 args_parse: flags end at 3 of 5
+1783499626.089846 args_parse: 3 = C (type STRING)
+1783499626.089851 args_parse: 4 = customize-mode -Z (type COMMANDS)
+1783499626.089855 cmd_parse_build_commands: bind-key -N "Customize options" C { customize-mode -Z }
+1783499626.089858 cmdq_get_command: [bind-key/0x58e4724c92c0] group 386
+1783499626.089859 cmdq_append <global>: [bind-key/0x58e4724c92c0]
+1783499626.089868 yylex_token: end at WS
+1783499626.089871 yylex_token: bind
+1783499626.089873 yylex_token: end at WS
+1783499626.089874 yylex_token: -N
+1783499626.089876 yylex_token: end at WS
+1783499626.089877 yylex_token: Select the previous window
+1783499626.089878 yylex_token: end at WS
+1783499626.089879 yylex_token: p
+1783499626.089881 yylex_token: end at WS
+1783499626.089882 yylex_token: previous-window
+1783499626.089884 cmd_parse_build_commands 0:0: bind
+1783499626.089885 cmd_parse_build_commands 0:1: -N
+1783499626.089887 cmd_parse_build_commands 0:2: Select the previous window
+1783499626.089888 cmd_parse_build_commands 0:3: p
+1783499626.089890 cmd_parse_build_commands 0:4 0:0: previous-window
+1783499626.089892 cmd_parse_build_commands 0:0: previous-window
+1783499626.089895 args_parse: flags end at 1 of 1
+1783499626.089897 cmd_parse_build_commands: previous-window
+1783499626.089898 args_parse_flags: next -N
+1783499626.089900 args_parse_flag_argument: -N = Select the previous window
+1783499626.089901 args_parse_flags: next p
+1783499626.089902 args_parse: flags end at 3 of 5
+1783499626.089903 args_parse: 3 = p (type STRING)
+1783499626.089905 args_parse: 4 = previous-window (type COMMANDS)
+1783499626.089909 cmd_parse_build_commands: bind-key -N "Select the previous window" p { previous-window }
+1783499626.089912 cmdq_get_command: [bind-key/0x58e4724c9740] group 394
+1783499626.089913 cmdq_append <global>: [bind-key/0x58e4724c9740]
+1783499626.089915 yylex_token: end at WS
+1783499626.089917 yylex_token: bind
+1783499626.089918 yylex_token: end at WS
+1783499626.089919 yylex_token: -N
+1783499626.089920 yylex_token: end at WS
+1783499626.089922 yylex_token: Display pane numbers
+1783499626.089923 yylex_token: end at WS
+1783499626.089924 yylex_token: q
+1783499626.089926 yylex_token: end at WS
+1783499626.089927 yylex_token: display-panes
+1783499626.089929 cmd_parse_build_commands 0:0: bind
+1783499626.089930 cmd_parse_build_commands 0:1: -N
+1783499626.089931 cmd_parse_build_commands 0:2: Display pane numbers
+1783499626.089932 cmd_parse_build_commands 0:3: q
+1783499626.089934 cmd_parse_build_commands 0:4 0:0: display-panes
+1783499626.089936 cmd_parse_build_commands 0:0: display-panes
+1783499626.089938 args_parse: flags end at 1 of 1
+1783499626.089940 cmd_parse_build_commands: display-panes
+1783499626.089941 args_parse_flags: next -N
+1783499626.089942 args_parse_flag_argument: -N = Display pane numbers
+1783499626.089944 args_parse_flags: next q
+1783499626.089945 args_parse: flags end at 3 of 5
+1783499626.089946 args_parse: 3 = q (type STRING)
+1783499626.089947 args_parse: 4 = display-panes (type COMMANDS)
+1783499626.089951 cmd_parse_build_commands: bind-key -N "Display pane numbers" q { display-panes }
+1783499626.089953 cmdq_get_command: [bind-key/0x58e4724c9c20] group 402
+1783499626.089955 cmdq_append <global>: [bind-key/0x58e4724c9c20]
+1783499626.089957 yylex_token: end at WS
+1783499626.089958 yylex_token: bind
+1783499626.089960 yylex_token: end at WS
+1783499626.089961 yylex_token: -N
+1783499626.089963 yylex_token: end at WS
+1783499626.089964 yylex_token: Redraw the current client
+1783499626.089965 yylex_token: end at WS
+1783499626.089966 yylex_token: r
+1783499626.089968 yylex_token: end at WS
+1783499626.089969 yylex_token: refresh-client
+1783499626.089971 cmd_parse_build_commands 0:0: bind
+1783499626.089972 cmd_parse_build_commands 0:1: -N
+1783499626.089973 cmd_parse_build_commands 0:2: Redraw the current client
+1783499626.089975 cmd_parse_build_commands 0:3: r
+1783499626.089976 cmd_parse_build_commands 0:4 0:0: refresh-client
+1783499626.089978 cmd_parse_build_commands 0:0: refresh-client
+1783499626.089981 args_parse: flags end at 1 of 1
+1783499626.089983 cmd_parse_build_commands: refresh-client
+1783499626.089984 args_parse_flags: next -N
+1783499626.089989 args_parse_flag_argument: -N = Redraw the current client
+1783499626.089990 args_parse_flags: next r
+1783499626.089991 args_parse: flags end at 3 of 5
+1783499626.089993 args_parse: 3 = r (type STRING)
+1783499626.089994 args_parse: 4 = refresh-client (type COMMANDS)
+1783499626.089998 cmd_parse_build_commands: bind-key -N "Redraw the current client" r { refresh-client }
+1783499626.090000 cmdq_get_command: [bind-key/0x58e4724ca230] group 410
+1783499626.090002 cmdq_append <global>: [bind-key/0x58e4724ca230]
+1783499626.090004 yylex_token: end at WS
+1783499626.090006 yylex_token: bind
+1783499626.090007 yylex_token: end at WS
+1783499626.090008 yylex_token: -N
+1783499626.090010 yylex_token: end at WS
+1783499626.090011 yylex_token: Choose a session from a list
+1783499626.090013 yylex_token: end at WS
+1783499626.090014 yylex_token: s
+1783499626.090015 yylex_token: end at WS
+1783499626.090016 yylex_token: choose-tree
+1783499626.090017 yylex_token: end at WS
+1783499626.090018 yylex_token: -Zs
+1783499626.090020 cmd_parse_build_commands 0:0: bind
+1783499626.090022 cmd_parse_build_commands 0:1: -N
+1783499626.090023 cmd_parse_build_commands 0:2: Choose a session from a list
+1783499626.090024 cmd_parse_build_commands 0:3: s
+1783499626.090026 cmd_parse_build_commands 0:4 0:0: choose-tree
+1783499626.090027 cmd_parse_build_commands 0:4 0:1: -Zs
+1783499626.090029 cmd_parse_build_commands 0:0: choose-tree
+1783499626.090030 cmd_parse_build_commands 0:1: -Zs
+1783499626.090032 args_parse_flags: next -Zs
+1783499626.090033 args_parse_flags: -Z
+1783499626.090035 args_parse_flags: -s
+1783499626.090036 args_parse: flags end at 2 of 2
+1783499626.090038 cmd_parse_build_commands: choose-tree -Zs
+1783499626.090039 args_parse_flags: next -N
+1783499626.090041 args_parse_flag_argument: -N = Choose a session from a list
+1783499626.090042 args_parse_flags: next s
+1783499626.090043 args_parse: flags end at 3 of 5
+1783499626.090044 args_parse: 3 = s (type STRING)
+1783499626.090046 args_parse: 4 = choose-tree -Zs (type COMMANDS)
+1783499626.090051 cmd_parse_build_commands: bind-key -N "Choose a session from a list" s { choose-tree -Zs }
+1783499626.090053 cmdq_get_command: [bind-key/0x58e4724ca8d0] group 418
+1783499626.090054 cmdq_append <global>: [bind-key/0x58e4724ca8d0]
+1783499626.090063 yylex_token: end at WS
+1783499626.090067 yylex_token: bind
+1783499626.090068 yylex_token: end at WS
+1783499626.090070 yylex_token: -N
+1783499626.090071 yylex_token: end at WS
+1783499626.090072 yylex_token: Show a clock
+1783499626.090074 yylex_token: end at WS
+1783499626.090075 yylex_token: t
+1783499626.090076 yylex_token: end at WS
+1783499626.090077 yylex_token: clock-mode
+1783499626.090079 cmd_parse_build_commands 0:0: bind
+1783499626.090080 cmd_parse_build_commands 0:1: -N
+1783499626.090082 cmd_parse_build_commands 0:2: Show a clock
+1783499626.090083 cmd_parse_build_commands 0:3: t
+1783499626.090084 cmd_parse_build_commands 0:4 0:0: clock-mode
+1783499626.090087 cmd_parse_build_commands 0:0: clock-mode
+1783499626.090089 args_parse: flags end at 1 of 1
+1783499626.090091 cmd_parse_build_commands: clock-mode
+1783499626.090092 args_parse_flags: next -N
+1783499626.090093 args_parse_flag_argument: -N = Show a clock
+1783499626.090094 args_parse_flags: next t
+1783499626.090096 args_parse: flags end at 3 of 5
+1783499626.090097 args_parse: 3 = t (type STRING)
+1783499626.090098 args_parse: 4 = clock-mode (type COMMANDS)
+1783499626.090102 cmd_parse_build_commands: bind-key -N "Show a clock" t { clock-mode }
+1783499626.090104 cmdq_get_command: [bind-key/0x58e4724caec0] group 426
+1783499626.090106 cmdq_append <global>: [bind-key/0x58e4724caec0]
+1783499626.090108 yylex_token: end at WS
+1783499626.090109 yylex_token: bind
+1783499626.090111 yylex_token: end at WS
+1783499626.090112 yylex_token: -N
+1783499626.090114 yylex_token: end at WS
+1783499626.090115 yylex_token: Choose a window from a list
+1783499626.090116 yylex_token: end at WS
+1783499626.090117 yylex_token: w
+1783499626.090119 yylex_token: end at WS
+1783499626.090120 yylex_token: choose-tree
+1783499626.090125 yylex_token: end at WS
+1783499626.090126 yylex_token: -Zw
+1783499626.090128 cmd_parse_build_commands 0:0: bind
+1783499626.090129 cmd_parse_build_commands 0:1: -N
+1783499626.090131 cmd_parse_build_commands 0:2: Choose a window from a list
+1783499626.090132 cmd_parse_build_commands 0:3: w
+1783499626.090133 cmd_parse_build_commands 0:4 0:0: choose-tree
+1783499626.090135 cmd_parse_build_commands 0:4 0:1: -Zw
+1783499626.090137 cmd_parse_build_commands 0:0: choose-tree
+1783499626.090138 cmd_parse_build_commands 0:1: -Zw
+1783499626.090140 args_parse_flags: next -Zw
+1783499626.090141 args_parse_flags: -Z
+1783499626.090142 args_parse_flags: -w
+1783499626.090143 args_parse: flags end at 2 of 2
+1783499626.090145 cmd_parse_build_commands: choose-tree -Zw
+1783499626.090147 args_parse_flags: next -N
+1783499626.090148 args_parse_flag_argument: -N = Choose a window from a list
+1783499626.090149 args_parse_flags: next w
+1783499626.090150 args_parse: flags end at 3 of 5
+1783499626.090152 args_parse: 3 = w (type STRING)
+1783499626.090154 args_parse: 4 = choose-tree -Zw (type COMMANDS)
+1783499626.090158 cmd_parse_build_commands: bind-key -N "Choose a window from a list" w { choose-tree -Zw }
+1783499626.090161 cmdq_get_command: [bind-key/0x58e4724cb460] group 434
+1783499626.090162 cmdq_append <global>: [bind-key/0x58e4724cb460]
+1783499626.090170 yylex_token: end at WS
+1783499626.090174 yylex_token: bind
+1783499626.090175 yylex_token: end at WS
+1783499626.090177 yylex_token: -N
+1783499626.090178 yylex_token: end at WS
+1783499626.090180 yylex_token: Kill the active pane
+1783499626.090181 yylex_token: end at WS
+1783499626.090182 yylex_token: x
+1783499626.090183 yylex_token: end at WS
+1783499626.090185 yylex_token: confirm-before
+1783499626.090186 yylex_token: end at WS
+1783499626.090188 yylex_token: -pkill-pane #P? (y/n)
+1783499626.090189 yylex_token: end at WS
+1783499626.090190 yylex_token: kill-pane
+1783499626.090192 cmd_parse_build_commands 0:0: bind
+1783499626.090194 cmd_parse_build_commands 0:1: -N
+1783499626.090195 cmd_parse_build_commands 0:2: Kill the active pane
+1783499626.090197 cmd_parse_build_commands 0:3: x
+1783499626.090198 cmd_parse_build_commands 0:4 0:0: confirm-before
+1783499626.090200 cmd_parse_build_commands 0:4 0:1: -pkill-pane #P? (y/n)
+1783499626.090201 cmd_parse_build_commands 0:4 0:2: kill-pane
+1783499626.090203 cmd_parse_build_commands 0:0: confirm-before
+1783499626.090204 cmd_parse_build_commands 0:1: -pkill-pane #P? (y/n)
+1783499626.090206 cmd_parse_build_commands 0:2: kill-pane
+1783499626.090208 args_parse_flags: next -pkill-pane #P? (y/n)
+1783499626.090210 args_parse_flag_argument: -p = kill-pane #P? (y/n)
+1783499626.090211 args_parse_flags: next kill-pane
+1783499626.090213 args_parse: flags end at 2 of 3
+1783499626.090214 args_parse: 2 = kill-pane (type STRING)
+1783499626.090218 cmd_parse_build_commands: confirm-before -p "kill-pane #P? (y/n)" kill-pane
+1783499626.090220 args_parse_flags: next -N
+1783499626.090221 args_parse_flag_argument: -N = Kill the active pane
+1783499626.090222 args_parse_flags: next x
+1783499626.090224 args_parse: flags end at 3 of 5
+1783499626.090225 args_parse: 3 = x (type STRING)
+1783499626.090228 args_parse: 4 = confirm-before -p "kill-pane #P? (y/n)" kill-pane (type COMMANDS)
+1783499626.090234 cmd_parse_build_commands: bind-key -N "Kill the active pane" x { confirm-before -p "kill-pane #P? (y/n)" kill-pane }
+1783499626.090253 cmdq_get_command: [bind-key/0x58e4724cbf70] group 442
+1783499626.090261 cmdq_append <global>: [bind-key/0x58e4724cbf70]
+1783499626.090267 yylex_token: end at WS
+1783499626.090269 yylex_token: bind
+1783499626.090270 yylex_token: end at WS
+1783499626.090272 yylex_token: -N
+1783499626.090274 yylex_token: end at WS
+1783499626.090276 yylex_token: Zoom the active pane
+1783499626.090277 yylex_token: end at WS
+1783499626.090278 yylex_token: z
+1783499626.090280 yylex_token: end at WS
+1783499626.090281 yylex_token: resize-pane
+1783499626.090283 yylex_token: end at WS
+1783499626.090284 yylex_token: -Z
+1783499626.090287 cmd_parse_build_commands 0:0: bind
+1783499626.090295 cmd_parse_build_commands 0:1: -N
+1783499626.090297 cmd_parse_build_commands 0:2: Zoom the active pane
+1783499626.090298 cmd_parse_build_commands 0:3: z
+1783499626.090300 cmd_parse_build_commands 0:4 0:0: resize-pane
+1783499626.090302 cmd_parse_build_commands 0:4 0:1: -Z
+1783499626.090305 cmd_parse_build_commands 0:0: resize-pane
+1783499626.090306 cmd_parse_build_commands 0:1: -Z
+1783499626.090310 args_parse_flags: next -Z
+1783499626.090311 args_parse_flags: -Z
+1783499626.090313 args_parse: flags end at 2 of 2
+1783499626.090316 cmd_parse_build_commands: resize-pane -Z
+1783499626.090318 args_parse_flags: next -N
+1783499626.090320 args_parse_flag_argument: -N = Zoom the active pane
+1783499626.090321 args_parse_flags: next z
+1783499626.090322 args_parse: flags end at 3 of 5
+1783499626.090324 args_parse: 3 = z (type STRING)
+1783499626.090326 args_parse: 4 = resize-pane -Z (type COMMANDS)
+1783499626.090332 cmd_parse_build_commands: bind-key -N "Zoom the active pane" z { resize-pane -Z }
+1783499626.090335 cmdq_get_command: [bind-key/0x58e4724cc3d0] group 450
+1783499626.090337 cmdq_append <global>: [bind-key/0x58e4724cc3d0]
+1783499626.090347 yylex_token: end at WS
+1783499626.090351 yylex_token: bind
+1783499626.090353 yylex_token: end at WS
+1783499626.090354 yylex_token: -N
+1783499626.090356 yylex_token: end at WS
+1783499626.090358 yylex_token: Swap the active pane with the pane above
+1783499626.090360 yylex_token: end at WS
+1783499626.090361 yylex_token: {
+1783499626.090362 yylex_token: end at WS
+1783499626.090364 yylex_token: swap-pane
+1783499626.090365 yylex_token: end at WS
+1783499626.090366 yylex_token: -U
+1783499626.090369 cmd_parse_build_commands 0:0: bind
+1783499626.090370 cmd_parse_build_commands 0:1: -N
+1783499626.090372 cmd_parse_build_commands 0:2: Swap the active pane with the pane above
+1783499626.090373 cmd_parse_build_commands 0:3: {
+1783499626.090375 cmd_parse_build_commands 0:4 0:0: swap-pane
+1783499626.090376 cmd_parse_build_commands 0:4 0:1: -U
+1783499626.090379 cmd_parse_build_commands 0:0: swap-pane
+1783499626.090380 cmd_parse_build_commands 0:1: -U
+1783499626.090384 args_parse_flags: next -U
+1783499626.090386 args_parse_flags: -U
+1783499626.090387 args_parse: flags end at 2 of 2
+1783499626.090390 cmd_parse_build_commands: swap-pane -U
+1783499626.090391 args_parse_flags: next -N
+1783499626.090393 args_parse_flag_argument: -N = Swap the active pane with the pane above
+1783499626.090394 args_parse_flags: next {
+1783499626.090396 args_parse: flags end at 3 of 5
+1783499626.090397 args_parse: 3 = { (type STRING)
+1783499626.090399 args_parse: 4 = swap-pane -U (type COMMANDS)
+1783499626.090405 cmd_parse_build_commands: bind-key -N "Swap the active pane with the pane above" \\{ { swap-pane -U }
+1783499626.090408 cmdq_get_command: [bind-key/0x58e4724cc950] group 458
+1783499626.090410 cmdq_append <global>: [bind-key/0x58e4724cc950]
+1783499626.090413 yylex_token: end at WS
+1783499626.090414 yylex_token: bind
+1783499626.090416 yylex_token: end at WS
+1783499626.090417 yylex_token: -N
+1783499626.090419 yylex_token: end at WS
+1783499626.090421 yylex_token: Swap the active pane with the pane below
+1783499626.090422 yylex_token: end at WS
+1783499626.090423 yylex_token: }
+1783499626.090425 yylex_token: end at WS
+1783499626.090426 yylex_token: swap-pane
+1783499626.090427 yylex_token: end at WS
+1783499626.090429 yylex_token: -D
+1783499626.090431 cmd_parse_build_commands 0:0: bind
+1783499626.090432 cmd_parse_build_commands 0:1: -N
+1783499626.090434 cmd_parse_build_commands 0:2: Swap the active pane with the pane below
+1783499626.090435 cmd_parse_build_commands 0:3: }
+1783499626.090437 cmd_parse_build_commands 0:4 0:0: swap-pane
+1783499626.090438 cmd_parse_build_commands 0:4 0:1: -D
+1783499626.090441 cmd_parse_build_commands 0:0: swap-pane
+1783499626.090442 cmd_parse_build_commands 0:1: -D
+1783499626.090446 args_parse_flags: next -D
+1783499626.090447 args_parse_flags: -D
+1783499626.090448 args_parse: flags end at 2 of 2
+1783499626.090451 cmd_parse_build_commands: swap-pane -D
+1783499626.090452 args_parse_flags: next -N
+1783499626.090462 args_parse_flag_argument: -N = Swap the active pane with the pane below
+1783499626.090464 args_parse_flags: next }
+1783499626.090465 args_parse: flags end at 3 of 5
+1783499626.090467 args_parse: 3 = } (type STRING)
+1783499626.090469 args_parse: 4 = swap-pane -D (type COMMANDS)
+1783499626.090474 cmd_parse_build_commands: bind-key -N "Swap the active pane with the pane below" \\} { swap-pane -D }
+1783499626.090477 cmdq_get_command: [bind-key/0x58e4724cd060] group 466
+1783499626.090478 cmdq_append <global>: [bind-key/0x58e4724cd060]
+1783499626.090481 yylex_token: end at WS
+1783499626.090482 yylex_token: bind
+1783499626.090484 yylex_token: end at WS
+1783499626.090485 yylex_token: -N
+1783499626.090487 yylex_token: end at WS
+1783499626.090488 yylex_token: Show messages
+1783499626.090489 yylex_token: end at WS
+1783499626.090490 yylex_token: ~
+1783499626.090492 yylex_token: end at WS
+1783499626.090493 yylex_token: show-messages
+1783499626.090495 cmd_parse_build_commands 0:0: bind
+1783499626.090497 cmd_parse_build_commands 0:1: -N
+1783499626.090498 cmd_parse_build_commands 0:2: Show messages
+1783499626.090499 cmd_parse_build_commands 0:3: ~
+1783499626.090501 cmd_parse_build_commands 0:4 0:0: show-messages
+1783499626.090503 cmd_parse_build_commands 0:0: show-messages
+1783499626.090506 args_parse: flags end at 1 of 1
+1783499626.090508 cmd_parse_build_commands: show-messages
+1783499626.090510 args_parse_flags: next -N
+1783499626.090511 args_parse_flag_argument: -N = Show messages
+1783499626.090513 args_parse_flags: next ~
+1783499626.090514 args_parse: flags end at 3 of 5
+1783499626.090515 args_parse: 3 = ~ (type STRING)
+1783499626.090517 args_parse: 4 = show-messages (type COMMANDS)
+1783499626.090521 cmd_parse_build_commands: bind-key -N "Show messages" \\~ { show-messages }
+1783499626.090524 cmdq_get_command: [bind-key/0x58e4724cd4c0] group 474
+1783499626.090525 cmdq_append <global>: [bind-key/0x58e4724cd4c0]
+1783499626.090535 yylex_token: end at WS
+1783499626.090539 yylex_token: bind
+1783499626.090541 yylex_token: end at WS
+1783499626.090542 yylex_token: -N
+1783499626.090544 yylex_token: end at WS
+1783499626.090545 yylex_token: Enter copy mode and scroll up
+1783499626.090547 yylex_token: end at WS
+1783499626.090548 yylex_token: PPage
+1783499626.090550 yylex_token: end at WS
+1783499626.090551 yylex_token: copy-mode
+1783499626.090552 yylex_token: end at WS
+1783499626.090553 yylex_token: -u
+1783499626.090556 cmd_parse_build_commands 0:0: bind
+1783499626.090557 cmd_parse_build_commands 0:1: -N
+1783499626.090559 cmd_parse_build_commands 0:2: Enter copy mode and scroll up
+1783499626.090560 cmd_parse_build_commands 0:3: PPage
+1783499626.090562 cmd_parse_build_commands 0:4 0:0: copy-mode
+1783499626.090563 cmd_parse_build_commands 0:4 0:1: -u
+1783499626.090565 cmd_parse_build_commands 0:0: copy-mode
+1783499626.090567 cmd_parse_build_commands 0:1: -u
+1783499626.090569 args_parse_flags: next -u
+1783499626.090571 args_parse_flags: -u
+1783499626.090572 args_parse: flags end at 2 of 2
+1783499626.090574 cmd_parse_build_commands: copy-mode -u
+1783499626.090575 args_parse_flags: next -N
+1783499626.090577 args_parse_flag_argument: -N = Enter copy mode and scroll up
+1783499626.090578 args_parse_flags: next PPage
+1783499626.090580 args_parse: flags end at 3 of 5
+1783499626.090581 args_parse: 3 = PPage (type STRING)
+1783499626.090583 args_parse: 4 = copy-mode -u (type COMMANDS)
+1783499626.090588 cmd_parse_build_commands: bind-key -N "Enter copy mode and scroll up" PPage { copy-mode -u }
+1783499626.090591 cmdq_get_command: [bind-key/0x58e4724cdc50] group 482
+1783499626.090592 cmdq_append <global>: [bind-key/0x58e4724cdc50]
+1783499626.090595 yylex_token: end at WS
+1783499626.090596 yylex_token: bind
+1783499626.090597 yylex_token: end at WS
+1783499626.090598 yylex_token: -N
+1783499626.090601 yylex_token: end at WS
+1783499626.090602 yylex_token: Select the pane above the active pane
+1783499626.090604 yylex_token: end at WS
+1783499626.090605 yylex_token: -r
+1783499626.090606 yylex_token: end at WS
+1783499626.090607 yylex_token: Up
+1783499626.090612 yylex_token: end at WS
+1783499626.090613 yylex_token: select-pane
+1783499626.090614 yylex_token: end at WS
+1783499626.090615 yylex_token: -U
+1783499626.090617 cmd_parse_build_commands 0:0: bind
+1783499626.090619 cmd_parse_build_commands 0:1: -N
+1783499626.090620 cmd_parse_build_commands 0:2: Select the pane above the active pane
+1783499626.090622 cmd_parse_build_commands 0:3: -r
+1783499626.090623 cmd_parse_build_commands 0:4: Up
+1783499626.090624 cmd_parse_build_commands 0:5 0:0: select-pane
+1783499626.090626 cmd_parse_build_commands 0:5 0:1: -U
+1783499626.090628 cmd_parse_build_commands 0:0: select-pane
+1783499626.090629 cmd_parse_build_commands 0:1: -U
+1783499626.090632 args_parse_flags: next -U
+1783499626.090633 args_parse_flags: -U
+1783499626.090635 args_parse: flags end at 2 of 2
+1783499626.090637 cmd_parse_build_commands: select-pane -U
+1783499626.090638 args_parse_flags: next -N
+1783499626.090640 args_parse_flag_argument: -N = Select the pane above the active pane
+1783499626.090641 args_parse_flags: next -r
+1783499626.090642 args_parse_flags: -r
+1783499626.090644 args_parse_flags: next Up
+1783499626.090645 args_parse: flags end at 4 of 6
+1783499626.090646 args_parse: 4 = Up (type STRING)
+1783499626.090648 args_parse: 5 = select-pane -U (type COMMANDS)
+1783499626.090654 cmd_parse_build_commands: bind-key -r -N "Select the pane above the active pane" Up { select-pane -U }
+1783499626.090656 cmdq_get_command: [bind-key/0x58e4724ce280] group 490
+1783499626.090657 cmdq_append <global>: [bind-key/0x58e4724ce280]
+1783499626.090666 yylex_token: end at WS
+1783499626.090669 yylex_token: bind
+1783499626.090670 yylex_token: end at WS
+1783499626.090672 yylex_token: -N
+1783499626.090674 yylex_token: end at WS
+1783499626.090675 yylex_token: Select the pane below the active pane
+1783499626.090677 yylex_token: end at WS
+1783499626.090678 yylex_token: -r
+1783499626.090679 yylex_token: end at WS
+1783499626.090680 yylex_token: Down
+1783499626.090682 yylex_token: end at WS
+1783499626.090683 yylex_token: select-pane
+1783499626.090685 yylex_token: end at WS
+1783499626.090686 yylex_token: -D
+1783499626.090688 cmd_parse_build_commands 0:0: bind
+1783499626.090689 cmd_parse_build_commands 0:1: -N
+1783499626.090691 cmd_parse_build_commands 0:2: Select the pane below the active pane
+1783499626.090692 cmd_parse_build_commands 0:3: -r
+1783499626.090693 cmd_parse_build_commands 0:4: Down
+1783499626.090695 cmd_parse_build_commands 0:5 0:0: select-pane
+1783499626.090696 cmd_parse_build_commands 0:5 0:1: -D
+1783499626.090699 cmd_parse_build_commands 0:0: select-pane
+1783499626.090700 cmd_parse_build_commands 0:1: -D
+1783499626.090703 args_parse_flags: next -D
+1783499626.090704 args_parse_flags: -D
+1783499626.090706 args_parse: flags end at 2 of 2
+1783499626.090708 cmd_parse_build_commands: select-pane -D
+1783499626.090709 args_parse_flags: next -N
+1783499626.090711 args_parse_flag_argument: -N = Select the pane below the active pane
+1783499626.090712 args_parse_flags: next -r
+1783499626.090713 args_parse_flags: -r
+1783499626.090714 args_parse_flags: next Down
+1783499626.090716 args_parse: flags end at 4 of 6
+1783499626.090717 args_parse: 4 = Down (type STRING)
+1783499626.090719 args_parse: 5 = select-pane -D (type COMMANDS)
+1783499626.090725 cmd_parse_build_commands: bind-key -r -N "Select the pane below the active pane" Down { select-pane -D }
+1783499626.090727 cmdq_get_command: [bind-key/0x58e4724ceaa0] group 498
+1783499626.090728 cmdq_append <global>: [bind-key/0x58e4724ceaa0]
+1783499626.090731 yylex_token: end at WS
+1783499626.090732 yylex_token: bind
+1783499626.090734 yylex_token: end at WS
+1783499626.090735 yylex_token: -N
+1783499626.090737 yylex_token: end at WS
+1783499626.090739 yylex_token: Select the pane to the left of the active pane
+1783499626.090740 yylex_token: end at WS
+1783499626.090741 yylex_token: -r
+1783499626.090743 yylex_token: end at WS
+1783499626.090744 yylex_token: Left
+1783499626.090745 yylex_token: end at WS
+1783499626.090747 yylex_token: select-pane
+1783499626.090748 yylex_token: end at WS
+1783499626.090749 yylex_token: -L
+1783499626.090754 cmd_parse_build_commands 0:0: bind
+1783499626.090756 cmd_parse_build_commands 0:1: -N
+1783499626.090758 cmd_parse_build_commands 0:2: Select the pane to the left of the active pane
+1783499626.090759 cmd_parse_build_commands 0:3: -r
+1783499626.090760 cmd_parse_build_commands 0:4: Left
+1783499626.090762 cmd_parse_build_commands 0:5 0:0: select-pane
+1783499626.090763 cmd_parse_build_commands 0:5 0:1: -L
+1783499626.090765 cmd_parse_build_commands 0:0: select-pane
+1783499626.090767 cmd_parse_build_commands 0:1: -L
+1783499626.090769 args_parse_flags: next -L
+1783499626.090771 args_parse_flags: -L
+1783499626.090799 args_parse: flags end at 2 of 2
+1783499626.090805 cmd_parse_build_commands: select-pane -L
+1783499626.090808 args_parse_flags: next -N
+1783499626.090811 args_parse_flag_argument: -N = Select the pane to the left of the active pane
+1783499626.090813 args_parse_flags: next -r
+1783499626.090815 args_parse_flags: -r
+1783499626.090816 args_parse_flags: next Left
+1783499626.090818 args_parse: flags end at 4 of 6
+1783499626.090820 args_parse: 4 = Left (type STRING)
+1783499626.090823 args_parse: 5 = select-pane -L (type COMMANDS)
+1783499626.090831 cmd_parse_build_commands: bind-key -r -N "Select the pane to the left of the active pane" Left { select-pane -L }
+1783499626.090835 cmdq_get_command: [bind-key/0x58e4724cf3f0] group 506
+1783499626.090837 cmdq_append <global>: [bind-key/0x58e4724cf3f0]
+1783499626.090848 yylex_token: end at WS
+1783499626.090852 yylex_token: bind
+1783499626.090854 yylex_token: end at WS
+1783499626.090855 yylex_token: -N
+1783499626.090858 yylex_token: end at WS
+1783499626.090860 yylex_token: Select the pane to the right of the active pane
+1783499626.090862 yylex_token: end at WS
+1783499626.090863 yylex_token: -r
+1783499626.090865 yylex_token: end at WS
+1783499626.090866 yylex_token: Right
+1783499626.090868 yylex_token: end at WS
+1783499626.090870 yylex_token: select-pane
+1783499626.090871 yylex_token: end at WS
+1783499626.090873 yylex_token: -R
+1783499626.090876 cmd_parse_build_commands 0:0: bind
+1783499626.090878 cmd_parse_build_commands 0:1: -N
+1783499626.090880 cmd_parse_build_commands 0:2: Select the pane to the right of the active pane
+1783499626.090882 cmd_parse_build_commands 0:3: -r
+1783499626.090884 cmd_parse_build_commands 0:4: Right
+1783499626.090886 cmd_parse_build_commands 0:5 0:0: select-pane
+1783499626.090888 cmd_parse_build_commands 0:5 0:1: -R
+1783499626.090891 cmd_parse_build_commands 0:0: select-pane
+1783499626.090893 cmd_parse_build_commands 0:1: -R
+1783499626.090897 args_parse_flags: next -R
+1783499626.090898 args_parse_flags: -R
+1783499626.090900 args_parse: flags end at 2 of 2
+1783499626.090903 cmd_parse_build_commands: select-pane -R
+1783499626.090905 args_parse_flags: next -N
+1783499626.090907 args_parse_flag_argument: -N = Select the pane to the right of the active pane
+1783499626.090909 args_parse_flags: next -r
+1783499626.090910 args_parse_flags: -r
+1783499626.090912 args_parse_flags: next Right
+1783499626.090913 args_parse: flags end at 4 of 6
+1783499626.090915 args_parse: 4 = Right (type STRING)
+1783499626.090918 args_parse: 5 = select-pane -R (type COMMANDS)
+1783499626.090925 cmd_parse_build_commands: bind-key -r -N "Select the pane to the right of the active pane" Right { select-pane -R }
+1783499626.090928 cmdq_get_command: [bind-key/0x58e4724cf8c0] group 514
+1783499626.090930 cmdq_append <global>: [bind-key/0x58e4724cf8c0]
+1783499626.090934 yylex_token: end at WS
+1783499626.090935 yylex_token: bind
+1783499626.090937 yylex_token: end at WS
+1783499626.090938 yylex_token: -N
+1783499626.090940 yylex_token: end at WS
+1783499626.090942 yylex_token: Set the even-horizontal layout
+1783499626.090944 yylex_token: end at WS
+1783499626.090945 yylex_token: M-1
+1783499626.090947 yylex_token: end at WS
+1783499626.090948 yylex_token: select-layout
+1783499626.090950 yylex_token: end at WS
+1783499626.090952 yylex_token: even-horizontal
+1783499626.090954 cmd_parse_build_commands 0:0: bind
+1783499626.090956 cmd_parse_build_commands 0:1: -N
+1783499626.090958 cmd_parse_build_commands 0:2: Set the even-horizontal layout
+1783499626.090966 cmd_parse_build_commands 0:3: M-1
+1783499626.090969 cmd_parse_build_commands 0:4 0:0: select-layout
+1783499626.090971 cmd_parse_build_commands 0:4 0:1: even-horizontal
+1783499626.090974 cmd_parse_build_commands 0:0: select-layout
+1783499626.090976 cmd_parse_build_commands 0:1: even-horizontal
+1783499626.090980 args_parse_flags: next even-horizontal
+1783499626.090981 args_parse: flags end at 1 of 2
+1783499626.090983 args_parse: 1 = even-horizontal (type STRING)
+1783499626.090987 cmd_parse_build_commands: select-layout even-horizontal
+1783499626.090989 args_parse_flags: next -N
+1783499626.090991 args_parse_flag_argument: -N = Set the even-horizontal layout
+1783499626.090992 args_parse_flags: next M-1
+1783499626.090994 args_parse: flags end at 3 of 5
+1783499626.090996 args_parse: 3 = M-1 (type STRING)
+1783499626.090999 args_parse: 4 = select-layout even-horizontal (type COMMANDS)
+1783499626.091005 cmd_parse_build_commands: bind-key -N "Set the even-horizontal layout" M-1 { select-layout even-horizontal }
+1783499626.091008 cmdq_get_command: [bind-key/0x58e4724cfef0] group 522
+1783499626.091010 cmdq_append <global>: [bind-key/0x58e4724cfef0]
+1783499626.091013 yylex_token: end at WS
+1783499626.091015 yylex_token: bind
+1783499626.091016 yylex_token: end at WS
+1783499626.091018 yylex_token: -N
+1783499626.091020 yylex_token: end at WS
+1783499626.091022 yylex_token: Set the even-vertical layout
+1783499626.091023 yylex_token: end at WS
+1783499626.091024 yylex_token: M-2
+1783499626.091026 yylex_token: end at WS
+1783499626.091028 yylex_token: select-layout
+1783499626.091029 yylex_token: end at WS
+1783499626.091031 yylex_token: even-vertical
+1783499626.091033 cmd_parse_build_commands 0:0: bind
+1783499626.091035 cmd_parse_build_commands 0:1: -N
+1783499626.091037 cmd_parse_build_commands 0:2: Set the even-vertical layout
+1783499626.091039 cmd_parse_build_commands 0:3: M-2
+1783499626.091041 cmd_parse_build_commands 0:4 0:0: select-layout
+1783499626.091043 cmd_parse_build_commands 0:4 0:1: even-vertical
+1783499626.091045 cmd_parse_build_commands 0:0: select-layout
+1783499626.091047 cmd_parse_build_commands 0:1: even-vertical
+1783499626.091050 args_parse_flags: next even-vertical
+1783499626.091052 args_parse: flags end at 1 of 2
+1783499626.091054 args_parse: 1 = even-vertical (type STRING)
+1783499626.091057 cmd_parse_build_commands: select-layout even-vertical
+1783499626.091059 args_parse_flags: next -N
+1783499626.091061 args_parse_flag_argument: -N = Set the even-vertical layout
+1783499626.091062 args_parse_flags: next M-2
+1783499626.091064 args_parse: flags end at 3 of 5
+1783499626.091066 args_parse: 3 = M-2 (type STRING)
+1783499626.091069 args_parse: 4 = select-layout even-vertical (type COMMANDS)
+1783499626.091075 cmd_parse_build_commands: bind-key -N "Set the even-vertical layout" M-2 { select-layout even-vertical }
+1783499626.091077 cmdq_get_command: [bind-key/0x58e4724d0560] group 530
+1783499626.091079 cmdq_append <global>: [bind-key/0x58e4724d0560]
+1783499626.091089 yylex_token: end at WS
+1783499626.091093 yylex_token: bind
+1783499626.091095 yylex_token: end at WS
+1783499626.091096 yylex_token: -N
+1783499626.091098 yylex_token: end at WS
+1783499626.091100 yylex_token: Set the main-horizontal layout
+1783499626.091101 yylex_token: end at WS
+1783499626.091103 yylex_token: M-3
+1783499626.091105 yylex_token: end at WS
+1783499626.091106 yylex_token: select-layout
+1783499626.091108 yylex_token: end at WS
+1783499626.091109 yylex_token: main-horizontal
+1783499626.091112 cmd_parse_build_commands 0:0: bind
+1783499626.091113 cmd_parse_build_commands 0:1: -N
+1783499626.091116 cmd_parse_build_commands 0:2: Set the main-horizontal layout
+1783499626.091117 cmd_parse_build_commands 0:3: M-3
+1783499626.091119 cmd_parse_build_commands 0:4 0:0: select-layout
+1783499626.091121 cmd_parse_build_commands 0:4 0:1: main-horizontal
+1783499626.091124 cmd_parse_build_commands 0:0: select-layout
+1783499626.091126 cmd_parse_build_commands 0:1: main-horizontal
+1783499626.091129 args_parse_flags: next main-horizontal
+1783499626.091135 args_parse: flags end at 1 of 2
+1783499626.091137 args_parse: 1 = main-horizontal (type STRING)
+1783499626.091141 cmd_parse_build_commands: select-layout main-horizontal
+1783499626.091143 args_parse_flags: next -N
+1783499626.091145 args_parse_flag_argument: -N = Set the main-horizontal layout
+1783499626.091146 args_parse_flags: next M-3
+1783499626.091148 args_parse: flags end at 3 of 5
+1783499626.091149 args_parse: 3 = M-3 (type STRING)
+1783499626.091152 args_parse: 4 = select-layout main-horizontal (type COMMANDS)
+1783499626.091158 cmd_parse_build_commands: bind-key -N "Set the main-horizontal layout" M-3 { select-layout main-horizontal }
+1783499626.091161 cmdq_get_command: [bind-key/0x58e4724d0b00] group 538
+1783499626.091163 cmdq_append <global>: [bind-key/0x58e4724d0b00]
+1783499626.091166 yylex_token: end at WS
+1783499626.091167 yylex_token: bind
+1783499626.091169 yylex_token: end at WS
+1783499626.091170 yylex_token: -N
+1783499626.091172 yylex_token: end at WS
+1783499626.091174 yylex_token: Set the main-vertical layout
+1783499626.091176 yylex_token: end at WS
+1783499626.091177 yylex_token: M-4
+1783499626.091179 yylex_token: end at WS
+1783499626.091180 yylex_token: select-layout
+1783499626.091182 yylex_token: end at WS
+1783499626.091183 yylex_token: main-vertical
+1783499626.091186 cmd_parse_build_commands 0:0: bind
+1783499626.091187 cmd_parse_build_commands 0:1: -N
+1783499626.091189 cmd_parse_build_commands 0:2: Set the main-vertical layout
+1783499626.091191 cmd_parse_build_commands 0:3: M-4
+1783499626.091193 cmd_parse_build_commands 0:4 0:0: select-layout
+1783499626.091195 cmd_parse_build_commands 0:4 0:1: main-vertical
+1783499626.091197 cmd_parse_build_commands 0:0: select-layout
+1783499626.091199 cmd_parse_build_commands 0:1: main-vertical
+1783499626.091203 args_parse_flags: next main-vertical
+1783499626.091204 args_parse: flags end at 1 of 2
+1783499626.091206 args_parse: 1 = main-vertical (type STRING)
+1783499626.091209 cmd_parse_build_commands: select-layout main-vertical
+1783499626.091211 args_parse_flags: next -N
+1783499626.091213 args_parse_flag_argument: -N = Set the main-vertical layout
+1783499626.091214 args_parse_flags: next M-4
+1783499626.091216 args_parse: flags end at 3 of 5
+1783499626.091218 args_parse: 3 = M-4 (type STRING)
+1783499626.091221 args_parse: 4 = select-layout main-vertical (type COMMANDS)
+1783499626.091226 cmd_parse_build_commands: bind-key -N "Set the main-vertical layout" M-4 { select-layout main-vertical }
+1783499626.091229 cmdq_get_command: [bind-key/0x58e4724d0ee0] group 546
+1783499626.091231 cmdq_append <global>: [bind-key/0x58e4724d0ee0]
+1783499626.091233 yylex_token: end at WS
+1783499626.091235 yylex_token: bind
+1783499626.091236 yylex_token: end at WS
+1783499626.091237 yylex_token: -N
+1783499626.091239 yylex_token: end at WS
+1783499626.091241 yylex_token: Select the tiled layout
+1783499626.091243 yylex_token: end at WS
+1783499626.091244 yylex_token: M-5
+1783499626.091246 yylex_token: end at WS
+1783499626.091247 yylex_token: select-layout
+1783499626.091248 yylex_token: end at WS
+1783499626.091250 yylex_token: tiled
+1783499626.091252 cmd_parse_build_commands 0:0: bind
+1783499626.091254 cmd_parse_build_commands 0:1: -N
+1783499626.091256 cmd_parse_build_commands 0:2: Select the tiled layout
+1783499626.091257 cmd_parse_build_commands 0:3: M-5
+1783499626.091259 cmd_parse_build_commands 0:4 0:0: select-layout
+1783499626.091261 cmd_parse_build_commands 0:4 0:1: tiled
+1783499626.091264 cmd_parse_build_commands 0:0: select-layout
+1783499626.091265 cmd_parse_build_commands 0:1: tiled
+1783499626.091268 args_parse_flags: next tiled
+1783499626.091270 args_parse: flags end at 1 of 2
+1783499626.091272 args_parse: 1 = tiled (type STRING)
+1783499626.091274 cmd_parse_build_commands: select-layout tiled
+1783499626.091276 args_parse_flags: next -N
+1783499626.091278 args_parse_flag_argument: -N = Select the tiled layout
+1783499626.091279 args_parse_flags: next M-5
+1783499626.091281 args_parse: flags end at 3 of 5
+1783499626.091282 args_parse: 3 = M-5 (type STRING)
+1783499626.091288 args_parse: 4 = select-layout tiled (type COMMANDS)
+1783499626.091294 cmd_parse_build_commands: bind-key -N "Select the tiled layout" M-5 { select-layout tiled }
+1783499626.091297 cmdq_get_command: [bind-key/0x58e4724d13f0] group 554
+1783499626.091299 cmdq_append <global>: [bind-key/0x58e4724d13f0]
+1783499626.091307 yylex_token: end at WS
+1783499626.091311 yylex_token: bind
+1783499626.091312 yylex_token: end at WS
+1783499626.091314 yylex_token: -N
+1783499626.091316 yylex_token: end at WS
+1783499626.091318 yylex_token: Select the next window with an alert
+1783499626.091320 yylex_token: end at WS
+1783499626.091321 yylex_token: M-n
+1783499626.091323 yylex_token: end at WS
+1783499626.091324 yylex_token: next-window
+1783499626.091325 yylex_token: end at WS
+1783499626.091327 yylex_token: -a
+1783499626.091329 cmd_parse_build_commands 0:0: bind
+1783499626.091331 cmd_parse_build_commands 0:1: -N
+1783499626.091333 cmd_parse_build_commands 0:2: Select the next window with an alert
+1783499626.091334 cmd_parse_build_commands 0:3: M-n
+1783499626.091336 cmd_parse_build_commands 0:4 0:0: next-window
+1783499626.091338 cmd_parse_build_commands 0:4 0:1: -a
+1783499626.091341 cmd_parse_build_commands 0:0: next-window
+1783499626.091342 cmd_parse_build_commands 0:1: -a
+1783499626.091345 args_parse_flags: next -a
+1783499626.091347 args_parse_flags: -a
+1783499626.091349 args_parse: flags end at 2 of 2
+1783499626.091351 cmd_parse_build_commands: next-window -a
+1783499626.091353 args_parse_flags: next -N
+1783499626.091355 args_parse_flag_argument: -N = Select the next window with an alert
+1783499626.091357 args_parse_flags: next M-n
+1783499626.091358 args_parse: flags end at 3 of 5
+1783499626.091360 args_parse: 3 = M-n (type STRING)
+1783499626.091362 args_parse: 4 = next-window -a (type COMMANDS)
+1783499626.091368 cmd_parse_build_commands: bind-key -N "Select the next window with an alert" M-n { next-window -a }
+1783499626.091371 cmdq_get_command: [bind-key/0x58e4724d17e0] group 562
+1783499626.091373 cmdq_append <global>: [bind-key/0x58e4724d17e0]
+1783499626.091376 yylex_token: end at WS
+1783499626.091377 yylex_token: bind
+1783499626.091379 yylex_token: end at WS
+1783499626.091380 yylex_token: -N
+1783499626.091382 yylex_token: end at WS
+1783499626.091384 yylex_token: Rotate through the panes in reverse
+1783499626.091385 yylex_token: end at WS
+1783499626.091394 yylex_token: M-o
+1783499626.091397 yylex_token: end at WS
+1783499626.091398 yylex_token: rotate-window
+1783499626.091400 yylex_token: end at WS
+1783499626.091401 yylex_token: -D
+1783499626.091403 cmd_parse_build_commands 0:0: bind
+1783499626.091405 cmd_parse_build_commands 0:1: -N
+1783499626.091407 cmd_parse_build_commands 0:2: Rotate through the panes in reverse
+1783499626.091409 cmd_parse_build_commands 0:3: M-o
+1783499626.091411 cmd_parse_build_commands 0:4 0:0: rotate-window
+1783499626.091413 cmd_parse_build_commands 0:4 0:1: -D
+1783499626.091415 cmd_parse_build_commands 0:0: rotate-window
+1783499626.091417 cmd_parse_build_commands 0:1: -D
+1783499626.091420 args_parse_flags: next -D
+1783499626.091422 args_parse_flags: -D
+1783499626.091423 args_parse: flags end at 2 of 2
+1783499626.091426 cmd_parse_build_commands: rotate-window -D
+1783499626.091427 args_parse_flags: next -N
+1783499626.091430 args_parse_flag_argument: -N = Rotate through the panes in reverse
+1783499626.091435 args_parse_flags: next M-o
+1783499626.091438 args_parse: flags end at 3 of 5
+1783499626.091440 args_parse: 3 = M-o (type STRING)
+1783499626.091443 args_parse: 4 = rotate-window -D (type COMMANDS)
+1783499626.091449 cmd_parse_build_commands: bind-key -N "Rotate through the panes in reverse" M-o { rotate-window -D }
+1783499626.091452 cmdq_get_command: [bind-key/0x58e4724d1540] group 570
+1783499626.091454 cmdq_append <global>: [bind-key/0x58e4724d1540]
+1783499626.091457 yylex_token: end at WS
+1783499626.091458 yylex_token: bind
+1783499626.091460 yylex_token: end at WS
+1783499626.091461 yylex_token: -N
+1783499626.091464 yylex_token: end at WS
+1783499626.091466 yylex_token: Select the previous window with an alert
+1783499626.091470 yylex_token: end at WS
+1783499626.091472 yylex_token: M-p
+1783499626.091474 yylex_token: end at WS
+1783499626.091475 yylex_token: previous-window
+1783499626.091477 yylex_token: end at WS
+1783499626.091478 yylex_token: -a
+1783499626.091480 cmd_parse_build_commands 0:0: bind
+1783499626.091482 cmd_parse_build_commands 0:1: -N
+1783499626.091484 cmd_parse_build_commands 0:2: Select the previous window with an alert
+1783499626.091486 cmd_parse_build_commands 0:3: M-p
+1783499626.091488 cmd_parse_build_commands 0:4 0:0: previous-window
+1783499626.091490 cmd_parse_build_commands 0:4 0:1: -a
+1783499626.091492 cmd_parse_build_commands 0:0: previous-window
+1783499626.091494 cmd_parse_build_commands 0:1: -a
+1783499626.091497 args_parse_flags: next -a
+1783499626.091499 args_parse_flags: -a
+1783499626.091500 args_parse: flags end at 2 of 2
+1783499626.091503 cmd_parse_build_commands: previous-window -a
+1783499626.091504 args_parse_flags: next -N
+1783499626.091507 args_parse_flag_argument: -N = Select the previous window with an alert
+1783499626.091508 args_parse_flags: next M-p
+1783499626.091510 args_parse: flags end at 3 of 5
+1783499626.091511 args_parse: 3 = M-p (type STRING)
+1783499626.091514 args_parse: 4 = previous-window -a (type COMMANDS)
+1783499626.091520 cmd_parse_build_commands: bind-key -N "Select the previous window with an alert" M-p { previous-window -a }
+1783499626.091523 cmdq_get_command: [bind-key/0x58e4724d2430] group 578
+1783499626.091525 cmdq_append <global>: [bind-key/0x58e4724d2430]
+1783499626.091533 yylex_token: end at WS
+1783499626.091536 yylex_token: bind
+1783499626.091538 yylex_token: end at WS
+1783499626.091539 yylex_token: -N
+1783499626.091541 yylex_token: end at WS
+1783499626.091543 yylex_token: Move the visible part of the window up
+1783499626.091545 yylex_token: end at WS
+1783499626.091546 yylex_token: -r
+1783499626.091548 yylex_token: end at WS
+1783499626.091549 yylex_token: S-Up
+1783499626.091551 yylex_token: end at WS
+1783499626.091552 yylex_token: refresh-client
+1783499626.091554 yylex_token: end at WS
+1783499626.091555 yylex_token: -U
+1783499626.091556 yylex_token: end at WS
+1783499626.091557 yylex_token: 10
+1783499626.091560 cmd_parse_build_commands 0:0: bind
+1783499626.091562 cmd_parse_build_commands 0:1: -N
+1783499626.091564 cmd_parse_build_commands 0:2: Move the visible part of the window up
+1783499626.091566 cmd_parse_build_commands 0:3: -r
+1783499626.091567 cmd_parse_build_commands 0:4: S-Up
+1783499626.091569 cmd_parse_build_commands 0:5 0:0: refresh-client
+1783499626.091571 cmd_parse_build_commands 0:5 0:1: -U
+1783499626.091573 cmd_parse_build_commands 0:5 0:2: 10
+1783499626.091576 cmd_parse_build_commands 0:0: refresh-client
+1783499626.091577 cmd_parse_build_commands 0:1: -U
+1783499626.091579 cmd_parse_build_commands 0:2: 10
+1783499626.091582 args_parse_flags: next -U
+1783499626.091583 args_parse_flags: -U
+1783499626.091585 args_parse_flags: next 10
+1783499626.091586 args_parse: flags end at 2 of 3
+1783499626.091588 args_parse: 2 = 10 (type STRING)
+1783499626.091591 cmd_parse_build_commands: refresh-client -U 10
+1783499626.091593 args_parse_flags: next -N
+1783499626.091596 args_parse_flag_argument: -N = Move the visible part of the window up
+1783499626.091597 args_parse_flags: next -r
+1783499626.091598 args_parse_flags: -r
+1783499626.091600 args_parse_flags: next S-Up
+1783499626.091601 args_parse: flags end at 4 of 6
+1783499626.091603 args_parse: 4 = S-Up (type STRING)
+1783499626.091606 args_parse: 5 = refresh-client -U 10 (type COMMANDS)
+1783499626.091612 cmd_parse_build_commands: bind-key -r -N "Move the visible part of the window up" S-Up { refresh-client -U 10 }
+1783499626.091616 cmdq_get_command: [bind-key/0x58e4724d2e80] group 586
+1783499626.091617 cmdq_append <global>: [bind-key/0x58e4724d2e80]
+1783499626.091620 yylex_token: end at WS
+1783499626.091622 yylex_token: bind
+1783499626.091623 yylex_token: end at WS
+1783499626.091624 yylex_token: -N
+1783499626.091627 yylex_token: end at WS
+1783499626.091629 yylex_token: Move the visible part of the window down
+1783499626.091634 yylex_token: end at WS
+1783499626.091635 yylex_token: -r
+1783499626.091637 yylex_token: end at WS
+1783499626.091638 yylex_token: S-Down
+1783499626.091640 yylex_token: end at WS
+1783499626.091641 yylex_token: refresh-client
+1783499626.091643 yylex_token: end at WS
+1783499626.091644 yylex_token: -D
+1783499626.091646 yylex_token: end at WS
+1783499626.091647 yylex_token: 10
+1783499626.091650 cmd_parse_build_commands 0:0: bind
+1783499626.091651 cmd_parse_build_commands 0:1: -N
+1783499626.091654 cmd_parse_build_commands 0:2: Move the visible part of the window down
+1783499626.091655 cmd_parse_build_commands 0:3: -r
+1783499626.091657 cmd_parse_build_commands 0:4: S-Down
+1783499626.091659 cmd_parse_build_commands 0:5 0:0: refresh-client
+1783499626.091661 cmd_parse_build_commands 0:5 0:1: -D
+1783499626.091662 cmd_parse_build_commands 0:5 0:2: 10
+1783499626.091665 cmd_parse_build_commands 0:0: refresh-client
+1783499626.091666 cmd_parse_build_commands 0:1: -D
+1783499626.091668 cmd_parse_build_commands 0:2: 10
+1783499626.091671 args_parse_flags: next -D
+1783499626.091673 args_parse_flags: -D
+1783499626.091674 args_parse_flags: next 10
+1783499626.091676 args_parse: flags end at 2 of 3
+1783499626.091677 args_parse: 2 = 10 (type STRING)
+1783499626.091680 cmd_parse_build_commands: refresh-client -D 10
+1783499626.091682 args_parse_flags: next -N
+1783499626.091684 args_parse_flag_argument: -N = Move the visible part of the window down
+1783499626.091686 args_parse_flags: next -r
+1783499626.091687 args_parse_flags: -r
+1783499626.091689 args_parse_flags: next S-Down
+1783499626.091690 args_parse: flags end at 4 of 6
+1783499626.091692 args_parse: 4 = S-Down (type STRING)
+1783499626.091694 args_parse: 5 = refresh-client -D 10 (type COMMANDS)
+1783499626.091701 cmd_parse_build_commands: bind-key -r -N "Move the visible part of the window down" S-Down { refresh-client -D 10 }
+1783499626.091704 cmdq_get_command: [bind-key/0x58e4724d35c0] group 594
+1783499626.091706 cmdq_append <global>: [bind-key/0x58e4724d35c0]
+1783499626.091715 yylex_token: end at WS
+1783499626.091718 yylex_token: bind
+1783499626.091720 yylex_token: end at WS
+1783499626.091721 yylex_token: -N
+1783499626.091723 yylex_token: end at WS
+1783499626.091725 yylex_token: Move the visible part of the window left
+1783499626.091727 yylex_token: end at WS
+1783499626.091728 yylex_token: -r
+1783499626.091730 yylex_token: end at WS
+1783499626.091731 yylex_token: S-Left
+1783499626.091733 yylex_token: end at WS
+1783499626.091734 yylex_token: refresh-client
+1783499626.091736 yylex_token: end at WS
+1783499626.091737 yylex_token: -L
+1783499626.091738 yylex_token: end at WS
+1783499626.091740 yylex_token: 10
+1783499626.091742 cmd_parse_build_commands 0:0: bind
+1783499626.091744 cmd_parse_build_commands 0:1: -N
+1783499626.091746 cmd_parse_build_commands 0:2: Move the visible part of the window left
+1783499626.091747 cmd_parse_build_commands 0:3: -r
+1783499626.091749 cmd_parse_build_commands 0:4: S-Left
+1783499626.091751 cmd_parse_build_commands 0:5 0:0: refresh-client
+1783499626.091753 cmd_parse_build_commands 0:5 0:1: -L
+1783499626.091754 cmd_parse_build_commands 0:5 0:2: 10
+1783499626.091757 cmd_parse_build_commands 0:0: refresh-client
+1783499626.091759 cmd_parse_build_commands 0:1: -L
+1783499626.091760 cmd_parse_build_commands 0:2: 10
+1783499626.091764 args_parse_flags: next -L
+1783499626.091765 args_parse_flags: -L
+1783499626.091766 args_parse_flags: next 10
+1783499626.091768 args_parse: flags end at 2 of 3
+1783499626.091770 args_parse: 2 = 10 (type STRING)
+1783499626.091773 cmd_parse_build_commands: refresh-client -L 10
+1783499626.091775 args_parse_flags: next -N
+1783499626.091777 args_parse_flag_argument: -N = Move the visible part of the window left
+1783499626.091778 args_parse_flags: next -r
+1783499626.091780 args_parse_flags: -r
+1783499626.091781 args_parse_flags: next S-Left
+1783499626.091782 args_parse: flags end at 4 of 6
+1783499626.091784 args_parse: 4 = S-Left (type STRING)
+1783499626.091787 args_parse: 5 = refresh-client -L 10 (type COMMANDS)
+1783499626.091793 cmd_parse_build_commands: bind-key -r -N "Move the visible part of the window left" S-Left { refresh-client -L 10 }
+1783499626.091800 cmdq_get_command: [bind-key/0x58e4724d3cc0] group 602
+1783499626.091802 cmdq_append <global>: [bind-key/0x58e4724d3cc0]
+1783499626.091805 yylex_token: end at WS
+1783499626.091806 yylex_token: bind
+1783499626.091808 yylex_token: end at WS
+1783499626.091809 yylex_token: -N
+1783499626.091811 yylex_token: end at WS
+1783499626.091813 yylex_token: Move the visible part of the window right
+1783499626.091815 yylex_token: end at WS
+1783499626.091816 yylex_token: -r
+1783499626.091818 yylex_token: end at WS
+1783499626.091819 yylex_token: S-Right
+1783499626.091821 yylex_token: end at WS
+1783499626.091822 yylex_token: refresh-client
+1783499626.091824 yylex_token: end at WS
+1783499626.091825 yylex_token: -R
+1783499626.091826 yylex_token: end at WS
+1783499626.091828 yylex_token: 10
+1783499626.091830 cmd_parse_build_commands 0:0: bind
+1783499626.091832 cmd_parse_build_commands 0:1: -N
+1783499626.091834 cmd_parse_build_commands 0:2: Move the visible part of the window right
+1783499626.091836 cmd_parse_build_commands 0:3: -r
+1783499626.091837 cmd_parse_build_commands 0:4: S-Right
+1783499626.091839 cmd_parse_build_commands 0:5 0:0: refresh-client
+1783499626.091841 cmd_parse_build_commands 0:5 0:1: -R
+1783499626.091843 cmd_parse_build_commands 0:5 0:2: 10
+1783499626.091845 cmd_parse_build_commands 0:0: refresh-client
+1783499626.091847 cmd_parse_build_commands 0:1: -R
+1783499626.091848 cmd_parse_build_commands 0:2: 10
+1783499626.091851 args_parse_flags: next -R
+1783499626.091853 args_parse_flags: -R
+1783499626.091854 args_parse_flags: next 10
+1783499626.091856 args_parse: flags end at 2 of 3
+1783499626.091857 args_parse: 2 = 10 (type STRING)
+1783499626.091860 cmd_parse_build_commands: refresh-client -R 10
+1783499626.091862 args_parse_flags: next -N
+1783499626.091864 args_parse_flag_argument: -N = Move the visible part of the window right
+1783499626.091866 args_parse_flags: next -r
+1783499626.091867 args_parse_flags: -r
+1783499626.091869 args_parse_flags: next S-Right
+1783499626.091870 args_parse: flags end at 4 of 6
+1783499626.091872 args_parse: 4 = S-Right (type STRING)
+1783499626.091874 args_parse: 5 = refresh-client -R 10 (type COMMANDS)
+1783499626.091881 cmd_parse_build_commands: bind-key -r -N "Move the visible part of the window right" S-Right { refresh-client -R 10 }
+1783499626.091884 cmdq_get_command: [bind-key/0x58e4724d45b0] group 610
+1783499626.091886 cmdq_append <global>: [bind-key/0x58e4724d45b0]
+1783499626.091895 yylex_token: end at WS
+1783499626.091899 yylex_token: bind
+1783499626.091901 yylex_token: end at WS
+1783499626.091902 yylex_token: -N
+1783499626.091905 yylex_token: end at WS
+1783499626.091907 yylex_token: Reset so the visible part of the window follows the cursor
+1783499626.091909 yylex_token: end at WS
+1783499626.091910 yylex_token: -r
+1783499626.091911 yylex_token: end at WS
+1783499626.091913 yylex_token: DC
+1783499626.091914 yylex_token: end at WS
+1783499626.091916 yylex_token: refresh-client
+1783499626.091917 yylex_token: end at WS
+1783499626.091919 yylex_token: -c
+1783499626.091921 cmd_parse_build_commands 0:0: bind
+1783499626.091923 cmd_parse_build_commands 0:1: -N
+1783499626.091926 cmd_parse_build_commands 0:2: Reset so the visible part of the window follows the cursor
+1783499626.091927 cmd_parse_build_commands 0:3: -r
+1783499626.091929 cmd_parse_build_commands 0:4: DC
+1783499626.091931 cmd_parse_build_commands 0:5 0:0: refresh-client
+1783499626.091933 cmd_parse_build_commands 0:5 0:1: -c
+1783499626.091936 cmd_parse_build_commands 0:0: refresh-client
+1783499626.091937 cmd_parse_build_commands 0:1: -c
+1783499626.091940 args_parse_flags: next -c
+1783499626.091942 args_parse_flags: -c
+1783499626.091943 args_parse: flags end at 2 of 2
+1783499626.091946 cmd_parse_build_commands: refresh-client -c
+1783499626.091948 args_parse_flags: next -N
+1783499626.091951 args_parse_flag_argument: -N = Reset so the visible part of the window follows the cursor
+1783499626.091952 args_parse_flags: next -r
+1783499626.091957 args_parse_flags: -r
+1783499626.091958 args_parse_flags: next DC
+1783499626.091960 args_parse: flags end at 4 of 6
+1783499626.091962 args_parse: 4 = DC (type STRING)
+1783499626.091965 args_parse: 5 = refresh-client -c (type COMMANDS)
+1783499626.091974 cmd_parse_build_commands: bind-key -r -N "Reset so the visible part of the window follows the cursor" DC { refresh-client -c }
+1783499626.091977 cmdq_get_command: [bind-key/0x58e4724bbef0] group 618
+1783499626.091979 cmdq_append <global>: [bind-key/0x58e4724bbef0]
+1783499626.091983 yylex_token: end at WS
+1783499626.091989 yylex_token: bind
+1783499626.091993 yylex_token: end at WS
+1783499626.091994 yylex_token: -N
+1783499626.091996 yylex_token: end at WS
+1783499626.091998 yylex_token: Resize the pane up by 5
+1783499626.091999 yylex_token: end at WS
+1783499626.092000 yylex_token: -r
+1783499626.092002 yylex_token: end at WS
+1783499626.092003 yylex_token: M-Up
+1783499626.092005 yylex_token: end at WS
+1783499626.092006 yylex_token: resize-pane
+1783499626.092008 yylex_token: end at WS
+1783499626.092009 yylex_token: -U
+1783499626.092010 yylex_token: end at WS
+1783499626.092012 yylex_token: 5
+1783499626.092014 cmd_parse_build_commands 0:0: bind
+1783499626.092016 cmd_parse_build_commands 0:1: -N
+1783499626.092018 cmd_parse_build_commands 0:2: Resize the pane up by 5
+1783499626.092019 cmd_parse_build_commands 0:3: -r
+1783499626.092021 cmd_parse_build_commands 0:4: M-Up
+1783499626.092023 cmd_parse_build_commands 0:5 0:0: resize-pane
+1783499626.092025 cmd_parse_build_commands 0:5 0:1: -U
+1783499626.092027 cmd_parse_build_commands 0:5 0:2: 5
+1783499626.092029 cmd_parse_build_commands 0:0: resize-pane
+1783499626.092031 cmd_parse_build_commands 0:1: -U
+1783499626.092033 cmd_parse_build_commands 0:2: 5
+1783499626.092036 args_parse_flags: next -U
+1783499626.092038 args_parse_flags: -U
+1783499626.092039 args_parse_flags: next 5
+1783499626.092041 args_parse: flags end at 2 of 3
+1783499626.092042 args_parse: 2 = 5 (type STRING)
+1783499626.092046 cmd_parse_build_commands: resize-pane -U 5
+1783499626.092047 args_parse_flags: next -N
+1783499626.092049 args_parse_flag_argument: -N = Resize the pane up by 5
+1783499626.092051 args_parse_flags: next -r
+1783499626.092052 args_parse_flags: -r
+1783499626.092054 args_parse_flags: next M-Up
+1783499626.092055 args_parse: flags end at 4 of 6
+1783499626.092057 args_parse: 4 = M-Up (type STRING)
+1783499626.092059 args_parse: 5 = resize-pane -U 5 (type COMMANDS)
+1783499626.092065 cmd_parse_build_commands: bind-key -r -N "Resize the pane up by 5" M-Up { resize-pane -U 5 }
+1783499626.092068 cmdq_get_command: [bind-key/0x58e4724d5200] group 626
+1783499626.092070 cmdq_append <global>: [bind-key/0x58e4724d5200]
+1783499626.092074 yylex_token: end at WS
+1783499626.092075 yylex_token: bind
+1783499626.092076 yylex_token: end at WS
+1783499626.092078 yylex_token: -N
+1783499626.092080 yylex_token: end at WS
+1783499626.092081 yylex_token: Resize the pane down by 5
+1783499626.092083 yylex_token: end at WS
+1783499626.092084 yylex_token: -r
+1783499626.092085 yylex_token: end at WS
+1783499626.092087 yylex_token: M-Down
+1783499626.092088 yylex_token: end at WS
+1783499626.092090 yylex_token: resize-pane
+1783499626.092091 yylex_token: end at WS
+1783499626.092092 yylex_token: -D
+1783499626.092094 yylex_token: end at WS
+1783499626.092095 yylex_token: 5
+1783499626.092097 cmd_parse_build_commands 0:0: bind
+1783499626.092099 cmd_parse_build_commands 0:1: -N
+1783499626.092101 cmd_parse_build_commands 0:2: Resize the pane down by 5
+1783499626.092103 cmd_parse_build_commands 0:3: -r
+1783499626.092104 cmd_parse_build_commands 0:4: M-Down
+1783499626.092106 cmd_parse_build_commands 0:5 0:0: resize-pane
+1783499626.092108 cmd_parse_build_commands 0:5 0:1: -D
+1783499626.092109 cmd_parse_build_commands 0:5 0:2: 5
+1783499626.092112 cmd_parse_build_commands 0:0: resize-pane
+1783499626.092114 cmd_parse_build_commands 0:1: -D
+1783499626.092115 cmd_parse_build_commands 0:2: 5
+1783499626.092118 args_parse_flags: next -D
+1783499626.092120 args_parse_flags: -D
+1783499626.092121 args_parse_flags: next 5
+1783499626.092126 args_parse: flags end at 2 of 3
+1783499626.092128 args_parse: 2 = 5 (type STRING)
+1783499626.092131 cmd_parse_build_commands: resize-pane -D 5
+1783499626.092133 args_parse_flags: next -N
+1783499626.092135 args_parse_flag_argument: -N = Resize the pane down by 5
+1783499626.092136 args_parse_flags: next -r
+1783499626.092138 args_parse_flags: -r
+1783499626.092139 args_parse_flags: next M-Down
+1783499626.092141 args_parse: flags end at 4 of 6
+1783499626.092142 args_parse: 4 = M-Down (type STRING)
+1783499626.092145 args_parse: 5 = resize-pane -D 5 (type COMMANDS)
+1783499626.092151 cmd_parse_build_commands: bind-key -r -N "Resize the pane down by 5" M-Down { resize-pane -D 5 }
+1783499626.092153 cmdq_get_command: [bind-key/0x58e4724d5850] group 634
+1783499626.092155 cmdq_append <global>: [bind-key/0x58e4724d5850]
+1783499626.092164 yylex_token: end at WS
+1783499626.092168 yylex_token: bind
+1783499626.092169 yylex_token: end at WS
+1783499626.092170 yylex_token: -N
+1783499626.092172 yylex_token: end at WS
+1783499626.092174 yylex_token: Resize the pane left by 5
+1783499626.092176 yylex_token: end at WS
+1783499626.092177 yylex_token: -r
+1783499626.092179 yylex_token: end at WS
+1783499626.092180 yylex_token: M-Left
+1783499626.092182 yylex_token: end at WS
+1783499626.092183 yylex_token: resize-pane
+1783499626.092184 yylex_token: end at WS
+1783499626.092186 yylex_token: -L
+1783499626.092187 yylex_token: end at WS
+1783499626.092188 yylex_token: 5
+1783499626.092191 cmd_parse_build_commands 0:0: bind
+1783499626.092192 cmd_parse_build_commands 0:1: -N
+1783499626.092194 cmd_parse_build_commands 0:2: Resize the pane left by 5
+1783499626.092196 cmd_parse_build_commands 0:3: -r
+1783499626.092198 cmd_parse_build_commands 0:4: M-Left
+1783499626.092200 cmd_parse_build_commands 0:5 0:0: resize-pane
+1783499626.092201 cmd_parse_build_commands 0:5 0:1: -L
+1783499626.092203 cmd_parse_build_commands 0:5 0:2: 5
+1783499626.092206 cmd_parse_build_commands 0:0: resize-pane
+1783499626.092207 cmd_parse_build_commands 0:1: -L
+1783499626.092209 cmd_parse_build_commands 0:2: 5
+1783499626.092212 args_parse_flags: next -L
+1783499626.092214 args_parse_flags: -L
+1783499626.092215 args_parse_flags: next 5
+1783499626.092217 args_parse: flags end at 2 of 3
+1783499626.092218 args_parse: 2 = 5 (type STRING)
+1783499626.092222 cmd_parse_build_commands: resize-pane -L 5
+1783499626.092223 args_parse_flags: next -N
+1783499626.092225 args_parse_flag_argument: -N = Resize the pane left by 5
+1783499626.092227 args_parse_flags: next -r
+1783499626.092228 args_parse_flags: -r
+1783499626.092230 args_parse_flags: next M-Left
+1783499626.092231 args_parse: flags end at 4 of 6
+1783499626.092233 args_parse: 4 = M-Left (type STRING)
+1783499626.092236 args_parse: 5 = resize-pane -L 5 (type COMMANDS)
+1783499626.092241 cmd_parse_build_commands: bind-key -r -N "Resize the pane left by 5" M-Left { resize-pane -L 5 }
+1783499626.092244 cmdq_get_command: [bind-key/0x58e4724d5e10] group 642
+1783499626.092246 cmdq_append <global>: [bind-key/0x58e4724d5e10]
+1783499626.092249 yylex_token: end at WS
+1783499626.092251 yylex_token: bind
+1783499626.092252 yylex_token: end at WS
+1783499626.092253 yylex_token: -N
+1783499626.092255 yylex_token: end at WS
+1783499626.092257 yylex_token: Resize the pane right by 5
+1783499626.092258 yylex_token: end at WS
+1783499626.092260 yylex_token: -r
+1783499626.092261 yylex_token: end at WS
+1783499626.092263 yylex_token: M-Right
+1783499626.092264 yylex_token: end at WS
+1783499626.092266 yylex_token: resize-pane
+1783499626.092267 yylex_token: end at WS
+1783499626.092268 yylex_token: -R
+1783499626.092270 yylex_token: end at WS
+1783499626.092271 yylex_token: 5
+1783499626.092274 cmd_parse_build_commands 0:0: bind
+1783499626.092275 cmd_parse_build_commands 0:1: -N
+1783499626.092277 cmd_parse_build_commands 0:2: Resize the pane right by 5
+1783499626.092279 cmd_parse_build_commands 0:3: -r
+1783499626.092281 cmd_parse_build_commands 0:4: M-Right
+1783499626.092283 cmd_parse_build_commands 0:5 0:0: resize-pane
+1783499626.092284 cmd_parse_build_commands 0:5 0:1: -R
+1783499626.092289 cmd_parse_build_commands 0:5 0:2: 5
+1783499626.092292 cmd_parse_build_commands 0:0: resize-pane
+1783499626.092294 cmd_parse_build_commands 0:1: -R
+1783499626.092295 cmd_parse_build_commands 0:2: 5
+1783499626.092298 args_parse_flags: next -R
+1783499626.092300 args_parse_flags: -R
+1783499626.092301 args_parse_flags: next 5
+1783499626.092302 args_parse: flags end at 2 of 3
+1783499626.092304 args_parse: 2 = 5 (type STRING)
+1783499626.092307 cmd_parse_build_commands: resize-pane -R 5
+1783499626.092308 args_parse_flags: next -N
+1783499626.092311 args_parse_flag_argument: -N = Resize the pane right by 5
+1783499626.092312 args_parse_flags: next -r
+1783499626.092313 args_parse_flags: -r
+1783499626.092315 args_parse_flags: next M-Right
+1783499626.092316 args_parse: flags end at 4 of 6
+1783499626.092318 args_parse: 4 = M-Right (type STRING)
+1783499626.092321 args_parse: 5 = resize-pane -R 5 (type COMMANDS)
+1783499626.092327 cmd_parse_build_commands: bind-key -r -N "Resize the pane right by 5" M-Right { resize-pane -R 5 }
+1783499626.092329 cmdq_get_command: [bind-key/0x58e4724d6460] group 650
+1783499626.092331 cmdq_append <global>: [bind-key/0x58e4724d6460]
+1783499626.092346 yylex_token: end at WS
+1783499626.092353 yylex_token: bind
+1783499626.092357 yylex_token: end at WS
+1783499626.092359 yylex_token: -N
+1783499626.092361 yylex_token: end at WS
+1783499626.092362 yylex_token: Resize the pane up
+1783499626.092364 yylex_token: end at WS
+1783499626.092365 yylex_token: -r
+1783499626.092367 yylex_token: end at WS
+1783499626.092368 yylex_token: C-Up
+1783499626.092370 yylex_token: end at WS
+1783499626.092371 yylex_token: resize-pane
+1783499626.092373 yylex_token: end at WS
+1783499626.092374 yylex_token: -U
+1783499626.092386 cmd_parse_build_commands 0:0: bind
+1783499626.092389 cmd_parse_build_commands 0:1: -N
+1783499626.092391 cmd_parse_build_commands 0:2: Resize the pane up
+1783499626.092392 cmd_parse_build_commands 0:3: -r
+1783499626.092394 cmd_parse_build_commands 0:4: C-Up
+1783499626.092396 cmd_parse_build_commands 0:5 0:0: resize-pane
+1783499626.092398 cmd_parse_build_commands 0:5 0:1: -U
+1783499626.092401 cmd_parse_build_commands 0:0: resize-pane
+1783499626.092403 cmd_parse_build_commands 0:1: -U
+1783499626.092406 args_parse_flags: next -U
+1783499626.092408 args_parse_flags: -U
+1783499626.092409 args_parse: flags end at 2 of 2
+1783499626.092412 cmd_parse_build_commands: resize-pane -U
+1783499626.092414 args_parse_flags: next -N
+1783499626.092416 args_parse_flag_argument: -N = Resize the pane up
+1783499626.092417 args_parse_flags: next -r
+1783499626.092419 args_parse_flags: -r
+1783499626.092420 args_parse_flags: next C-Up
+1783499626.092422 args_parse: flags end at 4 of 6
+1783499626.092423 args_parse: 4 = C-Up (type STRING)
+1783499626.092426 args_parse: 5 = resize-pane -U (type COMMANDS)
+1783499626.092432 cmd_parse_build_commands: bind-key -r -N "Resize the pane up" C-Up { resize-pane -U }
+1783499626.092436 cmdq_get_command: [bind-key/0x58e4724d61d0] group 658
+1783499626.092442 cmdq_append <global>: [bind-key/0x58e4724d61d0]
+1783499626.092447 yylex_token: end at WS
+1783499626.092448 yylex_token: bind
+1783499626.092450 yylex_token: end at WS
+1783499626.092451 yylex_token: -N
+1783499626.092453 yylex_token: end at WS
+1783499626.092455 yylex_token: Resize the pane down
+1783499626.092456 yylex_token: end at WS
+1783499626.092458 yylex_token: -r
+1783499626.092459 yylex_token: end at WS
+1783499626.092461 yylex_token: C-Down
+1783499626.092462 yylex_token: end at WS
+1783499626.092463 yylex_token: resize-pane
+1783499626.092465 yylex_token: end at WS
+1783499626.092466 yylex_token: -D
+1783499626.092469 cmd_parse_build_commands 0:0: bind
+1783499626.092470 cmd_parse_build_commands 0:1: -N
+1783499626.092472 cmd_parse_build_commands 0:2: Resize the pane down
+1783499626.092474 cmd_parse_build_commands 0:3: -r
+1783499626.092476 cmd_parse_build_commands 0:4: C-Down
+1783499626.092478 cmd_parse_build_commands 0:5 0:0: resize-pane
+1783499626.092479 cmd_parse_build_commands 0:5 0:1: -D
+1783499626.092482 cmd_parse_build_commands 0:0: resize-pane
+1783499626.092488 cmd_parse_build_commands 0:1: -D
+1783499626.092491 args_parse_flags: next -D
+1783499626.092492 args_parse_flags: -D
+1783499626.092494 args_parse: flags end at 2 of 2
+1783499626.092497 cmd_parse_build_commands: resize-pane -D
+1783499626.092498 args_parse_flags: next -N
+1783499626.092501 args_parse_flag_argument: -N = Resize the pane down
+1783499626.092502 args_parse_flags: next -r
+1783499626.092504 args_parse_flags: -r
+1783499626.092505 args_parse_flags: next C-Down
+1783499626.092507 args_parse: flags end at 4 of 6
+1783499626.092508 args_parse: 4 = C-Down (type STRING)
+1783499626.092511 args_parse: 5 = resize-pane -D (type COMMANDS)
+1783499626.092517 cmd_parse_build_commands: bind-key -r -N "Resize the pane down" C-Down { resize-pane -D }
+1783499626.092521 cmdq_get_command: [bind-key/0x58e4724d6a10] group 666
+1783499626.092523 cmdq_append <global>: [bind-key/0x58e4724d6a10]
+1783499626.092525 yylex_token: end at WS
+1783499626.092526 yylex_token: bind
+1783499626.092528 yylex_token: end at WS
+1783499626.092529 yylex_token: -N
+1783499626.092531 yylex_token: end at WS
+1783499626.092533 yylex_token: Resize the pane left
+1783499626.092535 yylex_token: end at WS
+1783499626.092536 yylex_token: -r
+1783499626.092538 yylex_token: end at WS
+1783499626.092539 yylex_token: C-Left
+1783499626.092541 yylex_token: end at WS
+1783499626.092542 yylex_token: resize-pane
+1783499626.092544 yylex_token: end at WS
+1783499626.092545 yylex_token: -L
+1783499626.092547 cmd_parse_build_commands 0:0: bind
+1783499626.092549 cmd_parse_build_commands 0:1: -N
+1783499626.092552 cmd_parse_build_commands 0:2: Resize the pane left
+1783499626.092553 cmd_parse_build_commands 0:3: -r
+1783499626.092555 cmd_parse_build_commands 0:4: C-Left
+1783499626.092557 cmd_parse_build_commands 0:5 0:0: resize-pane
+1783499626.092559 cmd_parse_build_commands 0:5 0:1: -L
+1783499626.092561 cmd_parse_build_commands 0:0: resize-pane
+1783499626.092563 cmd_parse_build_commands 0:1: -L
+1783499626.092567 args_parse_flags: next -L
+1783499626.092568 args_parse_flags: -L
+1783499626.092570 args_parse: flags end at 2 of 2
+1783499626.092573 cmd_parse_build_commands: resize-pane -L
+1783499626.092575 args_parse_flags: next -N
+1783499626.092577 args_parse_flag_argument: -N = Resize the pane left
+1783499626.092579 args_parse_flags: next -r
+1783499626.092581 args_parse_flags: -r
+1783499626.092583 args_parse_flags: next C-Left
+1783499626.092584 args_parse: flags end at 4 of 6
+1783499626.092586 args_parse: 4 = C-Left (type STRING)
+1783499626.092588 args_parse: 5 = resize-pane -L (type COMMANDS)
+1783499626.092594 cmd_parse_build_commands: bind-key -r -N "Resize the pane left" C-Left { resize-pane -L }
+1783499626.092597 cmdq_get_command: [bind-key/0x58e4724d6c40] group 674
+1783499626.092599 cmdq_append <global>: [bind-key/0x58e4724d6c40]
+1783499626.092601 yylex_token: end at WS
+1783499626.092602 yylex_token: bind
+1783499626.092604 yylex_token: end at WS
+1783499626.092605 yylex_token: -N
+1783499626.092607 yylex_token: end at WS
+1783499626.092608 yylex_token: Resize the pane right
+1783499626.092610 yylex_token: end at WS
+1783499626.092611 yylex_token: -r
+1783499626.092613 yylex_token: end at WS
+1783499626.092614 yylex_token: C-Right
+1783499626.092616 yylex_token: end at WS
+1783499626.092618 yylex_token: resize-pane
+1783499626.092619 yylex_token: end at WS
+1783499626.092620 yylex_token: -R
+1783499626.092623 cmd_parse_build_commands 0:0: bind
+1783499626.092624 cmd_parse_build_commands 0:1: -N
+1783499626.092626 cmd_parse_build_commands 0:2: Resize the pane right
+1783499626.092628 cmd_parse_build_commands 0:3: -r
+1783499626.092630 cmd_parse_build_commands 0:4: C-Right
+1783499626.092632 cmd_parse_build_commands 0:5 0:0: resize-pane
+1783499626.092633 cmd_parse_build_commands 0:5 0:1: -R
+1783499626.092636 cmd_parse_build_commands 0:0: resize-pane
+1783499626.092637 cmd_parse_build_commands 0:1: -R
+1783499626.092640 args_parse_flags: next -R
+1783499626.092642 args_parse_flags: -R
+1783499626.092643 args_parse: flags end at 2 of 2
+1783499626.092646 cmd_parse_build_commands: resize-pane -R
+1783499626.092650 args_parse_flags: next -N
+1783499626.092653 args_parse_flag_argument: -N = Resize the pane right
+1783499626.092654 args_parse_flags: next -r
+1783499626.092656 args_parse_flags: -r
+1783499626.092657 args_parse_flags: next C-Right
+1783499626.092659 args_parse: flags end at 4 of 6
+1783499626.092661 args_parse: 4 = C-Right (type STRING)
+1783499626.092663 args_parse: 5 = resize-pane -R (type COMMANDS)
+1783499626.092669 cmd_parse_build_commands: bind-key -r -N "Resize the pane right" C-Right { resize-pane -R }
+1783499626.092673 cmdq_get_command: [bind-key/0x58e4724d6ef0] group 682
+1783499626.092674 cmdq_append <global>: [bind-key/0x58e4724d6ef0]
+1783499626.092683 yylex_token: end at WS
+1783499626.092686 yylex_token: bind
+1783499626.092688 yylex_token: end at WS
+1783499626.092689 yylex_token: <
+1783499626.092691 yylex_token: end at WS
+1783499626.092692 yylex_token: display-menu
+1783499626.092694 yylex_token: end at WS
+1783499626.092695 yylex_token: -xW
+1783499626.092697 yylex_token: end at WS
+1783499626.092698 yylex_token: -yW
+1783499626.092700 yylex_token: end at WS
+1783499626.092701 yylex_token: -T
+1783499626.092703 yylex_token: end at WS
+1783499626.092706 yylex_token: #[align=centre]#{window_index}:#{window_name}
+1783499626.092708 yylex_token: end at WS
+1783499626.092711 yylex_token: #{?#{>:#{session_windows},1},,-}Swap Left
+1783499626.092712 yylex_token: end at WS
+1783499626.092713 yylex_token: l
+1783499626.092715 yylex_token: end at WS
+1783499626.092717 yylex_token: swap-window
+1783499626.092718 yylex_token: end at }
+1783499626.092720 yylex_token: -t:-1
+1783499626.092723 yylex_token: end at WS
+1783499626.092725 yylex_token: #{?#{>:#{session_windows},1},,-}Swap Right
+1783499626.092726 yylex_token: end at WS
+1783499626.092728 yylex_token: r
+1783499626.092729 yylex_token: end at WS
+1783499626.092731 yylex_token: swap-window
+1783499626.092732 yylex_token: end at }
+1783499626.092734 yylex_token: -t:+1
+1783499626.092736 yylex_token: end at WS
+1783499626.092738 yylex_token: #{?pane_marked_set,,-}Swap Marked
+1783499626.092740 yylex_token: end at WS
+1783499626.092741 yylex_token: s
+1783499626.092743 yylex_token: end at }
+1783499626.092744 yylex_token: swap-window
+1783499626.092746 yylex_token: end at WS
+1783499626.092747 yylex_token: 
+1783499626.092749 yylex_token: end at WS
+1783499626.092750 yylex_token: Kill
+1783499626.092751 yylex_token: end at WS
+1783499626.092753 yylex_token: X
+1783499626.092754 yylex_token: end at }
+1783499626.092756 yylex_token: kill-window
+1783499626.092758 yylex_token: end at WS
+1783499626.092759 yylex_token: Respawn
+1783499626.092760 yylex_token: end at WS
+1783499626.092762 yylex_token: R
+1783499626.092763 yylex_token: end at WS
+1783499626.092765 yylex_token: respawn-window
+1783499626.092766 yylex_token: end at }
+1783499626.092767 yylex_token: -k
+1783499626.092770 yylex_token: end at WS
+1783499626.092771 yylex_token: #{?pane_marked,Unmark,Mark}
+1783499626.092773 yylex_token: end at WS
+1783499626.092774 yylex_token: m
+1783499626.092776 yylex_token: end at WS
+1783499626.092777 yylex_token: select-pane
+1783499626.092779 yylex_token: end at }
+1783499626.092780 yylex_token: -m
+1783499626.092782 yylex_token: end at WS
+1783499626.092783 yylex_token: Rename
+1783499626.092807 yylex_token: end at WS
+1783499626.092813 yylex_token: n
+1783499626.092817 yylex_token: end at WS
+1783499626.092819 yylex_token: command-prompt
+1783499626.092821 yylex_token: end at WS
+1783499626.092823 yylex_token: -FI
+1783499626.092825 yylex_token: end at WS
+1783499626.092826 yylex_token: #W
+1783499626.092828 yylex_token: end at WS
+1783499626.092830 yylex_token: rename-window
+1783499626.092832 yylex_token: end at WS
+1783499626.092833 yylex_token: -t
+1783499626.092835 yylex_token: end at WS
+1783499626.092837 yylex_token: #{window_id}
+1783499626.092839 yylex_token: end at WS
+1783499626.092840 yylex_token: --
+1783499626.092842 yylex_token: end at }
+1783499626.092843 yylex_token: %%
+1783499626.092846 yylex_token: end at WS
+1783499626.092847 yylex_token: 
+1783499626.092849 yylex_token: end at WS
+1783499626.092857 yylex_token: New After
+1783499626.092867 yylex_token: end at WS
+1783499626.092868 yylex_token: w
+1783499626.092870 yylex_token: end at WS
+1783499626.092872 yylex_token: new-window
+1783499626.092874 yylex_token: end at }
+1783499626.092875 yylex_token: -a
+1783499626.092877 yylex_token: end at WS
+1783499626.092879 yylex_token: New At End
+1783499626.092880 yylex_token: end at WS
+1783499626.092882 yylex_token: W
+1783499626.092884 yylex_token: end at }
+1783499626.092885 yylex_token: new-window
+1783499626.092890 cmd_parse_build_commands 0:0: bind
+1783499626.092891 cmd_parse_build_commands 0:1: <
+1783499626.092894 cmd_parse_build_commands 0:2 0:0: display-menu
+1783499626.092896 cmd_parse_build_commands 0:2 0:1: -xW
+1783499626.092898 cmd_parse_build_commands 0:2 0:2: -yW
+1783499626.092899 cmd_parse_build_commands 0:2 0:3: -T
+1783499626.092902 cmd_parse_build_commands 0:2 0:4: #[align=centre]#{window_index}:#{window_name}
+1783499626.092904 cmd_parse_build_commands 0:2 0:5: #{?#{>:#{session_windows},1},,-}Swap Left
+1783499626.092906 cmd_parse_build_commands 0:2 0:6: l
+1783499626.092908 cmd_parse_build_commands 0:2 0:7 0:0: swap-window
+1783499626.092910 cmd_parse_build_commands 0:2 0:7 0:1: -t:-1
+1783499626.092913 cmd_parse_build_commands 0:2 0:8: #{?#{>:#{session_windows},1},,-}Swap Right
+1783499626.092915 cmd_parse_build_commands 0:2 0:9: r
+1783499626.092917 cmd_parse_build_commands 0:2 0:10 0:0: swap-window
+1783499626.092919 cmd_parse_build_commands 0:2 0:10 0:1: -t:+1
+1783499626.092921 cmd_parse_build_commands 0:2 0:11: #{?pane_marked_set,,-}Swap Marked
+1783499626.092923 cmd_parse_build_commands 0:2 0:12: s
+1783499626.092925 cmd_parse_build_commands 0:2 0:13 0:0: swap-window
+1783499626.092927 cmd_parse_build_commands 0:2 0:14: 
+1783499626.092929 cmd_parse_build_commands 0:2 0:15: Kill
+1783499626.092930 cmd_parse_build_commands 0:2 0:16: X
+1783499626.092933 cmd_parse_build_commands 0:2 0:17 0:0: kill-window
+1783499626.092934 cmd_parse_build_commands 0:2 0:18: Respawn
+1783499626.092936 cmd_parse_build_commands 0:2 0:19: R
+1783499626.092940 cmd_parse_build_commands 0:2 0:20 0:0: respawn-window
+1783499626.092942 cmd_parse_build_commands 0:2 0:20 0:1: -k
+1783499626.092944 cmd_parse_build_commands 0:2 0:21: #{?pane_marked,Unmark,Mark}
+1783499626.092946 cmd_parse_build_commands 0:2 0:22: m
+1783499626.092948 cmd_parse_build_commands 0:2 0:23 0:0: select-pane
+1783499626.092950 cmd_parse_build_commands 0:2 0:23 0:1: -m
+1783499626.092952 cmd_parse_build_commands 0:2 0:24: Rename
+1783499626.092954 cmd_parse_build_commands 0:2 0:25: n
+1783499626.092956 cmd_parse_build_commands 0:2 0:26 0:0: command-prompt
+1783499626.092958 cmd_parse_build_commands 0:2 0:26 0:1: -FI
+1783499626.092960 cmd_parse_build_commands 0:2 0:26 0:2: #W
+1783499626.092962 cmd_parse_build_commands 0:2 0:26 0:3 0:0: rename-window
+1783499626.092964 cmd_parse_build_commands 0:2 0:26 0:3 0:1: -t
+1783499626.092966 cmd_parse_build_commands 0:2 0:26 0:3 0:2: #{window_id}
+1783499626.092968 cmd_parse_build_commands 0:2 0:26 0:3 0:3: --
+1783499626.092970 cmd_parse_build_commands 0:2 0:26 0:3 0:4: %%
+1783499626.092971 cmd_parse_build_commands 0:2 0:27: 
+1783499626.092973 cmd_parse_build_commands 0:2 0:28: New After
+1783499626.092975 cmd_parse_build_commands 0:2 0:29: w
+1783499626.092977 cmd_parse_build_commands 0:2 0:30 0:0: new-window
+1783499626.092979 cmd_parse_build_commands 0:2 0:30 0:1: -a
+1783499626.092981 cmd_parse_build_commands 0:2 0:31: New At End
+1783499626.092982 cmd_parse_build_commands 0:2 0:32: W
+1783499626.092984 cmd_parse_build_commands 0:2 0:33 0:0: new-window
+1783499626.092989 cmd_parse_build_commands 0:0: display-menu
+1783499626.092991 cmd_parse_build_commands 0:1: -xW
+1783499626.092993 cmd_parse_build_commands 0:2: -yW
+1783499626.092994 cmd_parse_build_commands 0:3: -T
+1783499626.092997 cmd_parse_build_commands 0:4: #[align=centre]#{window_index}:#{window_name}
+1783499626.093000 cmd_parse_build_commands 0:5: #{?#{>:#{session_windows},1},,-}Swap Left
+1783499626.093002 cmd_parse_build_commands 0:6: l
+1783499626.093004 cmd_parse_build_commands 0:7 0:0: swap-window
+1783499626.093009 cmd_parse_build_commands 0:7 0:1: -t:-1
+1783499626.093011 cmd_parse_build_commands 0:8: #{?#{>:#{session_windows},1},,-}Swap Right
+1783499626.093013 cmd_parse_build_commands 0:9: r
+1783499626.093015 cmd_parse_build_commands 0:10 0:0: swap-window
+1783499626.093017 cmd_parse_build_commands 0:10 0:1: -t:+1
+1783499626.093019 cmd_parse_build_commands 0:11: #{?pane_marked_set,,-}Swap Marked
+1783499626.093021 cmd_parse_build_commands 0:12: s
+1783499626.093023 cmd_parse_build_commands 0:13 0:0: swap-window
+1783499626.093025 cmd_parse_build_commands 0:14: 
+1783499626.093026 cmd_parse_build_commands 0:15: Kill
+1783499626.093028 cmd_parse_build_commands 0:16: X
+1783499626.093030 cmd_parse_build_commands 0:17 0:0: kill-window
+1783499626.093032 cmd_parse_build_commands 0:18: Respawn
+1783499626.093033 cmd_parse_build_commands 0:19: R
+1783499626.093035 cmd_parse_build_commands 0:20 0:0: respawn-window
+1783499626.093037 cmd_parse_build_commands 0:20 0:1: -k
+1783499626.093039 cmd_parse_build_commands 0:21: #{?pane_marked,Unmark,Mark}
+1783499626.093041 cmd_parse_build_commands 0:22: m
+1783499626.093043 cmd_parse_build_commands 0:23 0:0: select-pane
+1783499626.093045 cmd_parse_build_commands 0:23 0:1: -m
+1783499626.093046 cmd_parse_build_commands 0:24: Rename
+1783499626.093048 cmd_parse_build_commands 0:25: n
+1783499626.093050 cmd_parse_build_commands 0:26 0:0: command-prompt
+1783499626.093052 cmd_parse_build_commands 0:26 0:1: -FI
+1783499626.093053 cmd_parse_build_commands 0:26 0:2: #W
+1783499626.093055 cmd_parse_build_commands 0:26 0:3 0:0: rename-window
+1783499626.093057 cmd_parse_build_commands 0:26 0:3 0:1: -t
+1783499626.093059 cmd_parse_build_commands 0:26 0:3 0:2: #{window_id}
+1783499626.093061 cmd_parse_build_commands 0:26 0:3 0:3: --
+1783499626.093063 cmd_parse_build_commands 0:26 0:3 0:4: %%
+1783499626.093065 cmd_parse_build_commands 0:27: 
+1783499626.093066 cmd_parse_build_commands 0:28: New After
+1783499626.093068 cmd_parse_build_commands 0:29: w
+1783499626.093070 cmd_parse_build_commands 0:30 0:0: new-window
+1783499626.093072 cmd_parse_build_commands 0:30 0:1: -a
+1783499626.093074 cmd_parse_build_commands 0:31: New At End
+1783499626.093075 cmd_parse_build_commands 0:32: W
+1783499626.093077 cmd_parse_build_commands 0:33 0:0: new-window
+1783499626.093082 cmd_parse_build_commands 0:0: swap-window
+1783499626.093084 cmd_parse_build_commands 0:1: -t:-1
+1783499626.093089 args_parse_flags: next -t:-1
+1783499626.093091 args_parse_flag_argument: -t = :-1
+1783499626.093093 args_parse: flags end at 2 of 2
+1783499626.093098 cmd_parse_build_commands: swap-window -t :-1
+1783499626.093101 cmd_parse_build_commands 0:0: swap-window
+1783499626.093103 cmd_parse_build_commands 0:1: -t:+1
+1783499626.093107 args_parse_flags: next -t:+1
+1783499626.093109 args_parse_flag_argument: -t = :+1
+1783499626.093116 args_parse: flags end at 2 of 2
+1783499626.093123 cmd_parse_build_commands: swap-window -t :+1
+1783499626.093131 cmd_parse_build_commands 0:0: swap-window
+1783499626.093137 args_parse: flags end at 1 of 1
+1783499626.093140 cmd_parse_build_commands: swap-window
+1783499626.093147 cmd_parse_build_commands 0:0: kill-window
+1783499626.093153 args_parse: flags end at 1 of 1
+1783499626.093156 cmd_parse_build_commands: kill-window
+1783499626.093159 cmd_parse_build_commands 0:0: respawn-window
+1783499626.093161 cmd_parse_build_commands 0:1: -k
+1783499626.093164 args_parse_flags: next -k
+1783499626.093166 args_parse_flags: -k
+1783499626.093168 args_parse: flags end at 2 of 2
+1783499626.093171 cmd_parse_build_commands: respawn-window -k
+1783499626.093179 cmd_parse_build_commands 0:0: select-pane
+1783499626.093209 cmd_parse_build_commands 0:1: -m
+1783499626.093225 args_parse_flags: next -m
+1783499626.093227 args_parse_flags: -m
+1783499626.093229 args_parse: flags end at 2 of 2
+1783499626.093233 cmd_parse_build_commands: select-pane -m
+1783499626.093254 cmd_parse_build_commands 0:0: command-prompt
+1783499626.093258 cmd_parse_build_commands 0:1: -FI
+1783499626.093260 cmd_parse_build_commands 0:2: #W
+1783499626.093263 cmd_parse_build_commands 0:3 0:0: rename-window
+1783499626.093269 cmd_parse_build_commands 0:3 0:1: -t
+1783499626.093272 cmd_parse_build_commands 0:3 0:2: #{window_id}
+1783499626.093274 cmd_parse_build_commands 0:3 0:3: --
+1783499626.093276 cmd_parse_build_commands 0:3 0:4: %%
+1783499626.093279 cmd_parse_build_commands 0:0: rename-window
+1783499626.093281 cmd_parse_build_commands 0:1: -t
+1783499626.093283 cmd_parse_build_commands 0:2: #{window_id}
+1783499626.093285 cmd_parse_build_commands 0:3: --
+1783499626.093287 cmd_parse_build_commands 0:4: %%
+1783499626.093291 args_parse_flags: next -t
+1783499626.093294 args_parse_flag_argument: -t = #{window_id}
+1783499626.093296 args_parse_flags: next --
+1783499626.093298 args_parse: flags end at 4 of 5
+1783499626.093300 args_parse: 4 = %% (type STRING)
+1783499626.093306 cmd_parse_build_commands: rename-window -t "#{window_id}" "%%"
+1783499626.093308 args_parse_flags: next -FI
+1783499626.093309 args_parse_flags: -F
+1783499626.093311 args_parse_flag_argument: -I = #W
+1783499626.093313 args_parse: flags end at 3 of 4
+1783499626.093318 args_parse: 3 = rename-window -t "#{window_id}" "%%" (type COMMANDS)
+1783499626.093324 cmd_parse_build_commands: command-prompt -F -I "#W" { rename-window -t "#{window_id}" "%%" }
+1783499626.093329 cmd_parse_build_commands 0:0: new-window
+1783499626.093331 cmd_parse_build_commands 0:1: -a
+1783499626.093334 args_parse_flags: next -a
+1783499626.093336 args_parse_flags: -a
+1783499626.093337 args_parse: flags end at 2 of 2
+1783499626.093340 cmd_parse_build_commands: new-window -a
+1783499626.093343 cmd_parse_build_commands 0:0: new-window
+1783499626.093347 args_parse: flags end at 1 of 1
+1783499626.093350 cmd_parse_build_commands: new-window
+1783499626.093352 args_parse_flags: next -xW
+1783499626.093355 args_parse_flag_argument: -x = W
+1783499626.093357 args_parse_flags: next -yW
+1783499626.093359 args_parse_flag_argument: -y = W
+1783499626.093360 args_parse_flags: next -T
+1783499626.093363 args_parse_flag_argument: -T = #[align=centre]#{window_index}:#{window_name}
+1783499626.093365 args_parse_flags: next #{?#{>:#{session_windows},1},,-}Swap Left
+1783499626.093367 args_parse: flags end at 5 of 34
+1783499626.093369 args_parse: 5 = #{?#{>:#{session_windows},1},,-}Swap Left (type STRING)
+1783499626.093371 args_parse: 6 = l (type STRING)
+1783499626.093375 args_parse: 7 = swap-window -t :-1 (type COMMANDS)
+1783499626.093378 args_parse: 8 = #{?#{>:#{session_windows},1},,-}Swap Right (type STRING)
+1783499626.093380 args_parse: 9 = r (type STRING)
+1783499626.093383 args_parse: 10 = swap-window -t :+1 (type COMMANDS)
+1783499626.093386 args_parse: 11 = #{?pane_marked_set,,-}Swap Marked (type STRING)
+1783499626.093388 args_parse: 12 = s (type STRING)
+1783499626.093391 args_parse: 13 = swap-window (type COMMANDS)
+1783499626.093393 args_parse: 14 =  (type STRING)
+1783499626.093396 args_parse: 15 = Kill (type STRING)
+1783499626.093398 args_parse: 16 = X (type STRING)
+1783499626.093401 args_parse: 17 = kill-window (type COMMANDS)
+1783499626.093404 args_parse: 18 = Respawn (type STRING)
+1783499626.093406 args_parse: 19 = R (type STRING)
+1783499626.093410 args_parse: 20 = respawn-window -k (type COMMANDS)
+1783499626.093413 args_parse: 21 = #{?pane_marked,Unmark,Mark} (type STRING)
+1783499626.093416 args_parse: 22 = m (type STRING)
+1783499626.093418 args_parse: 23 = select-pane -m (type COMMANDS)
+1783499626.093421 args_parse: 24 = Rename (type STRING)
+1783499626.093423 args_parse: 25 = n (type STRING)
+1783499626.093432 args_parse: 26 = command-prompt -F -I "#W" { rename-window -t "#{window_id}" "%%" } (type COMMANDS)
+1783499626.093434 args_parse: 27 =  (type STRING)
+1783499626.093437 args_parse: 28 = New After (type STRING)
+1783499626.093439 args_parse: 29 = w (type STRING)
+1783499626.093442 args_parse: 30 = new-window -a (type COMMANDS)
+1783499626.093447 args_parse: 31 = New At End (type STRING)
+1783499626.093450 args_parse: 32 = W (type STRING)
+1783499626.093459 args_parse: 33 = new-window (type COMMANDS)
+1783499626.093506 cmd_parse_build_commands: display-menu -T "#[align=centre]#{window_index}:#{window_name}" -x W -y W "#{?#{>:#{session_windows},1},,-}Swap Left" l { swap-window -t :-1 } "#{?#{>:#{session_windows},1},,-}Swap Right" r { swap-window -t :+1 } "#{?pane_marked_set,,-}Swap Marked" s { swap-window } '' Kill X { kill-window } Respawn R { respawn-window -k } "#{?pane_marked,Unmark,Mark}" m { select-pane -m } Rename n { command-prompt -F -I "#W" { rename-window -t "#{window_id}" "%%" } } '' "New After" w { new-window -a } "New At End" W { new-window }
+1783499626.093512 args_parse_flags: next <
+1783499626.093515 args_parse: flags end at 1 of 3
+1783499626.093516 args_parse: 1 = < (type STRING)
+1783499626.093557 args_parse: 2 = display-menu -T "#[align=centre]#{window_index}:#{window_name}" -x W -y W "#{?#{>:#{session_windows},1},,-}Swap Left" l { swap-window -t :-1 } "#{?#{>:#{session_windows},1},,-}Swap Right" r { swap-window -t :+1 } "#{?pane_marked_set,,-}Swap Marked" s { swap-window } '' Kill X { kill-window } Respawn R { respawn-window -k } "#{?pane_marked,Unmark,Mark}" m { select-pane -m } Rename n { command-prompt -F -I "#W" { rename-window -t "#{window_id}" "%%" } } '' "New After" w { new-window -a } "New At End" W { new-window } (type COMMANDS)
+1783499626.093605 cmd_parse_build_commands: bind-key < { display-menu -T "#[align=centre]#{window_index}:#{window_name}" -x W -y W "#{?#{>:#{session_windows},1},,-}Swap Left" l { swap-window -t :-1 } "#{?#{>:#{session_windows},1},,-}Swap Right" r { swap-window -t :+1 } "#{?pane_marked_set,,-}Swap Marked" s { swap-window } '' Kill X { kill-window } Respawn R { respawn-window -k } "#{?pane_marked,Unmark,Mark}" m { select-pane -m } Rename n { command-prompt -F -I "#W" { rename-window -t "#{window_id}" "%%" } } '' "New After" w { new-window -a } "New At End" W { new-window } }
+1783499626.093618 cmdq_get_command: [bind-key/0x58e4724dcae0] group 690
+1783499626.093620 cmdq_append <global>: [bind-key/0x58e4724dcae0]
+1783499626.093681 yylex_token: end at WS
+1783499626.093688 yylex_token: bind
+1783499626.093692 yylex_token: end at WS
+1783499626.093694 yylex_token: >
+1783499626.093696 yylex_token: end at WS
+1783499626.093698 yylex_token: display-menu
+1783499626.093700 yylex_token: end at WS
+1783499626.093701 yylex_token: -xP
+1783499626.093703 yylex_token: end at WS
+1783499626.093704 yylex_token: -yP
+1783499626.093706 yylex_token: end at WS
+1783499626.093708 yylex_token: -T
+1783499626.093710 yylex_token: end at WS
+1783499626.093712 yylex_token: #[align=centre]#{pane_index} (#{pane_id})
+1783499626.093715 yylex_token: end at WS
+1783499626.093718 yylex_token: #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,}
+1783499626.093720 yylex_token: end at WS
+1783499626.093721 yylex_token: <
+1783499626.093723 yylex_token: end at WS
+1783499626.093724 yylex_token: send
+1783499626.093726 yylex_token: end at WS
+1783499626.093727 yylex_token: -X
+1783499626.093729 yylex_token: end at }
+1783499626.093731 yylex_token: history-top
+1783499626.093734 yylex_token: end at WS
+1783499626.093737 yylex_token: #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Bottom,}
+1783499626.093738 yylex_token: end at WS
+1783499626.093740 yylex_token: >
+1783499626.093741 yylex_token: end at WS
+1783499626.093743 yylex_token: send
+1783499626.093744 yylex_token: end at WS
+1783499626.093745 yylex_token: -X
+1783499626.093747 yylex_token: end at }
+1783499626.093749 yylex_token: history-bottom
+1783499626.093751 yylex_token: end at WS
+1783499626.093753 yylex_token: 
+1783499626.093756 yylex_token: end at WS
+1783499626.093758 yylex_token: #{?mouse_word,Search For #[underscore]#{=/9/...:mouse_word},}
+1783499626.093760 yylex_token: end at WS
+1783499626.093761 yylex_token: C-r
+1783499626.093763 yylex_token: end at WS
+1783499626.093764 yylex_token: if
+1783499626.093766 yylex_token: end at WS
+1783499626.093767 yylex_token: -F
+1783499626.093769 yylex_token: end at WS
+1783499626.093771 yylex_token: #{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}
+1783499626.093773 yylex_token: end at ;
+1783499626.093775 yylex_token: copy-mode -t=
+1783499626.093777 yylex_token: end at WS
+1783499626.093778 yylex_token: send
+1783499626.093780 yylex_token: end at WS
+1783499626.093788 yylex_token: -Xt=
+1783499626.093791 yylex_token: end at WS
+1783499626.093792 yylex_token: search-backward
+1783499626.093794 yylex_token: end at }
+1783499626.093796 yylex_token: #{q:mouse_word}
+1783499626.093799 yylex_token: end at WS
+1783499626.093802 yylex_token: #{?mouse_word,Type #[underscore]#{=/9/...:mouse_word},}
+1783499626.093804 yylex_token: end at WS
+1783499626.093805 yylex_token: C-y
+1783499626.093807 yylex_token: end at WS
+1783499626.093808 yylex_token: copy-mode
+1783499626.093810 yylex_token: end at ;
+1783499626.093811 yylex_token: -q
+1783499626.093813 yylex_token: end at WS
+1783499626.093815 yylex_token: send-keys
+1783499626.093816 yylex_token: end at WS
+1783499626.093817 yylex_token: -l
+1783499626.093819 yylex_token: end at WS
+1783499626.093820 yylex_token: --
+1783499626.093822 yylex_token: end at }
+1783499626.093824 yylex_token: #{q:mouse_word}
+1783499626.093827 yylex_token: end at WS
+1783499626.093829 yylex_token: #{?mouse_word,Copy #[underscore]#{=/9/...:mouse_word},}
+1783499626.093831 yylex_token: end at WS
+1783499626.093832 yylex_token: c
+1783499626.093834 yylex_token: end at WS
+1783499626.093835 yylex_token: copy-mode
+1783499626.093837 yylex_token: end at ;
+1783499626.093838 yylex_token: -q
+1783499626.093840 yylex_token: end at WS
+1783499626.093841 yylex_token: set-buffer
+1783499626.093843 yylex_token: end at WS
+1783499626.093844 yylex_token: --
+1783499626.093846 yylex_token: end at }
+1783499626.093847 yylex_token: #{q:mouse_word}
+1783499626.093849 yylex_token: end at WS
+1783499626.093851 yylex_token: #{?mouse_line,Copy Line,}
+1783499626.093853 yylex_token: end at WS
+1783499626.093854 yylex_token: l
+1783499626.093856 yylex_token: end at WS
+1783499626.093857 yylex_token: copy-mode
+1783499626.093859 yylex_token: end at ;
+1783499626.093860 yylex_token: -q
+1783499626.093862 yylex_token: end at WS
+1783499626.093863 yylex_token: set-buffer
+1783499626.093864 yylex_token: end at WS
+1783499626.093866 yylex_token: --
+1783499626.093867 yylex_token: end at }
+1783499626.093869 yylex_token: #{q:mouse_line}
+1783499626.093871 yylex_token: end at WS
+1783499626.093872 yylex_token: 
+1783499626.093875 yylex_token: end at WS
+1783499626.093880 yylex_token: #{?mouse_hyperlink,Type #[underscore]#{=/9/...:mouse_hyperlink},}
+1783499626.093882 yylex_token: end at WS
+1783499626.093883 yylex_token: C-h
+1783499626.093885 yylex_token: end at WS
+1783499626.093887 yylex_token: copy-mode
+1783499626.093888 yylex_token: end at ;
+1783499626.093889 yylex_token: -q
+1783499626.093891 yylex_token: end at WS
+1783499626.093893 yylex_token: send-keys
+1783499626.093894 yylex_token: end at WS
+1783499626.093895 yylex_token: -l
+1783499626.093897 yylex_token: end at WS
+1783499626.093898 yylex_token: --
+1783499626.093900 yylex_token: end at }
+1783499626.093902 yylex_token: #{q:mouse_hyperlink}
+1783499626.093905 yylex_token: end at WS
+1783499626.093908 yylex_token: #{?mouse_hyperlink,Copy #[underscore]#{=/9/...:mouse_hyperlink},}
+1783499626.093909 yylex_token: end at WS
+1783499626.093911 yylex_token: h
+1783499626.093912 yylex_token: end at WS
+1783499626.093914 yylex_token: copy-mode
+1783499626.093915 yylex_token: end at ;
+1783499626.093916 yylex_token: -q
+1783499626.093918 yylex_token: end at WS
+1783499626.093920 yylex_token: set-buffer
+1783499626.093921 yylex_token: end at WS
+1783499626.093922 yylex_token: --
+1783499626.093924 yylex_token: end at }
+1783499626.093926 yylex_token: #{q:mouse_hyperlink}
+1783499626.093927 yylex_token: end at WS
+1783499626.093929 yylex_token: 
+1783499626.093930 yylex_token: end at WS
+1783499626.093932 yylex_token: Horizontal Split
+1783499626.093933 yylex_token: end at WS
+1783499626.093935 yylex_token: h
+1783499626.093936 yylex_token: end at WS
+1783499626.093938 yylex_token: split-window
+1783499626.093939 yylex_token: end at }
+1783499626.093941 yylex_token: -h
+1783499626.093943 yylex_token: end at WS
+1783499626.093944 yylex_token: Vertical Split
+1783499626.093946 yylex_token: end at WS
+1783499626.093947 yylex_token: v
+1783499626.093949 yylex_token: end at WS
+1783499626.093950 yylex_token: split-window
+1783499626.093955 yylex_token: end at }
+1783499626.093957 yylex_token: -v
+1783499626.093959 yylex_token: end at WS
+1783499626.093960 yylex_token: 
+1783499626.093969 yylex_token: end at WS
+1783499626.093976 yylex_token: #{?#{>:#{window_panes},1},,-}Swap Up
+1783499626.093978 yylex_token: end at WS
+1783499626.093979 yylex_token: u
+1783499626.093981 yylex_token: end at WS
+1783499626.093983 yylex_token: swap-pane
+1783499626.093984 yylex_token: end at }
+1783499626.093985 yylex_token: -U
+1783499626.093988 yylex_token: end at WS
+1783499626.093990 yylex_token: #{?#{>:#{window_panes},1},,-}Swap Down
+1783499626.093992 yylex_token: end at WS
+1783499626.093993 yylex_token: d
+1783499626.093995 yylex_token: end at WS
+1783499626.093996 yylex_token: swap-pane
+1783499626.093998 yylex_token: end at }
+1783499626.093999 yylex_token: -D
+1783499626.094001 yylex_token: end at WS
+1783499626.094003 yylex_token: #{?pane_marked_set,,-}Swap Marked
+1783499626.094005 yylex_token: end at WS
+1783499626.094006 yylex_token: s
+1783499626.094008 yylex_token: end at }
+1783499626.094009 yylex_token: swap-pane
+1783499626.094011 yylex_token: end at WS
+1783499626.094012 yylex_token: 
+1783499626.094014 yylex_token: end at WS
+1783499626.094015 yylex_token: Kill
+1783499626.094017 yylex_token: end at WS
+1783499626.094018 yylex_token: X
+1783499626.094020 yylex_token: end at }
+1783499626.094021 yylex_token: kill-pane
+1783499626.094023 yylex_token: end at WS
+1783499626.094024 yylex_token: Respawn
+1783499626.094026 yylex_token: end at WS
+1783499626.094027 yylex_token: R
+1783499626.094029 yylex_token: end at WS
+1783499626.094030 yylex_token: respawn-pane
+1783499626.094032 yylex_token: end at }
+1783499626.094033 yylex_token: -k
+1783499626.094035 yylex_token: end at WS
+1783499626.094037 yylex_token: #{?pane_marked,Unmark,Mark}
+1783499626.094039 yylex_token: end at WS
+1783499626.094040 yylex_token: m
+1783499626.094042 yylex_token: end at WS
+1783499626.094043 yylex_token: select-pane
+1783499626.094044 yylex_token: end at }
+1783499626.094046 yylex_token: -m
+1783499626.094049 yylex_token: end at WS
+1783499626.094051 yylex_token: #{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom}
+1783499626.094053 yylex_token: end at WS
+1783499626.094054 yylex_token: z
+1783499626.094056 yylex_token: end at WS
+1783499626.094058 yylex_token: resize-pane
+1783499626.094059 yylex_token: end at }
+1783499626.094060 yylex_token: -Z
+1783499626.094065 cmd_parse_build_commands 0:0: bind
+1783499626.094066 cmd_parse_build_commands 0:1: >
+1783499626.094069 cmd_parse_build_commands 0:2 0:0: display-menu
+1783499626.094071 cmd_parse_build_commands 0:2 0:1: -xP
+1783499626.094073 cmd_parse_build_commands 0:2 0:2: -yP
+1783499626.094074 cmd_parse_build_commands 0:2 0:3: -T
+1783499626.094077 cmd_parse_build_commands 0:2 0:4: #[align=centre]#{pane_index} (#{pane_id})
+1783499626.094079 cmd_parse_build_commands 0:2 0:5: #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,}
+1783499626.094081 cmd_parse_build_commands 0:2 0:6: <
+1783499626.094083 cmd_parse_build_commands 0:2 0:7 0:0: send
+1783499626.094085 cmd_parse_build_commands 0:2 0:7 0:1: -X
+1783499626.094087 cmd_parse_build_commands 0:2 0:7 0:2: history-top
+1783499626.094090 cmd_parse_build_commands 0:2 0:8: #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Bottom,}
+1783499626.094092 cmd_parse_build_commands 0:2 0:9: >
+1783499626.094094 cmd_parse_build_commands 0:2 0:10 0:0: send
+1783499626.094096 cmd_parse_build_commands 0:2 0:10 0:1: -X
+1783499626.094098 cmd_parse_build_commands 0:2 0:10 0:2: history-bottom
+1783499626.094100 cmd_parse_build_commands 0:2 0:11: 
+1783499626.094102 cmd_parse_build_commands 0:2 0:12: #{?mouse_word,Search For #[underscore]#{=/9/...:mouse_word},}
+1783499626.094104 cmd_parse_build_commands 0:2 0:13: C-r
+1783499626.094106 cmd_parse_build_commands 0:2 0:14 0:0: if
+1783499626.094108 cmd_parse_build_commands 0:2 0:14 0:1: -F
+1783499626.094112 cmd_parse_build_commands 0:2 0:14 0:2: #{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}
+1783499626.094114 cmd_parse_build_commands 0:2 0:14 0:3: copy-mode -t=
+1783499626.094116 cmd_parse_build_commands 0:2 0:14 1:0: send
+1783499626.094193 cmd_parse_build_commands 0:2 0:14 1:1: -Xt=
+1783499626.094200 cmd_parse_build_commands 0:2 0:14 1:2: search-backward
+1783499626.094203 cmd_parse_build_commands 0:2 0:14 1:3: #{q:mouse_word}
+1783499626.094206 cmd_parse_build_commands 0:2 0:15: #{?mouse_word,Type #[underscore]#{=/9/...:mouse_word},}
+1783499626.094209 cmd_parse_build_commands 0:2 0:16: C-y
+1783499626.094211 cmd_parse_build_commands 0:2 0:17 0:0: copy-mode
+1783499626.094213 cmd_parse_build_commands 0:2 0:17 0:1: -q
+1783499626.094216 cmd_parse_build_commands 0:2 0:17 1:0: send-keys
+1783499626.094218 cmd_parse_build_commands 0:2 0:17 1:1: -l
+1783499626.094220 cmd_parse_build_commands 0:2 0:17 1:2: --
+1783499626.094222 cmd_parse_build_commands 0:2 0:17 1:3: #{q:mouse_word}
+1783499626.094225 cmd_parse_build_commands 0:2 0:18: #{?mouse_word,Copy #[underscore]#{=/9/...:mouse_word},}
+1783499626.094227 cmd_parse_build_commands 0:2 0:19: c
+1783499626.094229 cmd_parse_build_commands 0:2 0:20 0:0: copy-mode
+1783499626.094231 cmd_parse_build_commands 0:2 0:20 0:1: -q
+1783499626.094233 cmd_parse_build_commands 0:2 0:20 1:0: set-buffer
+1783499626.094235 cmd_parse_build_commands 0:2 0:20 1:1: --
+1783499626.094237 cmd_parse_build_commands 0:2 0:20 1:2: #{q:mouse_word}
+1783499626.094240 cmd_parse_build_commands 0:2 0:21: #{?mouse_line,Copy Line,}
+1783499626.094241 cmd_parse_build_commands 0:2 0:22: l
+1783499626.094244 cmd_parse_build_commands 0:2 0:23 0:0: copy-mode
+1783499626.094246 cmd_parse_build_commands 0:2 0:23 0:1: -q
+1783499626.094249 cmd_parse_build_commands 0:2 0:23 1:0: set-buffer
+1783499626.094251 cmd_parse_build_commands 0:2 0:23 1:1: --
+1783499626.094253 cmd_parse_build_commands 0:2 0:23 1:2: #{q:mouse_line}
+1783499626.094255 cmd_parse_build_commands 0:2 0:24: 
+1783499626.094258 cmd_parse_build_commands 0:2 0:25: #{?mouse_hyperlink,Type #[underscore]#{=/9/...:mouse_hyperlink},}
+1783499626.094260 cmd_parse_build_commands 0:2 0:26: C-h
+1783499626.094262 cmd_parse_build_commands 0:2 0:27 0:0: copy-mode
+1783499626.094264 cmd_parse_build_commands 0:2 0:27 0:1: -q
+1783499626.094266 cmd_parse_build_commands 0:2 0:27 1:0: send-keys
+1783499626.094268 cmd_parse_build_commands 0:2 0:27 1:1: -l
+1783499626.094269 cmd_parse_build_commands 0:2 0:27 1:2: --
+1783499626.094272 cmd_parse_build_commands 0:2 0:27 1:3: #{q:mouse_hyperlink}
+1783499626.094274 cmd_parse_build_commands 0:2 0:28: #{?mouse_hyperlink,Copy #[underscore]#{=/9/...:mouse_hyperlink},}
+1783499626.094276 cmd_parse_build_commands 0:2 0:29: h
+1783499626.094278 cmd_parse_build_commands 0:2 0:30 0:0: copy-mode
+1783499626.094280 cmd_parse_build_commands 0:2 0:30 0:1: -q
+1783499626.094282 cmd_parse_build_commands 0:2 0:30 1:0: set-buffer
+1783499626.094284 cmd_parse_build_commands 0:2 0:30 1:1: --
+1783499626.094286 cmd_parse_build_commands 0:2 0:30 1:2: #{q:mouse_hyperlink}
+1783499626.094288 cmd_parse_build_commands 0:2 0:31: 
+1783499626.094290 cmd_parse_build_commands 0:2 0:32: Horizontal Split
+1783499626.094292 cmd_parse_build_commands 0:2 0:33: h
+1783499626.094294 cmd_parse_build_commands 0:2 0:34 0:0: split-window
+1783499626.094296 cmd_parse_build_commands 0:2 0:34 0:1: -h
+1783499626.094298 cmd_parse_build_commands 0:2 0:35: Vertical Split
+1783499626.094300 cmd_parse_build_commands 0:2 0:36: v
+1783499626.094303 cmd_parse_build_commands 0:2 0:37 0:0: split-window
+1783499626.094305 cmd_parse_build_commands 0:2 0:37 0:1: -v
+1783499626.094307 cmd_parse_build_commands 0:2 0:38: 
+1783499626.094309 cmd_parse_build_commands 0:2 0:39: #{?#{>:#{window_panes},1},,-}Swap Up
+1783499626.094311 cmd_parse_build_commands 0:2 0:40: u
+1783499626.094313 cmd_parse_build_commands 0:2 0:41 0:0: swap-pane
+1783499626.094315 cmd_parse_build_commands 0:2 0:41 0:1: -U
+1783499626.094317 cmd_parse_build_commands 0:2 0:42: #{?#{>:#{window_panes},1},,-}Swap Down
+1783499626.094319 cmd_parse_build_commands 0:2 0:43: d
+1783499626.094321 cmd_parse_build_commands 0:2 0:44 0:0: swap-pane
+1783499626.094323 cmd_parse_build_commands 0:2 0:44 0:1: -D
+1783499626.094325 cmd_parse_build_commands 0:2 0:45: #{?pane_marked_set,,-}Swap Marked
+1783499626.094331 cmd_parse_build_commands 0:2 0:46: s
+1783499626.094334 cmd_parse_build_commands 0:2 0:47 0:0: swap-pane
+1783499626.094335 cmd_parse_build_commands 0:2 0:48: 
+1783499626.094337 cmd_parse_build_commands 0:2 0:49: Kill
+1783499626.094339 cmd_parse_build_commands 0:2 0:50: X
+1783499626.094341 cmd_parse_build_commands 0:2 0:51 0:0: kill-pane
+1783499626.094343 cmd_parse_build_commands 0:2 0:52: Respawn
+1783499626.094345 cmd_parse_build_commands 0:2 0:53: R
+1783499626.094347 cmd_parse_build_commands 0:2 0:54 0:0: respawn-pane
+1783499626.094349 cmd_parse_build_commands 0:2 0:54 0:1: -k
+1783499626.094351 cmd_parse_build_commands 0:2 0:55: #{?pane_marked,Unmark,Mark}
+1783499626.094353 cmd_parse_build_commands 0:2 0:56: m
+1783499626.094355 cmd_parse_build_commands 0:2 0:57 0:0: select-pane
+1783499626.094357 cmd_parse_build_commands 0:2 0:57 0:1: -m
+1783499626.094360 cmd_parse_build_commands 0:2 0:58: #{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom}
+1783499626.094362 cmd_parse_build_commands 0:2 0:59: z
+1783499626.094364 cmd_parse_build_commands 0:2 0:60 0:0: resize-pane
+1783499626.094366 cmd_parse_build_commands 0:2 0:60 0:1: -Z
+1783499626.094371 cmd_parse_build_commands 0:0: display-menu
+1783499626.094373 cmd_parse_build_commands 0:1: -xP
+1783499626.094374 cmd_parse_build_commands 0:2: -yP
+1783499626.094376 cmd_parse_build_commands 0:3: -T
+1783499626.094378 cmd_parse_build_commands 0:4: #[align=centre]#{pane_index} (#{pane_id})
+1783499626.094381 cmd_parse_build_commands 0:5: #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,}
+1783499626.094383 cmd_parse_build_commands 0:6: <
+1783499626.094385 cmd_parse_build_commands 0:7 0:0: send
+1783499626.094387 cmd_parse_build_commands 0:7 0:1: -X
+1783499626.094388 cmd_parse_build_commands 0:7 0:2: history-top
+1783499626.094391 cmd_parse_build_commands 0:8: #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Bottom,}
+1783499626.094393 cmd_parse_build_commands 0:9: >
+1783499626.094395 cmd_parse_build_commands 0:10 0:0: send
+1783499626.094397 cmd_parse_build_commands 0:10 0:1: -X
+1783499626.094399 cmd_parse_build_commands 0:10 0:2: history-bottom
+1783499626.094401 cmd_parse_build_commands 0:11: 
+1783499626.094403 cmd_parse_build_commands 0:12: #{?mouse_word,Search For #[underscore]#{=/9/...:mouse_word},}
+1783499626.094405 cmd_parse_build_commands 0:13: C-r
+1783499626.094407 cmd_parse_build_commands 0:14 0:0: if
+1783499626.094409 cmd_parse_build_commands 0:14 0:1: -F
+1783499626.094412 cmd_parse_build_commands 0:14 0:2: #{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}
+1783499626.094414 cmd_parse_build_commands 0:14 0:3: copy-mode -t=
+1783499626.094416 cmd_parse_build_commands 0:14 1:0: send
+1783499626.094418 cmd_parse_build_commands 0:14 1:1: -Xt=
+1783499626.094420 cmd_parse_build_commands 0:14 1:2: search-backward
+1783499626.094422 cmd_parse_build_commands 0:14 1:3: #{q:mouse_word}
+1783499626.094425 cmd_parse_build_commands 0:15: #{?mouse_word,Type #[underscore]#{=/9/...:mouse_word},}
+1783499626.094427 cmd_parse_build_commands 0:16: C-y
+1783499626.094429 cmd_parse_build_commands 0:17 0:0: copy-mode
+1783499626.094431 cmd_parse_build_commands 0:17 0:1: -q
+1783499626.094432 cmd_parse_build_commands 0:17 1:0: send-keys
+1783499626.094434 cmd_parse_build_commands 0:17 1:1: -l
+1783499626.094436 cmd_parse_build_commands 0:17 1:2: --
+1783499626.094438 cmd_parse_build_commands 0:17 1:3: #{q:mouse_word}
+1783499626.094440 cmd_parse_build_commands 0:18: #{?mouse_word,Copy #[underscore]#{=/9/...:mouse_word},}
+1783499626.094442 cmd_parse_build_commands 0:19: c
+1783499626.094444 cmd_parse_build_commands 0:20 0:0: copy-mode
+1783499626.094446 cmd_parse_build_commands 0:20 0:1: -q
+1783499626.094448 cmd_parse_build_commands 0:20 1:0: set-buffer
+1783499626.094449 cmd_parse_build_commands 0:20 1:1: --
+1783499626.094451 cmd_parse_build_commands 0:20 1:2: #{q:mouse_word}
+1783499626.094454 cmd_parse_build_commands 0:21: #{?mouse_line,Copy Line,}
+1783499626.094455 cmd_parse_build_commands 0:22: l
+1783499626.094457 cmd_parse_build_commands 0:23 0:0: copy-mode
+1783499626.094459 cmd_parse_build_commands 0:23 0:1: -q
+1783499626.094464 cmd_parse_build_commands 0:23 1:0: set-buffer
+1783499626.094466 cmd_parse_build_commands 0:23 1:1: --
+1783499626.094468 cmd_parse_build_commands 0:23 1:2: #{q:mouse_line}
+1783499626.094470 cmd_parse_build_commands 0:24: 
+1783499626.094473 cmd_parse_build_commands 0:25: #{?mouse_hyperlink,Type #[underscore]#{=/9/...:mouse_hyperlink},}
+1783499626.094475 cmd_parse_build_commands 0:26: C-h
+1783499626.094477 cmd_parse_build_commands 0:27 0:0: copy-mode
+1783499626.094478 cmd_parse_build_commands 0:27 0:1: -q
+1783499626.094480 cmd_parse_build_commands 0:27 1:0: send-keys
+1783499626.094482 cmd_parse_build_commands 0:27 1:1: -l
+1783499626.094484 cmd_parse_build_commands 0:27 1:2: --
+1783499626.094486 cmd_parse_build_commands 0:27 1:3: #{q:mouse_hyperlink}
+1783499626.094489 cmd_parse_build_commands 0:28: #{?mouse_hyperlink,Copy #[underscore]#{=/9/...:mouse_hyperlink},}
+1783499626.094490 cmd_parse_build_commands 0:29: h
+1783499626.094492 cmd_parse_build_commands 0:30 0:0: copy-mode
+1783499626.094494 cmd_parse_build_commands 0:30 0:1: -q
+1783499626.094496 cmd_parse_build_commands 0:30 1:0: set-buffer
+1783499626.094497 cmd_parse_build_commands 0:30 1:1: --
+1783499626.094499 cmd_parse_build_commands 0:30 1:2: #{q:mouse_hyperlink}
+1783499626.094501 cmd_parse_build_commands 0:31: 
+1783499626.094503 cmd_parse_build_commands 0:32: Horizontal Split
+1783499626.094505 cmd_parse_build_commands 0:33: h
+1783499626.094507 cmd_parse_build_commands 0:34 0:0: split-window
+1783499626.094509 cmd_parse_build_commands 0:34 0:1: -h
+1783499626.094510 cmd_parse_build_commands 0:35: Vertical Split
+1783499626.094512 cmd_parse_build_commands 0:36: v
+1783499626.094514 cmd_parse_build_commands 0:37 0:0: split-window
+1783499626.094516 cmd_parse_build_commands 0:37 0:1: -v
+1783499626.094518 cmd_parse_build_commands 0:38: 
+1783499626.094520 cmd_parse_build_commands 0:39: #{?#{>:#{window_panes},1},,-}Swap Up
+1783499626.094521 cmd_parse_build_commands 0:40: u
+1783499626.094524 cmd_parse_build_commands 0:41 0:0: swap-pane
+1783499626.094525 cmd_parse_build_commands 0:41 0:1: -U
+1783499626.094528 cmd_parse_build_commands 0:42: #{?#{>:#{window_panes},1},,-}Swap Down
+1783499626.094530 cmd_parse_build_commands 0:43: d
+1783499626.094532 cmd_parse_build_commands 0:44 0:0: swap-pane
+1783499626.094534 cmd_parse_build_commands 0:44 0:1: -D
+1783499626.094536 cmd_parse_build_commands 0:45: #{?pane_marked_set,,-}Swap Marked
+1783499626.094538 cmd_parse_build_commands 0:46: s
+1783499626.094540 cmd_parse_build_commands 0:47 0:0: swap-pane
+1783499626.094542 cmd_parse_build_commands 0:48: 
+1783499626.094543 cmd_parse_build_commands 0:49: Kill
+1783499626.094545 cmd_parse_build_commands 0:50: X
+1783499626.094547 cmd_parse_build_commands 0:51 0:0: kill-pane
+1783499626.094549 cmd_parse_build_commands 0:52: Respawn
+1783499626.094550 cmd_parse_build_commands 0:53: R
+1783499626.094553 cmd_parse_build_commands 0:54 0:0: respawn-pane
+1783499626.094554 cmd_parse_build_commands 0:54 0:1: -k
+1783499626.094556 cmd_parse_build_commands 0:55: #{?pane_marked,Unmark,Mark}
+1783499626.094558 cmd_parse_build_commands 0:56: m
+1783499626.094560 cmd_parse_build_commands 0:57 0:0: select-pane
+1783499626.094562 cmd_parse_build_commands 0:57 0:1: -m
+1783499626.094565 cmd_parse_build_commands 0:58: #{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom}
+1783499626.094566 cmd_parse_build_commands 0:59: z
+1783499626.094568 cmd_parse_build_commands 0:60 0:0: resize-pane
+1783499626.094570 cmd_parse_build_commands 0:60 0:1: -Z
+1783499626.094574 cmd_parse_build_commands 0:0: send
+1783499626.094576 cmd_parse_build_commands 0:1: -X
+1783499626.094578 cmd_parse_build_commands 0:2: history-top
+1783499626.094584 args_parse_flags: next -X
+1783499626.094586 args_parse_flags: -X
+1783499626.094588 args_parse_flags: next history-top
+1783499626.094589 args_parse: flags end at 2 of 3
+1783499626.094591 args_parse: 2 = history-top (type STRING)
+1783499626.094598 cmd_parse_build_commands: send-keys -X history-top
+1783499626.094601 cmd_parse_build_commands 0:0: send
+1783499626.094605 cmd_parse_build_commands 0:1: -X
+1783499626.094607 cmd_parse_build_commands 0:2: history-bottom
+1783499626.094611 args_parse_flags: next -X
+1783499626.094612 args_parse_flags: -X
+1783499626.094614 args_parse_flags: next history-bottom
+1783499626.094616 args_parse: flags end at 2 of 3
+1783499626.094624 args_parse: 2 = history-bottom (type STRING)
+1783499626.094634 cmd_parse_build_commands: send-keys -X history-bottom
+1783499626.094638 cmd_parse_build_commands 0:0: if
+1783499626.094639 cmd_parse_build_commands 0:1: -F
+1783499626.094642 cmd_parse_build_commands 0:2: #{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}
+1783499626.094644 cmd_parse_build_commands 0:3: copy-mode -t=
+1783499626.094646 cmd_parse_build_commands 1:0: send
+1783499626.094648 cmd_parse_build_commands 1:1: -Xt=
+1783499626.094649 cmd_parse_build_commands 1:2: search-backward
+1783499626.094651 cmd_parse_build_commands 1:3: #{q:mouse_word}
+1783499626.094654 args_parse_flags: next -F
+1783499626.094656 args_parse_flags: -F
+1783499626.094658 args_parse_flags: next #{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}
+1783499626.094660 args_parse: flags end at 2 of 4
+1783499626.094663 args_parse: 2 = #{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1} (type STRING)
+1783499626.094665 args_parse: 3 = copy-mode -t= (type STRING)
+1783499626.094669 args_parse_flags: next -Xt=
+1783499626.094670 args_parse_flags: -X
+1783499626.094672 args_parse_flag_argument: -t = =
+1783499626.094674 args_parse_flags: next search-backward
+1783499626.094676 args_parse: flags end at 2 of 4
+1783499626.094677 args_parse: 2 = search-backward (type STRING)
+1783499626.094680 args_parse: 3 = #{q:mouse_word} (type STRING)
+1783499626.094689 cmd_parse_build_commands: if-shell -F "#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}" "copy-mode -t=" ; send-keys -X -t = search-backward "#{q:mouse_word}"
+1783499626.094692 cmd_parse_build_commands 0:0: copy-mode
+1783499626.094694 cmd_parse_build_commands 0:1: -q
+1783499626.094696 cmd_parse_build_commands 1:0: send-keys
+1783499626.094698 cmd_parse_build_commands 1:1: -l
+1783499626.094700 cmd_parse_build_commands 1:2: --
+1783499626.094701 cmd_parse_build_commands 1:3: #{q:mouse_word}
+1783499626.094704 args_parse_flags: next -q
+1783499626.094705 args_parse_flags: -q
+1783499626.094707 args_parse: flags end at 2 of 2
+1783499626.094710 args_parse_flags: next -l
+1783499626.094712 args_parse_flags: -l
+1783499626.094713 args_parse_flags: next --
+1783499626.094715 args_parse: flags end at 3 of 4
+1783499626.094716 args_parse: 3 = #{q:mouse_word} (type STRING)
+1783499626.094722 cmd_parse_build_commands: copy-mode -q ; send-keys -l "#{q:mouse_word}"
+1783499626.094725 cmd_parse_build_commands 0:0: copy-mode
+1783499626.094727 cmd_parse_build_commands 0:1: -q
+1783499626.094728 cmd_parse_build_commands 1:0: set-buffer
+1783499626.094730 cmd_parse_build_commands 1:1: --
+1783499626.094732 cmd_parse_build_commands 1:2: #{q:mouse_word}
+1783499626.094734 args_parse_flags: next -q
+1783499626.094736 args_parse_flags: -q
+1783499626.094737 args_parse: flags end at 2 of 2
+1783499626.094741 args_parse_flags: next --
+1783499626.094743 args_parse: flags end at 2 of 3
+1783499626.094745 args_parse: 2 = #{q:mouse_word} (type STRING)
+1783499626.094748 cmd_parse_build_commands: copy-mode -q ; set-buffer "#{q:mouse_word}"
+1783499626.094751 cmd_parse_build_commands 0:0: copy-mode
+1783499626.094753 cmd_parse_build_commands 0:1: -q
+1783499626.094754 cmd_parse_build_commands 1:0: set-buffer
+1783499626.094756 cmd_parse_build_commands 1:1: --
+1783499626.094758 cmd_parse_build_commands 1:2: #{q:mouse_line}
+1783499626.094760 args_parse_flags: next -q
+1783499626.094761 args_parse_flags: -q
+1783499626.094763 args_parse: flags end at 2 of 2
+1783499626.094766 args_parse_flags: next --
+1783499626.094768 args_parse: flags end at 2 of 3
+1783499626.094769 args_parse: 2 = #{q:mouse_line} (type STRING)
+1783499626.094774 cmd_parse_build_commands: copy-mode -q ; set-buffer "#{q:mouse_line}"
+1783499626.094783 cmd_parse_build_commands 0:0: copy-mode
+1783499626.094787 cmd_parse_build_commands 0:1: -q
+1783499626.094789 cmd_parse_build_commands 1:0: send-keys
+1783499626.094794 cmd_parse_build_commands 1:1: -l
+1783499626.094796 cmd_parse_build_commands 1:2: --
+1783499626.094821 cmd_parse_build_commands 1:3: #{q:mouse_hyperlink}
+1783499626.094831 args_parse_flags: next -q
+1783499626.094834 args_parse_flags: -q
+1783499626.094836 args_parse: flags end at 2 of 2
+1783499626.094841 args_parse_flags: next -l
+1783499626.094842 args_parse_flags: -l
+1783499626.094844 args_parse_flags: next --
+1783499626.094846 args_parse: flags end at 3 of 4
+1783499626.094848 args_parse: 3 = #{q:mouse_hyperlink} (type STRING)
+1783499626.094855 cmd_parse_build_commands: copy-mode -q ; send-keys -l "#{q:mouse_hyperlink}"
+1783499626.094859 cmd_parse_build_commands 0:0: copy-mode
+1783499626.094861 cmd_parse_build_commands 0:1: -q
+1783499626.094863 cmd_parse_build_commands 1:0: set-buffer
+1783499626.094865 cmd_parse_build_commands 1:1: --
+1783499626.094867 cmd_parse_build_commands 1:2: #{q:mouse_hyperlink}
+1783499626.094870 args_parse_flags: next -q
+1783499626.094871 args_parse_flags: -q
+1783499626.094873 args_parse: flags end at 2 of 2
+1783499626.094877 args_parse_flags: next --
+1783499626.094879 args_parse: flags end at 2 of 3
+1783499626.094881 args_parse: 2 = #{q:mouse_hyperlink} (type STRING)
+1783499626.094886 cmd_parse_build_commands: copy-mode -q ; set-buffer "#{q:mouse_hyperlink}"
+1783499626.094890 cmd_parse_build_commands 0:0: split-window
+1783499626.094891 cmd_parse_build_commands 0:1: -h
+1783499626.094896 args_parse_flags: next -h
+1783499626.094897 args_parse_flags: -h
+1783499626.094899 args_parse: flags end at 2 of 2
+1783499626.094901 cmd_parse_build_commands: split-window -h
+1783499626.094905 cmd_parse_build_commands 0:0: split-window
+1783499626.094906 cmd_parse_build_commands 0:1: -v
+1783499626.094911 args_parse_flags: next -v
+1783499626.094912 args_parse_flags: -v
+1783499626.094914 args_parse: flags end at 2 of 2
+1783499626.094916 cmd_parse_build_commands: split-window -v
+1783499626.094919 cmd_parse_build_commands 0:0: swap-pane
+1783499626.094921 cmd_parse_build_commands 0:1: -U
+1783499626.094925 args_parse_flags: next -U
+1783499626.094927 args_parse_flags: -U
+1783499626.094929 args_parse: flags end at 2 of 2
+1783499626.094931 cmd_parse_build_commands: swap-pane -U
+1783499626.094934 cmd_parse_build_commands 0:0: swap-pane
+1783499626.094936 cmd_parse_build_commands 0:1: -D
+1783499626.094940 args_parse_flags: next -D
+1783499626.094942 args_parse_flags: -D
+1783499626.094943 args_parse: flags end at 2 of 2
+1783499626.094946 cmd_parse_build_commands: swap-pane -D
+1783499626.094949 cmd_parse_build_commands 0:0: swap-pane
+1783499626.094953 args_parse: flags end at 1 of 1
+1783499626.094956 cmd_parse_build_commands: swap-pane
+1783499626.094959 cmd_parse_build_commands 0:0: kill-pane
+1783499626.094981 args_parse: flags end at 1 of 1
+1783499626.094989 cmd_parse_build_commands: kill-pane
+1783499626.094995 cmd_parse_build_commands 0:0: respawn-pane
+1783499626.094997 cmd_parse_build_commands 0:1: -k
+1783499626.095001 args_parse_flags: next -k
+1783499626.095003 args_parse_flags: -k
+1783499626.095005 args_parse: flags end at 2 of 2
+1783499626.095008 cmd_parse_build_commands: respawn-pane -k
+1783499626.095012 cmd_parse_build_commands 0:0: select-pane
+1783499626.095014 cmd_parse_build_commands 0:1: -m
+1783499626.095018 args_parse_flags: next -m
+1783499626.095020 args_parse_flags: -m
+1783499626.095021 args_parse: flags end at 2 of 2
+1783499626.095024 cmd_parse_build_commands: select-pane -m
+1783499626.095036 cmd_parse_build_commands 0:0: resize-pane
+1783499626.095041 cmd_parse_build_commands 0:1: -Z
+1783499626.095045 args_parse_flags: next -Z
+1783499626.095047 args_parse_flags: -Z
+1783499626.095049 args_parse: flags end at 2 of 2
+1783499626.095052 cmd_parse_build_commands: resize-pane -Z
+1783499626.095054 args_parse_flags: next -xP
+1783499626.095056 args_parse_flag_argument: -x = P
+1783499626.095058 args_parse_flags: next -yP
+1783499626.095059 args_parse_flag_argument: -y = P
+1783499626.095061 args_parse_flags: next -T
+1783499626.095064 args_parse_flag_argument: -T = #[align=centre]#{pane_index} (#{pane_id})
+1783499626.095073 args_parse_flags: next #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,}
+1783499626.095075 args_parse: flags end at 5 of 61
+1783499626.095078 args_parse: 5 = #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,} (type STRING)
+1783499626.095080 args_parse: 6 = < (type STRING)
+1783499626.095086 args_parse: 7 = send-keys -X history-top (type COMMANDS)
+1783499626.095089 args_parse: 8 = #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Bottom,} (type STRING)
+1783499626.095091 args_parse: 9 = > (type STRING)
+1783499626.095095 args_parse: 10 = send-keys -X history-bottom (type COMMANDS)
+1783499626.095098 args_parse: 11 =  (type STRING)
+1783499626.095101 args_parse: 12 = #{?mouse_word,Search For #[underscore]#{=/9/...:mouse_word},} (type STRING)
+1783499626.095103 args_parse: 13 = C-r (type STRING)
+1783499626.095113 args_parse: 14 = if-shell -F "#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}" "copy-mode -t=" ; send-keys -X -t = search-backward "#{q:mouse_word}" (type COMMANDS)
+1783499626.095117 args_parse: 15 = #{?mouse_word,Type #[underscore]#{=/9/...:mouse_word},} (type STRING)
+1783499626.095119 args_parse: 16 = C-y (type STRING)
+1783499626.095124 args_parse: 17 = copy-mode -q ; send-keys -l "#{q:mouse_word}" (type COMMANDS)
+1783499626.095127 args_parse: 18 = #{?mouse_word,Copy #[underscore]#{=/9/...:mouse_word},} (type STRING)
+1783499626.095129 args_parse: 19 = c (type STRING)
+1783499626.095133 args_parse: 20 = copy-mode -q ; set-buffer "#{q:mouse_word}" (type COMMANDS)
+1783499626.095136 args_parse: 21 = #{?mouse_line,Copy Line,} (type STRING)
+1783499626.095138 args_parse: 22 = l (type STRING)
+1783499626.095142 args_parse: 23 = copy-mode -q ; set-buffer "#{q:mouse_line}" (type COMMANDS)
+1783499626.095144 args_parse: 24 =  (type STRING)
+1783499626.095147 args_parse: 25 = #{?mouse_hyperlink,Type #[underscore]#{=/9/...:mouse_hyperlink},} (type STRING)
+1783499626.095149 args_parse: 26 = C-h (type STRING)
+1783499626.095153 args_parse: 27 = copy-mode -q ; send-keys -l "#{q:mouse_hyperlink}" (type COMMANDS)
+1783499626.095157 args_parse: 28 = #{?mouse_hyperlink,Copy #[underscore]#{=/9/...:mouse_hyperlink},} (type STRING)
+1783499626.095158 args_parse: 29 = h (type STRING)
+1783499626.095163 args_parse: 30 = copy-mode -q ; set-buffer "#{q:mouse_hyperlink}" (type COMMANDS)
+1783499626.095165 args_parse: 31 =  (type STRING)
+1783499626.095167 args_parse: 32 = Horizontal Split (type STRING)
+1783499626.095169 args_parse: 33 = h (type STRING)
+1783499626.095172 args_parse: 34 = split-window -h (type COMMANDS)
+1783499626.095175 args_parse: 35 = Vertical Split (type STRING)
+1783499626.095177 args_parse: 36 = v (type STRING)
+1783499626.095180 args_parse: 37 = split-window -v (type COMMANDS)
+1783499626.095182 args_parse: 38 =  (type STRING)
+1783499626.095185 args_parse: 39 = #{?#{>:#{window_panes},1},,-}Swap Up (type STRING)
+1783499626.095187 args_parse: 40 = u (type STRING)
+1783499626.095190 args_parse: 41 = swap-pane -U (type COMMANDS)
+1783499626.095193 args_parse: 42 = #{?#{>:#{window_panes},1},,-}Swap Down (type STRING)
+1783499626.095195 args_parse: 43 = d (type STRING)
+1783499626.095197 args_parse: 44 = swap-pane -D (type COMMANDS)
+1783499626.095265 args_parse: 45 = #{?pane_marked_set,,-}Swap Marked (type STRING)
+1783499626.095274 args_parse: 46 = s (type STRING)
+1783499626.095525 args_parse: 47 = swap-pane (type COMMANDS)
+1783499626.095543 args_parse: 48 =  (type STRING)
+1783499626.095548 args_parse: 49 = Kill (type STRING)
+1783499626.095552 args_parse: 50 = X (type STRING)
+1783499626.095557 args_parse: 51 = kill-pane (type COMMANDS)
+1783499626.095561 args_parse: 52 = Respawn (type STRING)
+1783499626.095564 args_parse: 53 = R (type STRING)
+1783499626.095570 args_parse: 54 = respawn-pane -k (type COMMANDS)
+1783499626.095575 args_parse: 55 = #{?pane_marked,Unmark,Mark} (type STRING)
+1783499626.095660 args_parse: 56 = m (type STRING)
+1783499626.095673 args_parse: 57 = select-pane -m (type COMMANDS)
+1783499626.095679 args_parse: 58 = #{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom} (type STRING)
+1783499626.095905 args_parse: 59 = z (type STRING)
+1783499626.095925 args_parse: 60 = resize-pane -Z (type COMMANDS)
+1783499626.096314 cmd_parse_build_commands: display-menu -T "#[align=centre]#{pane_index} (#{pane_id})" -x P -y P "#{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,}" < { send-keys -X history-top } "#{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Bottom,}" > { send-keys -X history-bottom } '' "#{?mouse_word,Search For #[underscore]#{=/9/...:mouse_word},}" C-r { if-shell -F "#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}" "copy-mode -t=" ; send-keys -X -t = search-backward "#{q:mouse_word}" } "#{?mouse_word,Type #[underscore]#{=/9/...:mouse_word},}" C-y { copy-mode -q ; send-keys -l "#{q:mouse_word}" } "#{?mouse_word,Copy #[underscore]#{=/9/...:mouse_word},}" c { copy-mode -q ; set-buffer "#{q:mouse_word}" } "#{?mouse_line,Copy Line,}" l { copy-mode -q ; set-buffer "#{q:mouse_line}" } '' "#{?mouse_hyperlink,Type #[underscore]#{=/9/...:mouse_hyperlink},}" C-h { copy-mode -q ; send-keys -l "#{q:mouse_hyperlink}" } "#{?mouse_hyperlink,Copy #[underscore]#{=/9/...:mouse_hyperlink},}" h { copy-mode -q ; set-buffer "#{q:mouse_hyperlink}" } '' "Horizontal Split" h { split-window -h } "Vertical Split" v { split-window -v } '' "#{?#{>:#{window_panes},1},,-}Swap Up" u { swap-pane -U } "#{?#{>:#{window_panes},1},,-}Swap Down" d { swap-pane -D } "#{?pane_marked_set,,-}Swap Marked" s { swap-pane } '' Kill X { kill-pane } Respawn R { respawn-pane -k } "#{?pane_marked,Unmark,Mark}" m { select-pane -m } "#{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom}" z { resize-pane -Z }
+1783499626.096419 args_parse_flags: next >
+1783499626.096425 args_parse: flags end at 1 of 3
+1783499626.096429 args_parse: 1 = > (type STRING)
+1783499626.097137 args_parse: 2 = display-menu -T "#[align=centre]#{pane_index} (#{pane_id})" -x P -y P "#{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,}" < { send-keys -X history-top } "#{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Bottom,}" > { send-keys -X history-bottom } '' "#{?mouse_word,Search For #[underscore]#{=/9/...:mouse_word},}" C-r { if-shell -F "#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}" "copy-mode -t=" ; send-keys -X -t = search-backward "#{q:mouse_word}" } "#{?mouse_word,Type #[underscore]#{=/9/...:mouse_word},}" C-y { copy-mode -q ; send-keys -l "#{q:mouse_word}" } "#{?mouse_word,Copy #[underscore]#{=/9/...:mouse_word},}" c { copy-mode -q ; set-buffer "#{q:mouse_word}" } "#{?mouse_line,Copy Line,}" l { copy-mode -q ; set-buffer "#{q:mouse_line}" } '' "#{?mouse_hyperlink,Type #[underscore]#{=/9/...:mouse_hyperlink},}" C-h { copy-mode -q ; send-keys -l "#{q:mouse_hyperlink}" } "#{?mouse_hyperlink,Copy #[underscore]#{=/9/...:mouse_hyperlink},}" h { copy-mode -q ; set-buffer "#{q:mouse_hyperlink}" } '' "Horizontal Split" h { split-window -h } "Vertical Split" v { split-window -v } '' "#{?#{>:#{window_panes},1},,-}Swap Up" u { swap-pane -U } "#{?#{>:#{window_panes},1},,-}Swap Down" d { swap-pane -D } "#{?pane_marked_set,,-}Swap Marked" s { swap-pane } '' Kill X { kill-pane } Respawn R { respawn-pane -k } "#{?pane_marked,Unmark,Mark}" m { select-pane -m } "#{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom}" z { resize-pane -Z } (type COMMANDS)
+1783499626.097269 cmd_parse_build_commands: bind-key > { display-menu -T "#[align=centre]#{pane_index} (#{pane_id})" -x P -y P "#{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,}" < { send-keys -X history-top } "#{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Bottom,}" > { send-keys -X history-bottom } '' "#{?mouse_word,Search For #[underscore]#{=/9/...:mouse_word},}" C-r { if-shell -F "#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}" "copy-mode -t=" ; send-keys -X -t = search-backward "#{q:mouse_word}" } "#{?mouse_word,Type #[underscore]#{=/9/...:mouse_word},}" C-y { copy-mode -q ; send-keys -l "#{q:mouse_word}" } "#{?mouse_word,Copy #[underscore]#{=/9/...:mouse_word},}" c { copy-mode -q ; set-buffer "#{q:mouse_word}" } "#{?mouse_line,Copy Line,}" l { copy-mode -q ; set-buffer "#{q:mouse_line}" } '' "#{?mouse_hyperlink,Type #[underscore]#{=/9/...:mouse_hyperlink},}" C-h { copy-mode -q ; send-keys -l "#{q:mouse_hyperlink}" } "#{?mouse_hyperlink,Copy #[underscore]#{=/9/...:mouse_hyperlink},}" h { copy-mode -q ; set-buffer "#{q:mouse_hyperlink}" } '' "Horizontal Split" h { split-window -h } "Vertical Split" v { split-window -v } '' "#{?#{>:#{window_panes},1},,-}Swap Up" u { swap-pane -U } "#{?#{>:#{window_panes},1},,-}Swap Down" d { swap-pane -D } "#{?pane_marked_set,,-}Swap Marked" s { swap-pane } '' Kill X { kill-pane } Respawn R { respawn-pane -k } "#{?pane_marked,Unmark,Mark}" m { select-pane -m } "#{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom}" z { resize-pane -Z } }
+1783499626.097311 cmdq_get_command: [bind-key/0x58e4724d66a0] group 738
+1783499626.097315 cmdq_append <global>: [bind-key/0x58e4724d66a0]
+1783499626.097326 yylex_token: end at WS
+1783499626.097328 yylex_token: bind
+1783499626.097330 yylex_token: end at WS
+1783499626.097331 yylex_token: -n
+1783499626.097333 yylex_token: end at WS
+1783499626.097334 yylex_token: MouseDown1Pane
+1783499626.097336 yylex_token: end at WS
+1783499626.097337 yylex_token: select-pane
+1783499626.097339 yylex_token: end at ;
+1783499626.097340 yylex_token: -t=
+1783499626.097342 yylex_token: end at WS
+1783499626.097343 yylex_token: send
+1783499626.097344 yylex_token: end at WS
+1783499626.097345 yylex_token: -M
+1783499626.097349 cmd_parse_build_commands 0:0: bind
+1783499626.097350 cmd_parse_build_commands 0:1: -n
+1783499626.097352 cmd_parse_build_commands 0:2: MouseDown1Pane
+1783499626.097353 cmd_parse_build_commands 0:3 0:0: select-pane
+1783499626.097355 cmd_parse_build_commands 0:3 0:1: -t=
+1783499626.097356 cmd_parse_build_commands 0:3 1:0: send
+1783499626.097358 cmd_parse_build_commands 0:3 1:1: -M
+1783499626.097363 cmd_parse_build_commands 0:0: select-pane
+1783499626.097364 cmd_parse_build_commands 0:1: -t=
+1783499626.097365 cmd_parse_build_commands 1:0: send
+1783499626.097366 cmd_parse_build_commands 1:1: -M
+1783499626.097371 args_parse_flags: next -t=
+1783499626.097373 args_parse_flag_argument: -t = =
+1783499626.097375 args_parse: flags end at 2 of 2
+1783499626.097378 args_parse_flags: next -M
+1783499626.097379 args_parse_flags: -M
+1783499626.097381 args_parse: flags end at 2 of 2
+1783499626.097385 cmd_parse_build_commands: select-pane -t = ; send-keys -M
+1783499626.097386 args_parse_flags: next -n
+1783499626.097387 args_parse_flags: -n
+1783499626.097389 args_parse_flags: next MouseDown1Pane
+1783499626.097390 args_parse: flags end at 2 of 4
+1783499626.097391 args_parse: 2 = MouseDown1Pane (type STRING)
+1783499626.097395 args_parse: 3 = select-pane -t = ; send-keys -M (type COMMANDS)
+1783499626.097400 cmd_parse_build_commands: bind-key -n MouseDown1Pane { select-pane -t = ; send-keys -M }
+1783499626.097402 cmdq_get_command: [bind-key/0x58e4724d8540] group 820
+1783499626.097404 cmdq_append <global>: [bind-key/0x58e4724d8540]
+1783499626.097408 yylex_token: end at WS
+1783499626.097517 yylex_token: bind
+1783499626.097527 yylex_token: end at WS
+1783499626.097529 yylex_token: -n
+1783499626.097532 yylex_token: end at WS
+1783499626.097534 yylex_token: MouseDrag1Pane
+1783499626.097536 yylex_token: end at WS
+1783499626.097537 yylex_token: if
+1783499626.097538 yylex_token: end at WS
+1783499626.097540 yylex_token: -F
+1783499626.097542 yylex_token: end at WS
+1783499626.097545 yylex_token: #{||:#{pane_in_mode},#{mouse_any_flag}}
+1783499626.097547 yylex_token: end at WS
+1783499626.097548 yylex_token: send
+1783499626.097550 yylex_token: end at WS
+1783499626.097551 yylex_token: -M
+1783499626.097553 yylex_token: end at WS
+1783499626.097555 yylex_token: copy-mode
+1783499626.097557 yylex_token: end at WS
+1783499626.097558 yylex_token: -M
+1783499626.097562 cmd_parse_build_commands 0:0: bind
+1783499626.097563 cmd_parse_build_commands 0:1: -n
+1783499626.097565 cmd_parse_build_commands 0:2: MouseDrag1Pane
+1783499626.097567 cmd_parse_build_commands 0:3 0:0: if
+1783499626.097569 cmd_parse_build_commands 0:3 0:1: -F
+1783499626.097571 cmd_parse_build_commands 0:3 0:2: #{||:#{pane_in_mode},#{mouse_any_flag}}
+1783499626.097580 cmd_parse_build_commands 0:3 0:3 0:0: send
+1783499626.097582 cmd_parse_build_commands 0:3 0:3 0:1: -M
+1783499626.097585 cmd_parse_build_commands 0:3 0:4 0:0: copy-mode
+1783499626.097587 cmd_parse_build_commands 0:3 0:4 0:1: -M
+1783499626.097590 cmd_parse_build_commands 0:0: if
+1783499626.097592 cmd_parse_build_commands 0:1: -F
+1783499626.097594 cmd_parse_build_commands 0:2: #{||:#{pane_in_mode},#{mouse_any_flag}}
+1783499626.097596 cmd_parse_build_commands 0:3 0:0: send
+1783499626.097598 cmd_parse_build_commands 0:3 0:1: -M
+1783499626.097600 cmd_parse_build_commands 0:4 0:0: copy-mode
+1783499626.097602 cmd_parse_build_commands 0:4 0:1: -M
+1783499626.097604 cmd_parse_build_commands 0:0: send
+1783499626.097606 cmd_parse_build_commands 0:1: -M
+1783499626.097611 args_parse_flags: next -M
+1783499626.097613 args_parse_flags: -M
+1783499626.097615 args_parse: flags end at 2 of 2
+1783499626.097618 cmd_parse_build_commands: send-keys -M
+1783499626.097620 cmd_parse_build_commands 0:0: copy-mode
+1783499626.097622 cmd_parse_build_commands 0:1: -M
+1783499626.097624 args_parse_flags: next -M
+1783499626.097626 args_parse_flags: -M
+1783499626.097627 args_parse: flags end at 2 of 2
+1783499626.097630 cmd_parse_build_commands: copy-mode -M
+1783499626.097632 args_parse_flags: next -F
+1783499626.097633 args_parse_flags: -F
+1783499626.097635 args_parse_flags: next #{||:#{pane_in_mode},#{mouse_any_flag}}
+1783499626.097637 args_parse: flags end at 2 of 5
+1783499626.097639 args_parse: 2 = #{||:#{pane_in_mode},#{mouse_any_flag}} (type STRING)
+1783499626.097642 args_parse: 3 = send-keys -M (type COMMANDS)
+1783499626.097644 args_parse: 4 = copy-mode -M (type COMMANDS)
+1783499626.097652 cmd_parse_build_commands: if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" { send-keys -M } { copy-mode -M }
+1783499626.097654 args_parse_flags: next -n
+1783499626.097655 args_parse_flags: -n
+1783499626.097657 args_parse_flags: next MouseDrag1Pane
+1783499626.097658 args_parse: flags end at 2 of 4
+1783499626.097660 args_parse: 2 = MouseDrag1Pane (type STRING)
+1783499626.097667 args_parse: 3 = if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" { send-keys -M } { copy-mode -M } (type COMMANDS)
+1783499626.097676 cmd_parse_build_commands: bind-key -n MouseDrag1Pane { if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" { send-keys -M } { copy-mode -M } }
+1783499626.097680 cmdq_get_command: [bind-key/0x58e4724e0610] group 829
+1783499626.097683 cmdq_append <global>: [bind-key/0x58e4724e0610]
+1783499626.097688 yylex_token: end at WS
+1783499626.097690 yylex_token: bind
+1783499626.097691 yylex_token: end at WS
+1783499626.097693 yylex_token: -n
+1783499626.097694 yylex_token: end at WS
+1783499626.097696 yylex_token: WheelUpPane
+1783499626.097697 yylex_token: end at WS
+1783499626.097699 yylex_token: if
+1783499626.097700 yylex_token: end at WS
+1783499626.097701 yylex_token: -F
+1783499626.097704 yylex_token: end at WS
+1783499626.097705 yylex_token: #{||:#{pane_in_mode},#{mouse_any_flag}}
+1783499626.097707 yylex_token: end at WS
+1783499626.097709 yylex_token: send
+1783499626.097710 yylex_token: end at WS
+1783499626.097711 yylex_token: -M
+1783499626.097713 yylex_token: end at WS
+1783499626.097715 yylex_token: copy-mode
+1783499626.097717 yylex_token: end at WS
+1783499626.097718 yylex_token: -e
+1783499626.097721 cmd_parse_build_commands 0:0: bind
+1783499626.097723 cmd_parse_build_commands 0:1: -n
+1783499626.097724 cmd_parse_build_commands 0:2: WheelUpPane
+1783499626.097726 cmd_parse_build_commands 0:3 0:0: if
+1783499626.097728 cmd_parse_build_commands 0:3 0:1: -F
+1783499626.097730 cmd_parse_build_commands 0:3 0:2: #{||:#{pane_in_mode},#{mouse_any_flag}}
+1783499626.097732 cmd_parse_build_commands 0:3 0:3 0:0: send
+1783499626.097734 cmd_parse_build_commands 0:3 0:3 0:1: -M
+1783499626.097736 cmd_parse_build_commands 0:3 0:4 0:0: copy-mode
+1783499626.097737 cmd_parse_build_commands 0:3 0:4 0:1: -e
+1783499626.097740 cmd_parse_build_commands 0:0: if
+1783499626.097741 cmd_parse_build_commands 0:1: -F
+1783499626.097744 cmd_parse_build_commands 0:2: #{||:#{pane_in_mode},#{mouse_any_flag}}
+1783499626.097750 cmd_parse_build_commands 0:3 0:0: send
+1783499626.097751 cmd_parse_build_commands 0:3 0:1: -M
+1783499626.097753 cmd_parse_build_commands 0:4 0:0: copy-mode
+1783499626.097755 cmd_parse_build_commands 0:4 0:1: -e
+1783499626.097757 cmd_parse_build_commands 0:0: send
+1783499626.097759 cmd_parse_build_commands 0:1: -M
+1783499626.097763 args_parse_flags: next -M
+1783499626.097764 args_parse_flags: -M
+1783499626.097766 args_parse: flags end at 2 of 2
+1783499626.097768 cmd_parse_build_commands: send-keys -M
+1783499626.097770 cmd_parse_build_commands 0:0: copy-mode
+1783499626.097771 cmd_parse_build_commands 0:1: -e
+1783499626.097774 args_parse_flags: next -e
+1783499626.097775 args_parse_flags: -e
+1783499626.097777 args_parse: flags end at 2 of 2
+1783499626.097779 cmd_parse_build_commands: copy-mode -e
+1783499626.097781 args_parse_flags: next -F
+1783499626.097782 args_parse_flags: -F
+1783499626.097784 args_parse_flags: next #{||:#{pane_in_mode},#{mouse_any_flag}}
+1783499626.097786 args_parse: flags end at 2 of 5
+1783499626.097788 args_parse: 2 = #{||:#{pane_in_mode},#{mouse_any_flag}} (type STRING)
+1783499626.097790 args_parse: 3 = send-keys -M (type COMMANDS)
+1783499626.097793 args_parse: 4 = copy-mode -e (type COMMANDS)
+1783499626.097799 cmd_parse_build_commands: if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" { send-keys -M } { copy-mode -e }
+1783499626.097801 args_parse_flags: next -n
+1783499626.097802 args_parse_flags: -n
+1783499626.097804 args_parse_flags: next WheelUpPane
+1783499626.097805 args_parse: flags end at 2 of 4
+1783499626.097807 args_parse: 2 = WheelUpPane (type STRING)
+1783499626.097813 args_parse: 3 = if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" { send-keys -M } { copy-mode -e } (type COMMANDS)
+1783499626.097821 cmd_parse_build_commands: bind-key -n WheelUpPane { if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" { send-keys -M } { copy-mode -e } }
+1783499626.097825 cmdq_get_command: [bind-key/0x58e4724d7fd0] group 845
+1783499626.097827 cmdq_append <global>: [bind-key/0x58e4724d7fd0]
+1783499626.097831 yylex_token: end at WS
+1783499626.097832 yylex_token: bind
+1783499626.097834 yylex_token: end at WS
+1783499626.097835 yylex_token: -n
+1783499626.097837 yylex_token: end at WS
+1783499626.097839 yylex_token: MouseDown2Pane
+1783499626.097841 yylex_token: end at WS
+1783499626.097842 yylex_token: select-pane
+1783499626.097844 yylex_token: end at ;
+1783499626.097845 yylex_token: -t=
+1783499626.097846 yylex_token: end at WS
+1783499626.097848 yylex_token: if
+1783499626.097849 yylex_token: end at WS
+1783499626.097850 yylex_token: -F
+1783499626.097853 yylex_token: end at WS
+1783499626.097855 yylex_token: #{||:#{pane_in_mode},#{mouse_any_flag}}
+1783499626.097856 yylex_token: end at WS
+1783499626.097857 yylex_token: send
+1783499626.097859 yylex_token: end at WS
+1783499626.097860 yylex_token: -M
+1783499626.097862 yylex_token: end at WS
+1783499626.097863 yylex_token: paste
+1783499626.097864 yylex_token: end at WS
+1783499626.097866 yylex_token: -p
+1783499626.097869 cmd_parse_build_commands 0:0: bind
+1783499626.097870 cmd_parse_build_commands 0:1: -n
+1783499626.097872 cmd_parse_build_commands 0:2: MouseDown2Pane
+1783499626.097874 cmd_parse_build_commands 0:3 0:0: select-pane
+1783499626.097876 cmd_parse_build_commands 0:3 0:1: -t=
+1783499626.097878 cmd_parse_build_commands 0:3 1:0: if
+1783499626.097879 cmd_parse_build_commands 0:3 1:1: -F
+1783499626.097882 cmd_parse_build_commands 0:3 1:2: #{||:#{pane_in_mode},#{mouse_any_flag}}
+1783499626.097883 cmd_parse_build_commands 0:3 1:3 0:0: send
+1783499626.097885 cmd_parse_build_commands 0:3 1:3 0:1: -M
+1783499626.097887 cmd_parse_build_commands 0:3 1:4 0:0: paste
+1783499626.097889 cmd_parse_build_commands 0:3 1:4 0:1: -p
+1783499626.097891 cmd_parse_build_commands 0:0: select-pane
+1783499626.097893 cmd_parse_build_commands 0:1: -t=
+1783499626.097894 cmd_parse_build_commands 1:0: if
+1783499626.097896 cmd_parse_build_commands 1:1: -F
+1783499626.097898 cmd_parse_build_commands 1:2: #{||:#{pane_in_mode},#{mouse_any_flag}}
+1783499626.097900 cmd_parse_build_commands 1:3 0:0: send
+1783499626.097904 cmd_parse_build_commands 1:3 0:1: -M
+1783499626.097907 cmd_parse_build_commands 1:4 0:0: paste
+1783499626.097908 cmd_parse_build_commands 1:4 0:1: -p
+1783499626.097912 args_parse_flags: next -t=
+1783499626.097914 args_parse_flag_argument: -t = =
+1783499626.097915 args_parse: flags end at 2 of 2
+1783499626.097918 cmd_parse_build_commands 0:0: send
+1783499626.097919 cmd_parse_build_commands 0:1: -M
+1783499626.097922 args_parse_flags: next -M
+1783499626.097924 args_parse_flags: -M
+1783499626.097925 args_parse: flags end at 2 of 2
+1783499626.097928 cmd_parse_build_commands: send-keys -M
+1783499626.097930 cmd_parse_build_commands 0:0: paste
+1783499626.097931 cmd_parse_build_commands 0:1: -p
+1783499626.097935 args_parse_flags: next -p
+1783499626.097936 args_parse_flags: -p
+1783499626.097938 args_parse: flags end at 2 of 2
+1783499626.097940 cmd_parse_build_commands: paste-buffer -p
+1783499626.097942 args_parse_flags: next -F
+1783499626.097944 args_parse_flags: -F
+1783499626.097946 args_parse_flags: next #{||:#{pane_in_mode},#{mouse_any_flag}}
+1783499626.097947 args_parse: flags end at 2 of 5
+1783499626.097949 args_parse: 2 = #{||:#{pane_in_mode},#{mouse_any_flag}} (type STRING)
+1783499626.097952 args_parse: 3 = send-keys -M (type COMMANDS)
+1783499626.097954 args_parse: 4 = paste-buffer -p (type COMMANDS)
+1783499626.097961 cmd_parse_build_commands: select-pane -t = ; if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" { send-keys -M } { paste-buffer -p }
+1783499626.097964 args_parse_flags: next -n
+1783499626.097965 args_parse_flags: -n
+1783499626.097966 args_parse_flags: next MouseDown2Pane
+1783499626.097968 args_parse: flags end at 2 of 4
+1783499626.097970 args_parse: 2 = MouseDown2Pane (type STRING)
+1783499626.097976 args_parse: 3 = select-pane -t = ; if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" { send-keys -M } { paste-buffer -p } (type COMMANDS)
+1783499626.097985 cmd_parse_build_commands: bind-key -n MouseDown2Pane { select-pane -t = ; if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" { send-keys -M } { paste-buffer -p } }
+1783499626.097989 cmdq_get_command: [bind-key/0x58e4724e7000] group 861
+1783499626.097991 cmdq_append <global>: [bind-key/0x58e4724e7000]
+1783499626.097996 yylex_token: end at WS
+1783499626.097997 yylex_token: bind
+1783499626.097999 yylex_token: end at WS
+1783499626.098000 yylex_token: -n
+1783499626.098002 yylex_token: end at WS
+1783499626.098004 yylex_token: DoubleClick1Pane
+1783499626.098005 yylex_token: end at WS
+1783499626.098007 yylex_token: select-pane
+1783499626.098008 yylex_token: end at ;
+1783499626.098009 yylex_token: -t=
+1783499626.098011 yylex_token: end at WS
+1783499626.098012 yylex_token: if
+1783499626.098013 yylex_token: end at WS
+1783499626.098015 yylex_token: -F
+1783499626.098017 yylex_token: end at WS
+1783499626.098019 yylex_token: #{||:#{pane_in_mode},#{mouse_any_flag}}
+1783499626.098020 yylex_token: end at WS
+1783499626.098022 yylex_token: send
+1783499626.098023 yylex_token: end at WS
+1783499626.098024 yylex_token: -M
+1783499626.098026 yylex_token: end at WS
+1783499626.098028 yylex_token: copy-mode
+1783499626.098029 yylex_token: end at ;
+1783499626.098030 yylex_token: -H
+1783499626.098032 yylex_token: end at WS
+1783499626.098033 yylex_token: send
+1783499626.098034 yylex_token: end at WS
+1783499626.098036 yylex_token: -X
+1783499626.098037 yylex_token: end at ;
+1783499626.098039 yylex_token: select-word
+1783499626.098041 yylex_token: end at WS
+1783499626.098042 yylex_token: run
+1783499626.098043 yylex_token: end at ;
+1783499626.098045 yylex_token: -d0.3
+1783499626.098046 yylex_token: end at WS
+1783499626.098047 yylex_token: send
+1783499626.098049 yylex_token: end at WS
+1783499626.098050 yylex_token: -X
+1783499626.098052 yylex_token: end at WS
+1783499626.098053 yylex_token: copy-pipe-and-cancel
+1783499626.098056 cmd_parse_build_commands 0:0: bind
+1783499626.098058 cmd_parse_build_commands 0:1: -n
+1783499626.098060 cmd_parse_build_commands 0:2: DoubleClick1Pane
+1783499626.098062 cmd_parse_build_commands 0:3 0:0: select-pane
+1783499626.098066 cmd_parse_build_commands 0:3 0:1: -t=
+1783499626.098068 cmd_parse_build_commands 0:3 1:0: if
+1783499626.098069 cmd_parse_build_commands 0:3 1:1: -F
+1783499626.098072 cmd_parse_build_commands 0:3 1:2: #{||:#{pane_in_mode},#{mouse_any_flag}}
+1783499626.098073 cmd_parse_build_commands 0:3 1:3 0:0: send
+1783499626.098075 cmd_parse_build_commands 0:3 1:3 0:1: -M
+1783499626.098077 cmd_parse_build_commands 0:3 1:4 0:0: copy-mode
+1783499626.098079 cmd_parse_build_commands 0:3 1:4 0:1: -H
+1783499626.098081 cmd_parse_build_commands 0:3 1:4 1:0: send
+1783499626.098082 cmd_parse_build_commands 0:3 1:4 1:1: -X
+1783499626.098084 cmd_parse_build_commands 0:3 1:4 1:2: select-word
+1783499626.098086 cmd_parse_build_commands 0:3 1:4 2:0: run
+1783499626.098088 cmd_parse_build_commands 0:3 1:4 2:1: -d0.3
+1783499626.098090 cmd_parse_build_commands 0:3 1:4 3:0: send
+1783499626.098091 cmd_parse_build_commands 0:3 1:4 3:1: -X
+1783499626.098093 cmd_parse_build_commands 0:3 1:4 3:2: copy-pipe-and-cancel
+1783499626.098096 cmd_parse_build_commands 0:0: select-pane
+1783499626.098097 cmd_parse_build_commands 0:1: -t=
+1783499626.098099 cmd_parse_build_commands 1:0: if
+1783499626.098101 cmd_parse_build_commands 1:1: -F
+1783499626.098103 cmd_parse_build_commands 1:2: #{||:#{pane_in_mode},#{mouse_any_flag}}
+1783499626.098105 cmd_parse_build_commands 1:3 0:0: send
+1783499626.098106 cmd_parse_build_commands 1:3 0:1: -M
+1783499626.098108 cmd_parse_build_commands 1:4 0:0: copy-mode
+1783499626.098110 cmd_parse_build_commands 1:4 0:1: -H
+1783499626.098111 cmd_parse_build_commands 1:4 1:0: send
+1783499626.098113 cmd_parse_build_commands 1:4 1:1: -X
+1783499626.098114 cmd_parse_build_commands 1:4 1:2: select-word
+1783499626.098116 cmd_parse_build_commands 1:4 2:0: run
+1783499626.098118 cmd_parse_build_commands 1:4 2:1: -d0.3
+1783499626.098119 cmd_parse_build_commands 1:4 3:0: send
+1783499626.098121 cmd_parse_build_commands 1:4 3:1: -X
+1783499626.098123 cmd_parse_build_commands 1:4 3:2: copy-pipe-and-cancel
+1783499626.098126 args_parse_flags: next -t=
+1783499626.098128 args_parse_flag_argument: -t = =
+1783499626.098129 args_parse: flags end at 2 of 2
+1783499626.098132 cmd_parse_build_commands 0:0: send
+1783499626.098133 cmd_parse_build_commands 0:1: -M
+1783499626.098136 args_parse_flags: next -M
+1783499626.098137 args_parse_flags: -M
+1783499626.098139 args_parse: flags end at 2 of 2
+1783499626.098141 cmd_parse_build_commands: send-keys -M
+1783499626.098143 cmd_parse_build_commands 0:0: copy-mode
+1783499626.098144 cmd_parse_build_commands 0:1: -H
+1783499626.098146 cmd_parse_build_commands 1:0: send
+1783499626.098148 cmd_parse_build_commands 1:1: -X
+1783499626.098149 cmd_parse_build_commands 1:2: select-word
+1783499626.098151 cmd_parse_build_commands 2:0: run
+1783499626.098152 cmd_parse_build_commands 2:1: -d0.3
+1783499626.098154 cmd_parse_build_commands 3:0: send
+1783499626.098155 cmd_parse_build_commands 3:1: -X
+1783499626.098157 cmd_parse_build_commands 3:2: copy-pipe-and-cancel
+1783499626.098159 args_parse_flags: next -H
+1783499626.098161 args_parse_flags: -H
+1783499626.098162 args_parse: flags end at 2 of 2
+1783499626.098165 args_parse_flags: next -X
+1783499626.098167 args_parse_flags: -X
+1783499626.098168 args_parse_flags: next select-word
+1783499626.098170 args_parse: flags end at 2 of 3
+1783499626.098171 args_parse: 2 = select-word (type STRING)
+1783499626.098175 args_parse_flags: next -d0.3
+1783499626.098176 args_parse_flag_argument: -d = 0.3
+1783499626.098178 args_parse: flags end at 2 of 2
+1783499626.098181 args_parse_flags: next -X
+1783499626.098182 args_parse_flags: -X
+1783499626.098184 args_parse_flags: next copy-pipe-and-cancel
+1783499626.098186 args_parse: flags end at 2 of 3
+1783499626.098187 args_parse: 2 = copy-pipe-and-cancel (type STRING)
+1783499626.098195 cmd_parse_build_commands: copy-mode -H ; send-keys -X select-word ; run-shell -d 0.3 ; send-keys -X copy-pipe-and-cancel
+1783499626.098198 args_parse_flags: next -F
+1783499626.098199 args_parse_flags: -F
+1783499626.098201 args_parse_flags: next #{||:#{pane_in_mode},#{mouse_any_flag}}
+1783499626.098205 args_parse: flags end at 2 of 5
+1783499626.098207 args_parse: 2 = #{||:#{pane_in_mode},#{mouse_any_flag}} (type STRING)
+1783499626.098210 args_parse: 3 = send-keys -M (type COMMANDS)
+1783499626.098224 args_parse: 4 = copy-mode -H ; send-keys -X select-word ; run-shell -d 0.3 ; send-keys -X copy-pipe-and-cancel (type COMMANDS)
+1783499626.098242 cmd_parse_build_commands: select-pane -t = ; if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" { send-keys -M } { copy-mode -H ; send-keys -X select-word ; run-shell -d 0.3 ; send-keys -X copy-pipe-and-cancel }
+1783499626.098245 args_parse_flags: next -n
+1783499626.098246 args_parse_flags: -n
+1783499626.098248 args_parse_flags: next DoubleClick1Pane
+1783499626.098249 args_parse: flags end at 2 of 4
+1783499626.098251 args_parse: 2 = DoubleClick1Pane (type STRING)
+1783499626.098262 args_parse: 3 = select-pane -t = ; if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" { send-keys -M } { copy-mode -H ; send-keys -X select-word ; run-shell -d 0.3 ; send-keys -X copy-pipe-and-cancel } (type COMMANDS)
+1783499626.098276 cmd_parse_build_commands: bind-key -n DoubleClick1Pane { select-pane -t = ; if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" { send-keys -M } { copy-mode -H ; send-keys -X select-word ; run-shell -d 0.3 ; send-keys -X copy-pipe-and-cancel } }
+1783499626.098280 cmdq_get_command: [bind-key/0x58e4724e9290] group 878
+1783499626.098282 cmdq_append <global>: [bind-key/0x58e4724e9290]
+1783499626.098295 yylex_token: end at WS
+1783499626.098298 yylex_token: bind
+1783499626.098300 yylex_token: end at WS
+1783499626.098301 yylex_token: -n
+1783499626.098303 yylex_token: end at WS
+1783499626.098304 yylex_token: TripleClick1Pane
+1783499626.098306 yylex_token: end at WS
+1783499626.098307 yylex_token: select-pane
+1783499626.098309 yylex_token: end at ;
+1783499626.098310 yylex_token: -t=
+1783499626.098312 yylex_token: end at WS
+1783499626.098313 yylex_token: if
+1783499626.098314 yylex_token: end at WS
+1783499626.098316 yylex_token: -F
+1783499626.098318 yylex_token: end at WS
+1783499626.098320 yylex_token: #{||:#{pane_in_mode},#{mouse_any_flag}}
+1783499626.098321 yylex_token: end at WS
+1783499626.098323 yylex_token: send
+1783499626.098324 yylex_token: end at WS
+1783499626.098325 yylex_token: -M
+1783499626.098327 yylex_token: end at WS
+1783499626.098329 yylex_token: copy-mode
+1783499626.098330 yylex_token: end at ;
+1783499626.098331 yylex_token: -H
+1783499626.098333 yylex_token: end at WS
+1783499626.098334 yylex_token: send
+1783499626.098335 yylex_token: end at WS
+1783499626.098336 yylex_token: -X
+1783499626.098338 yylex_token: end at ;
+1783499626.098340 yylex_token: select-line
+1783499626.098341 yylex_token: end at WS
+1783499626.098343 yylex_token: run
+1783499626.098344 yylex_token: end at ;
+1783499626.098345 yylex_token: -d0.3
+1783499626.098347 yylex_token: end at WS
+1783499626.098348 yylex_token: send
+1783499626.098349 yylex_token: end at WS
+1783499626.098350 yylex_token: -X
+1783499626.098352 yylex_token: end at WS
+1783499626.098354 yylex_token: copy-pipe-and-cancel
+1783499626.098357 cmd_parse_build_commands 0:0: bind
+1783499626.098359 cmd_parse_build_commands 0:1: -n
+1783499626.098361 cmd_parse_build_commands 0:2: TripleClick1Pane
+1783499626.098363 cmd_parse_build_commands 0:3 0:0: select-pane
+1783499626.098364 cmd_parse_build_commands 0:3 0:1: -t=
+1783499626.098366 cmd_parse_build_commands 0:3 1:0: if
+1783499626.098421 cmd_parse_build_commands 0:3 1:1: -F
+1783499626.098431 cmd_parse_build_commands 0:3 1:2: #{||:#{pane_in_mode},#{mouse_any_flag}}
+1783499626.098434 cmd_parse_build_commands 0:3 1:3 0:0: send
+1783499626.098436 cmd_parse_build_commands 0:3 1:3 0:1: -M
+1783499626.098438 cmd_parse_build_commands 0:3 1:4 0:0: copy-mode
+1783499626.098439 cmd_parse_build_commands 0:3 1:4 0:1: -H
+1783499626.098441 cmd_parse_build_commands 0:3 1:4 1:0: send
+1783499626.098442 cmd_parse_build_commands 0:3 1:4 1:1: -X
+1783499626.098443 cmd_parse_build_commands 0:3 1:4 1:2: select-line
+1783499626.098445 cmd_parse_build_commands 0:3 1:4 2:0: run
+1783499626.098446 cmd_parse_build_commands 0:3 1:4 2:1: -d0.3
+1783499626.098547 cmd_parse_build_commands 0:3 1:4 3:0: send
+1783499626.098552 cmd_parse_build_commands 0:3 1:4 3:1: -X
+1783499626.098555 cmd_parse_build_commands 0:3 1:4 3:2: copy-pipe-and-cancel
+1783499626.098560 cmd_parse_build_commands 0:0: select-pane
+1783499626.098562 cmd_parse_build_commands 0:1: -t=
+1783499626.098564 cmd_parse_build_commands 1:0: if
+1783499626.098566 cmd_parse_build_commands 1:1: -F
+1783499626.098568 cmd_parse_build_commands 1:2: #{||:#{pane_in_mode},#{mouse_any_flag}}
+1783499626.098571 cmd_parse_build_commands 1:3 0:0: send
+1783499626.098573 cmd_parse_build_commands 1:3 0:1: -M
+1783499626.098575 cmd_parse_build_commands 1:4 0:0: copy-mode
+1783499626.098577 cmd_parse_build_commands 1:4 0:1: -H
+1783499626.098579 cmd_parse_build_commands 1:4 1:0: send
+1783499626.098581 cmd_parse_build_commands 1:4 1:1: -X
+1783499626.098583 cmd_parse_build_commands 1:4 1:2: select-line
+1783499626.098584 cmd_parse_build_commands 1:4 2:0: run
+1783499626.098586 cmd_parse_build_commands 1:4 2:1: -d0.3
+1783499626.098588 cmd_parse_build_commands 1:4 3:0: send
+1783499626.098590 cmd_parse_build_commands 1:4 3:1: -X
+1783499626.098592 cmd_parse_build_commands 1:4 3:2: copy-pipe-and-cancel
+1783499626.098597 args_parse_flags: next -t=
+1783499626.098599 args_parse_flag_argument: -t = =
+1783499626.098601 args_parse: flags end at 2 of 2
+1783499626.098604 cmd_parse_build_commands 0:0: send
+1783499626.098605 cmd_parse_build_commands 0:1: -M
+1783499626.098609 args_parse_flags: next -M
+1783499626.098610 args_parse_flags: -M
+1783499626.098612 args_parse: flags end at 2 of 2
+1783499626.098615 cmd_parse_build_commands: send-keys -M
+1783499626.098617 cmd_parse_build_commands 0:0: copy-mode
+1783499626.098619 cmd_parse_build_commands 0:1: -H
+1783499626.098620 cmd_parse_build_commands 1:0: send
+1783499626.098622 cmd_parse_build_commands 1:1: -X
+1783499626.098624 cmd_parse_build_commands 1:2: select-line
+1783499626.098626 cmd_parse_build_commands 2:0: run
+1783499626.098627 cmd_parse_build_commands 2:1: -d0.3
+1783499626.098629 cmd_parse_build_commands 3:0: send
+1783499626.098631 cmd_parse_build_commands 3:1: -X
+1783499626.098633 cmd_parse_build_commands 3:2: copy-pipe-and-cancel
+1783499626.098635 args_parse_flags: next -H
+1783499626.098636 args_parse_flags: -H
+1783499626.098638 args_parse: flags end at 2 of 2
+1783499626.098641 args_parse_flags: next -X
+1783499626.098643 args_parse_flags: -X
+1783499626.098644 args_parse_flags: next select-line
+1783499626.098646 args_parse: flags end at 2 of 3
+1783499626.098648 args_parse: 2 = select-line (type STRING)
+1783499626.098651 args_parse_flags: next -d0.3
+1783499626.098653 args_parse_flag_argument: -d = 0.3
+1783499626.098654 args_parse: flags end at 2 of 2
+1783499626.098657 args_parse_flags: next -X
+1783499626.098659 args_parse_flags: -X
+1783499626.098661 args_parse_flags: next copy-pipe-and-cancel
+1783499626.098662 args_parse: flags end at 2 of 3
+1783499626.098664 args_parse: 2 = copy-pipe-and-cancel (type STRING)
+1783499626.098672 cmd_parse_build_commands: copy-mode -H ; send-keys -X select-line ; run-shell -d 0.3 ; send-keys -X copy-pipe-and-cancel
+1783499626.098674 args_parse_flags: next -F
+1783499626.098676 args_parse_flags: -F
+1783499626.098678 args_parse_flags: next #{||:#{pane_in_mode},#{mouse_any_flag}}
+1783499626.098679 args_parse: flags end at 2 of 5
+1783499626.098682 args_parse: 2 = #{||:#{pane_in_mode},#{mouse_any_flag}} (type STRING)
+1783499626.098684 args_parse: 3 = send-keys -M (type COMMANDS)
+1783499626.098691 args_parse: 4 = copy-mode -H ; send-keys -X select-line ; run-shell -d 0.3 ; send-keys -X copy-pipe-and-cancel (type COMMANDS)
+1783499626.098702 cmd_parse_build_commands: select-pane -t = ; if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" { send-keys -M } { copy-mode -H ; send-keys -X select-line ; run-shell -d 0.3 ; send-keys -X copy-pipe-and-cancel }
+1783499626.098705 args_parse_flags: next -n
+1783499626.098706 args_parse_flags: -n
+1783499626.098708 args_parse_flags: next TripleClick1Pane
+1783499626.098709 args_parse: flags end at 2 of 4
+1783499626.098799 args_parse: 2 = TripleClick1Pane (type STRING)
+1783499626.098820 args_parse: 3 = select-pane -t = ; if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" { send-keys -M } { copy-mode -H ; send-keys -X select-line ; run-shell -d 0.3 ; send-keys -X copy-pipe-and-cancel } (type COMMANDS)
+1783499626.098843 cmd_parse_build_commands: bind-key -n TripleClick1Pane { select-pane -t = ; if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" { send-keys -M } { copy-mode -H ; send-keys -X select-line ; run-shell -d 0.3 ; send-keys -X copy-pipe-and-cancel } }
+1783499626.098852 cmdq_get_command: [bind-key/0x58e4724ea530] group 898
+1783499626.098855 cmdq_append <global>: [bind-key/0x58e4724ea530]
+1783499626.098887 yylex_token: end at WS
+1783499626.098892 yylex_token: bind
+1783499626.098895 yylex_token: end at WS
+1783499626.098897 yylex_token: -n
+1783499626.098899 yylex_token: end at WS
+1783499626.098901 yylex_token: MouseDrag1Border
+1783499626.098903 yylex_token: end at WS
+1783499626.098904 yylex_token: resize-pane
+1783499626.098906 yylex_token: end at WS
+1783499626.098907 yylex_token: -M
+1783499626.098911 cmd_parse_build_commands 0:0: bind
+1783499626.098913 cmd_parse_build_commands 0:1: -n
+1783499626.098915 cmd_parse_build_commands 0:2: MouseDrag1Border
+1783499626.098917 cmd_parse_build_commands 0:3 0:0: resize-pane
+1783499626.098919 cmd_parse_build_commands 0:3 0:1: -M
+1783499626.098923 cmd_parse_build_commands 0:0: resize-pane
+1783499626.098924 cmd_parse_build_commands 0:1: -M
+1783499626.098928 args_parse_flags: next -M
+1783499626.098930 args_parse_flags: -M
+1783499626.098932 args_parse: flags end at 2 of 2
+1783499626.098935 cmd_parse_build_commands: resize-pane -M
+1783499626.098937 args_parse_flags: next -n
+1783499626.098938 args_parse_flags: -n
+1783499626.098940 args_parse_flags: next MouseDrag1Border
+1783499626.098941 args_parse: flags end at 2 of 4
+1783499626.098943 args_parse: 2 = MouseDrag1Border (type STRING)
+1783499626.098946 args_parse: 3 = resize-pane -M (type COMMANDS)
+1783499626.098952 cmd_parse_build_commands: bind-key -n MouseDrag1Border { resize-pane -M }
+1783499626.098955 cmdq_get_command: [bind-key/0x58e4724e99a0] group 918
+1783499626.098957 cmdq_append <global>: [bind-key/0x58e4724e99a0]
+1783499626.098960 yylex_token: end at WS
+1783499626.098962 yylex_token: bind
+1783499626.098963 yylex_token: end at WS
+1783499626.098965 yylex_token: -n
+1783499626.098966 yylex_token: end at WS
+1783499626.098968 yylex_token: MouseDown1Status
+1783499626.098970 yylex_token: end at WS
+1783499626.098971 yylex_token: select-window
+1783499626.098973 yylex_token: end at WS
+1783499626.098974 yylex_token: -t=
+1783499626.098977 cmd_parse_build_commands 0:0: bind
+1783499626.098979 cmd_parse_build_commands 0:1: -n
+1783499626.098981 cmd_parse_build_commands 0:2: MouseDown1Status
+1783499626.098983 cmd_parse_build_commands 0:3 0:0: select-window
+1783499626.098984 cmd_parse_build_commands 0:3 0:1: -t=
+1783499626.098987 cmd_parse_build_commands 0:0: select-window
+1783499626.098989 cmd_parse_build_commands 0:1: -t=
+1783499626.098992 args_parse_flags: next -t=
+1783499626.098994 args_parse_flag_argument: -t = =
+1783499626.098996 args_parse: flags end at 2 of 2
+1783499626.098999 cmd_parse_build_commands: select-window -t =
+1783499626.099001 args_parse_flags: next -n
+1783499626.099002 args_parse_flags: -n
+1783499626.099004 args_parse_flags: next MouseDown1Status
+1783499626.099005 args_parse: flags end at 2 of 4
+1783499626.099007 args_parse: 2 = MouseDown1Status (type STRING)
+1783499626.099011 args_parse: 3 = select-window -t = (type COMMANDS)
+1783499626.099016 cmd_parse_build_commands: bind-key -n MouseDown1Status { select-window -t = }
+1783499626.099019 cmdq_get_command: [bind-key/0x58e4724d2270] group 926
+1783499626.099021 cmdq_append <global>: [bind-key/0x58e4724d2270]
+1783499626.099024 yylex_token: end at WS
+1783499626.099025 yylex_token: bind
+1783499626.099027 yylex_token: end at WS
+1783499626.099028 yylex_token: -n
+1783499626.099030 yylex_token: end at WS
+1783499626.099031 yylex_token: WheelDownStatus
+1783499626.099033 yylex_token: end at WS
+1783499626.099041 yylex_token: next-window
+1783499626.099045 cmd_parse_build_commands 0:0: bind
+1783499626.099046 cmd_parse_build_commands 0:1: -n
+1783499626.099048 cmd_parse_build_commands 0:2: WheelDownStatus
+1783499626.099050 cmd_parse_build_commands 0:3 0:0: next-window
+1783499626.099053 cmd_parse_build_commands 0:0: next-window
+1783499626.099055 args_parse: flags end at 1 of 1
+1783499626.099058 cmd_parse_build_commands: next-window
+1783499626.099060 args_parse_flags: next -n
+1783499626.099061 args_parse_flags: -n
+1783499626.099063 args_parse_flags: next WheelDownStatus
+1783499626.099064 args_parse: flags end at 2 of 4
+1783499626.099066 args_parse: 2 = WheelDownStatus (type STRING)
+1783499626.099069 args_parse: 3 = next-window (type COMMANDS)
+1783499626.099073 cmd_parse_build_commands: bind-key -n WheelDownStatus { next-window }
+1783499626.099076 cmdq_get_command: [bind-key/0x58e4724e1590] group 934
+1783499626.099078 cmdq_append <global>: [bind-key/0x58e4724e1590]
+1783499626.099081 yylex_token: end at WS
+1783499626.099082 yylex_token: bind
+1783499626.099084 yylex_token: end at WS
+1783499626.099085 yylex_token: -n
+1783499626.099087 yylex_token: end at WS
+1783499626.099088 yylex_token: WheelUpStatus
+1783499626.099090 yylex_token: end at WS
+1783499626.099092 yylex_token: previous-window
+1783499626.099094 cmd_parse_build_commands 0:0: bind
+1783499626.099096 cmd_parse_build_commands 0:1: -n
+1783499626.099098 cmd_parse_build_commands 0:2: WheelUpStatus
+1783499626.099100 cmd_parse_build_commands 0:3 0:0: previous-window
+1783499626.099103 cmd_parse_build_commands 0:0: previous-window
+1783499626.099106 args_parse: flags end at 1 of 1
+1783499626.099108 cmd_parse_build_commands: previous-window
+1783499626.099110 args_parse_flags: next -n
+1783499626.099111 args_parse_flags: -n
+1783499626.099113 args_parse_flags: next WheelUpStatus
+1783499626.099114 args_parse: flags end at 2 of 4
+1783499626.099116 args_parse: 2 = WheelUpStatus (type STRING)
+1783499626.099118 args_parse: 3 = previous-window (type COMMANDS)
+1783499626.099123 cmd_parse_build_commands: bind-key -n WheelUpStatus { previous-window }
+1783499626.099126 cmdq_get_command: [bind-key/0x58e4724e8f50] group 942
+1783499626.099128 cmdq_append <global>: [bind-key/0x58e4724e8f50]
+1783499626.099131 yylex_token: end at WS
+1783499626.099132 yylex_token: bind
+1783499626.099134 yylex_token: end at WS
+1783499626.099135 yylex_token: -n
+1783499626.099137 yylex_token: end at WS
+1783499626.099139 yylex_token: MouseDown3StatusLeft
+1783499626.099140 yylex_token: end at WS
+1783499626.099142 yylex_token: display-menu
+1783499626.099144 yylex_token: end at WS
+1783499626.099145 yylex_token: -t=
+1783499626.099147 yylex_token: end at WS
+1783499626.099148 yylex_token: -xM
+1783499626.099149 yylex_token: end at WS
+1783499626.099151 yylex_token: -yW
+1783499626.099152 yylex_token: end at WS
+1783499626.099153 yylex_token: -T
+1783499626.099156 yylex_token: end at WS
+1783499626.099157 yylex_token: #[align=centre]#{session_name}
+1783499626.099159 yylex_token: end at WS
+1783499626.099160 yylex_token: Next
+1783499626.099162 yylex_token: end at WS
+1783499626.099163 yylex_token: n
+1783499626.099165 yylex_token: end at WS
+1783499626.099166 yylex_token: switch-client
+1783499626.099168 yylex_token: end at }
+1783499626.099169 yylex_token: -n
+1783499626.099171 yylex_token: end at WS
+1783499626.099173 yylex_token: Previous
+1783499626.099174 yylex_token: end at WS
+1783499626.099176 yylex_token: p
+1783499626.099178 yylex_token: end at WS
+1783499626.099179 yylex_token: switch-client
+1783499626.099181 yylex_token: end at }
+1783499626.099182 yylex_token: -p
+1783499626.099184 yylex_token: end at WS
+1783499626.099185 yylex_token: 
+1783499626.099186 yylex_token: end at WS
+1783499626.099188 yylex_token: Renumber
+1783499626.099189 yylex_token: end at WS
+1783499626.099191 yylex_token: N
+1783499626.099192 yylex_token: end at WS
+1783499626.099194 yylex_token: move-window
+1783499626.099196 yylex_token: end at }
+1783499626.099197 yylex_token: -r
+1783499626.099199 yylex_token: end at WS
+1783499626.099200 yylex_token: Rename
+1783499626.099206 yylex_token: end at WS
+1783499626.099208 yylex_token: n
+1783499626.099210 yylex_token: end at WS
+1783499626.099211 yylex_token: command-prompt
+1783499626.099213 yylex_token: end at WS
+1783499626.099214 yylex_token: -I
+1783499626.099215 yylex_token: end at WS
+1783499626.099217 yylex_token: #S
+1783499626.099218 yylex_token: end at WS
+1783499626.099220 yylex_token: rename-session
+1783499626.099222 yylex_token: end at WS
+1783499626.099223 yylex_token: --
+1783499626.099224 yylex_token: end at }
+1783499626.099225 yylex_token: %%
+1783499626.099228 yylex_token: end at WS
+1783499626.099229 yylex_token: 
+1783499626.099231 yylex_token: end at WS
+1783499626.099232 yylex_token: New Session
+1783499626.099234 yylex_token: end at WS
+1783499626.099235 yylex_token: s
+1783499626.099237 yylex_token: end at }
+1783499626.099238 yylex_token: new-session
+1783499626.099240 yylex_token: end at WS
+1783499626.099241 yylex_token: New Window
+1783499626.099243 yylex_token: end at WS
+1783499626.099244 yylex_token: w
+1783499626.099246 yylex_token: end at }
+1783499626.099247 yylex_token: new-window
+1783499626.099250 cmd_parse_build_commands 0:0: bind
+1783499626.099252 cmd_parse_build_commands 0:1: -n
+1783499626.099254 cmd_parse_build_commands 0:2: MouseDown3StatusLeft
+1783499626.099256 cmd_parse_build_commands 0:3 0:0: display-menu
+1783499626.099258 cmd_parse_build_commands 0:3 0:1: -t=
+1783499626.099260 cmd_parse_build_commands 0:3 0:2: -xM
+1783499626.099262 cmd_parse_build_commands 0:3 0:3: -yW
+1783499626.099263 cmd_parse_build_commands 0:3 0:4: -T
+1783499626.099266 cmd_parse_build_commands 0:3 0:5: #[align=centre]#{session_name}
+1783499626.099267 cmd_parse_build_commands 0:3 0:6: Next
+1783499626.099269 cmd_parse_build_commands 0:3 0:7: n
+1783499626.099271 cmd_parse_build_commands 0:3 0:8 0:0: switch-client
+1783499626.099273 cmd_parse_build_commands 0:3 0:8 0:1: -n
+1783499626.099275 cmd_parse_build_commands 0:3 0:9: Previous
+1783499626.099277 cmd_parse_build_commands 0:3 0:10: p
+1783499626.099279 cmd_parse_build_commands 0:3 0:11 0:0: switch-client
+1783499626.099281 cmd_parse_build_commands 0:3 0:11 0:1: -p
+1783499626.099282 cmd_parse_build_commands 0:3 0:12: 
+1783499626.099284 cmd_parse_build_commands 0:3 0:13: Renumber
+1783499626.099286 cmd_parse_build_commands 0:3 0:14: N
+1783499626.099288 cmd_parse_build_commands 0:3 0:15 0:0: move-window
+1783499626.099290 cmd_parse_build_commands 0:3 0:15 0:1: -r
+1783499626.099291 cmd_parse_build_commands 0:3 0:16: Rename
+1783499626.099293 cmd_parse_build_commands 0:3 0:17: n
+1783499626.099295 cmd_parse_build_commands 0:3 0:18 0:0: command-prompt
+1783499626.099297 cmd_parse_build_commands 0:3 0:18 0:1: -I
+1783499626.099298 cmd_parse_build_commands 0:3 0:18 0:2: #S
+1783499626.099301 cmd_parse_build_commands 0:3 0:18 0:3 0:0: rename-session
+1783499626.099303 cmd_parse_build_commands 0:3 0:18 0:3 0:1: --
+1783499626.099304 cmd_parse_build_commands 0:3 0:18 0:3 0:2: %%
+1783499626.099306 cmd_parse_build_commands 0:3 0:19: 
+1783499626.099308 cmd_parse_build_commands 0:3 0:20: New Session
+1783499626.099309 cmd_parse_build_commands 0:3 0:21: s
+1783499626.099311 cmd_parse_build_commands 0:3 0:22 0:0: new-session
+1783499626.099313 cmd_parse_build_commands 0:3 0:23: New Window
+1783499626.099315 cmd_parse_build_commands 0:3 0:24: w
+1783499626.099317 cmd_parse_build_commands 0:3 0:25 0:0: new-window
+1783499626.099319 cmd_parse_build_commands 0:0: display-menu
+1783499626.099321 cmd_parse_build_commands 0:1: -t=
+1783499626.099330 cmd_parse_build_commands 0:2: -xM
+1783499626.099336 cmd_parse_build_commands 0:3: -yW
+1783499626.099337 cmd_parse_build_commands 0:4: -T
+1783499626.099340 cmd_parse_build_commands 0:5: #[align=centre]#{session_name}
+1783499626.099341 cmd_parse_build_commands 0:6: Next
+1783499626.099343 cmd_parse_build_commands 0:7: n
+1783499626.099345 cmd_parse_build_commands 0:8 0:0: switch-client
+1783499626.099347 cmd_parse_build_commands 0:8 0:1: -n
+1783499626.099349 cmd_parse_build_commands 0:9: Previous
+1783499626.099350 cmd_parse_build_commands 0:10: p
+1783499626.099352 cmd_parse_build_commands 0:11 0:0: switch-client
+1783499626.099357 cmd_parse_build_commands 0:11 0:1: -p
+1783499626.099359 cmd_parse_build_commands 0:12: 
+1783499626.099361 cmd_parse_build_commands 0:13: Renumber
+1783499626.099362 cmd_parse_build_commands 0:14: N
+1783499626.099364 cmd_parse_build_commands 0:15 0:0: move-window
+1783499626.099366 cmd_parse_build_commands 0:15 0:1: -r
+1783499626.099368 cmd_parse_build_commands 0:16: Rename
+1783499626.099369 cmd_parse_build_commands 0:17: n
+1783499626.099371 cmd_parse_build_commands 0:18 0:0: command-prompt
+1783499626.099373 cmd_parse_build_commands 0:18 0:1: -I
+1783499626.099374 cmd_parse_build_commands 0:18 0:2: #S
+1783499626.099376 cmd_parse_build_commands 0:18 0:3 0:0: rename-session
+1783499626.099378 cmd_parse_build_commands 0:18 0:3 0:1: --
+1783499626.099380 cmd_parse_build_commands 0:18 0:3 0:2: %%
+1783499626.099382 cmd_parse_build_commands 0:19: 
+1783499626.099383 cmd_parse_build_commands 0:20: New Session
+1783499626.099385 cmd_parse_build_commands 0:21: s
+1783499626.099391 cmd_parse_build_commands 0:22 0:0: new-session
+1783499626.099396 cmd_parse_build_commands 0:23: New Window
+1783499626.099397 cmd_parse_build_commands 0:24: w
+1783499626.099399 cmd_parse_build_commands 0:25 0:0: new-window
+1783499626.099404 cmd_parse_build_commands 0:0: switch-client
+1783499626.099405 cmd_parse_build_commands 0:1: -n
+1783499626.099410 args_parse_flags: next -n
+1783499626.099412 args_parse_flags: -n
+1783499626.099414 args_parse: flags end at 2 of 2
+1783499626.099417 cmd_parse_build_commands: switch-client -n
+1783499626.099419 cmd_parse_build_commands 0:0: switch-client
+1783499626.099420 cmd_parse_build_commands 0:1: -p
+1783499626.099424 args_parse_flags: next -p
+1783499626.099425 args_parse_flags: -p
+1783499626.099427 args_parse: flags end at 2 of 2
+1783499626.099429 cmd_parse_build_commands: switch-client -p
+1783499626.099432 cmd_parse_build_commands 0:0: move-window
+1783499626.099433 cmd_parse_build_commands 0:1: -r
+1783499626.099436 args_parse_flags: next -r
+1783499626.099437 args_parse_flags: -r
+1783499626.099439 args_parse: flags end at 2 of 2
+1783499626.099441 cmd_parse_build_commands: move-window -r
+1783499626.099444 cmd_parse_build_commands 0:0: command-prompt
+1783499626.099445 cmd_parse_build_commands 0:1: -I
+1783499626.099447 cmd_parse_build_commands 0:2: #S
+1783499626.099449 cmd_parse_build_commands 0:3 0:0: rename-session
+1783499626.099450 cmd_parse_build_commands 0:3 0:1: --
+1783499626.099452 cmd_parse_build_commands 0:3 0:2: %%
+1783499626.099454 cmd_parse_build_commands 0:0: rename-session
+1783499626.099456 cmd_parse_build_commands 0:1: --
+1783499626.099457 cmd_parse_build_commands 0:2: %%
+1783499626.099460 args_parse_flags: next --
+1783499626.099462 args_parse: flags end at 2 of 3
+1783499626.099464 args_parse: 2 = %% (type STRING)
+1783499626.099472 cmd_parse_build_commands: rename-session "%%"
+1783499626.099477 args_parse_flags: next -I
+1783499626.099479 args_parse_flag_argument: -I = #S
+1783499626.099481 args_parse: flags end at 3 of 4
+1783499626.099484 args_parse: 3 = rename-session "%%" (type COMMANDS)
+1783499626.099489 cmd_parse_build_commands: command-prompt -I "#S" { rename-session "%%" }
+1783499626.099492 cmd_parse_build_commands 0:0: new-session
+1783499626.099495 args_parse: flags end at 1 of 1
+1783499626.099497 cmd_parse_build_commands: new-session
+1783499626.099506 cmd_parse_build_commands 0:0: new-window
+1783499626.099509 args_parse: flags end at 1 of 1
+1783499626.099511 cmd_parse_build_commands: new-window
+1783499626.099513 args_parse_flags: next -t=
+1783499626.099515 args_parse_flag_argument: -t = =
+1783499626.099516 args_parse_flags: next -xM
+1783499626.099518 args_parse_flag_argument: -x = M
+1783499626.099519 args_parse_flags: next -yW
+1783499626.099521 args_parse_flag_argument: -y = W
+1783499626.099522 args_parse_flags: next -T
+1783499626.099525 args_parse_flag_argument: -T = #[align=centre]#{session_name}
+1783499626.099526 args_parse_flags: next Next
+1783499626.099528 args_parse: flags end at 6 of 26
+1783499626.099530 args_parse: 6 = Next (type STRING)
+1783499626.099532 args_parse: 7 = n (type STRING)
+1783499626.099538 args_parse: 8 = switch-client -n (type COMMANDS)
+1783499626.099540 args_parse: 9 = Previous (type STRING)
+1783499626.099542 args_parse: 10 = p (type STRING)
+1783499626.099545 args_parse: 11 = switch-client -p (type COMMANDS)
+1783499626.099547 args_parse: 12 =  (type STRING)
+1783499626.099549 args_parse: 13 = Renumber (type STRING)
+1783499626.099551 args_parse: 14 = N (type STRING)
+1783499626.099554 args_parse: 15 = move-window -r (type COMMANDS)
+1783499626.099556 args_parse: 16 = Rename (type STRING)
+1783499626.099558 args_parse: 17 = n (type STRING)
+1783499626.099563 args_parse: 18 = command-prompt -I "#S" { rename-session "%%" } (type COMMANDS)
+1783499626.099565 args_parse: 19 =  (type STRING)
+1783499626.099567 args_parse: 20 = New Session (type STRING)
+1783499626.099569 args_parse: 21 = s (type STRING)
+1783499626.099571 args_parse: 22 = new-session (type COMMANDS)
+1783499626.099573 args_parse: 23 = New Window (type STRING)
+1783499626.099575 args_parse: 24 = w (type STRING)
+1783499626.099577 args_parse: 25 = new-window (type COMMANDS)
+1783499626.099601 cmd_parse_build_commands: display-menu -T "#[align=centre]#{session_name}" -t = -x M -y W Next n { switch-client -n } Previous p { switch-client -p } '' Renumber N { move-window -r } Rename n { command-prompt -I "#S" { rename-session "%%" } } '' "New Session" s { new-session } "New Window" w { new-window }
+1783499626.099603 args_parse_flags: next -n
+1783499626.099605 args_parse_flags: -n
+1783499626.099607 args_parse_flags: next MouseDown3StatusLeft
+1783499626.099608 args_parse: flags end at 2 of 4
+1783499626.099639 args_parse: 2 = MouseDown3StatusLeft (type STRING)
+1783499626.099668 args_parse: 3 = display-menu -T "#[align=centre]#{session_name}" -t = -x M -y W Next n { switch-client -n } Previous p { switch-client -p } '' Renumber N { move-window -r } Rename n { command-prompt -I "#S" { rename-session "%%" } } '' "New Session" s { new-session } "New Window" w { new-window } (type COMMANDS)
+1783499626.099694 cmd_parse_build_commands: bind-key -n MouseDown3StatusLeft { display-menu -T "#[align=centre]#{session_name}" -t = -x M -y W Next n { switch-client -n } Previous p { switch-client -p } '' Renumber N { move-window -r } Rename n { command-prompt -I "#S" { rename-session "%%" } } '' "New Session" s { new-session } "New Window" w { new-window } }
+1783499626.099702 cmdq_get_command: [bind-key/0x58e4724ed6e0] group 950
+1783499626.099705 cmdq_append <global>: [bind-key/0x58e4724ed6e0]
+1783499626.099711 yylex_token: end at WS
+1783499626.099712 yylex_token: bind
+1783499626.099714 yylex_token: end at WS
+1783499626.099716 yylex_token: -n
+1783499626.099718 yylex_token: end at WS
+1783499626.099719 yylex_token: M-MouseDown3StatusLeft
+1783499626.099721 yylex_token: end at WS
+1783499626.099723 yylex_token: display-menu
+1783499626.099724 yylex_token: end at WS
+1783499626.099726 yylex_token: -t=
+1783499626.099727 yylex_token: end at WS
+1783499626.099729 yylex_token: -xM
+1783499626.099730 yylex_token: end at WS
+1783499626.099731 yylex_token: -yW
+1783499626.099733 yylex_token: end at WS
+1783499626.099734 yylex_token: -T
+1783499626.099736 yylex_token: end at WS
+1783499626.099738 yylex_token: #[align=centre]#{session_name}
+1783499626.099740 yylex_token: end at WS
+1783499626.099741 yylex_token: Next
+1783499626.099742 yylex_token: end at WS
+1783499626.099744 yylex_token: n
+1783499626.099746 yylex_token: end at WS
+1783499626.099747 yylex_token: switch-client
+1783499626.099749 yylex_token: end at }
+1783499626.099750 yylex_token: -n
+1783499626.099752 yylex_token: end at WS
+1783499626.099754 yylex_token: Previous
+1783499626.099755 yylex_token: end at WS
+1783499626.099756 yylex_token: p
+1783499626.099758 yylex_token: end at WS
+1783499626.099760 yylex_token: switch-client
+1783499626.099761 yylex_token: end at }
+1783499626.099762 yylex_token: -p
+1783499626.099764 yylex_token: end at WS
+1783499626.099765 yylex_token: 
+1783499626.099767 yylex_token: end at WS
+1783499626.099768 yylex_token: Renumber
+1783499626.099770 yylex_token: end at WS
+1783499626.099777 yylex_token: N
+1783499626.099780 yylex_token: end at WS
+1783499626.099781 yylex_token: move-window
+1783499626.099783 yylex_token: end at }
+1783499626.099784 yylex_token: -r
+1783499626.099786 yylex_token: end at WS
+1783499626.099787 yylex_token: Rename
+1783499626.099789 yylex_token: end at WS
+1783499626.099790 yylex_token: n
+1783499626.099792 yylex_token: end at WS
+1783499626.099793 yylex_token: command-prompt
+1783499626.099795 yylex_token: end at WS
+1783499626.099796 yylex_token: -I
+1783499626.099798 yylex_token: end at WS
+1783499626.099799 yylex_token: #S
+1783499626.099801 yylex_token: end at WS
+1783499626.099802 yylex_token: rename-session
+1783499626.099804 yylex_token: end at WS
+1783499626.099805 yylex_token: --
+1783499626.099806 yylex_token: end at }
+1783499626.099808 yylex_token: %%
+1783499626.099810 yylex_token: end at WS
+1783499626.099811 yylex_token: 
+1783499626.099813 yylex_token: end at WS
+1783499626.099814 yylex_token: New Session
+1783499626.099815 yylex_token: end at WS
+1783499626.099817 yylex_token: s
+1783499626.099819 yylex_token: end at }
+1783499626.099820 yylex_token: new-session
+1783499626.099822 yylex_token: end at WS
+1783499626.099823 yylex_token: New Window
+1783499626.099825 yylex_token: end at WS
+1783499626.099826 yylex_token: w
+1783499626.099828 yylex_token: end at }
+1783499626.099829 yylex_token: new-window
+1783499626.099833 cmd_parse_build_commands 0:0: bind
+1783499626.099835 cmd_parse_build_commands 0:1: -n
+1783499626.099837 cmd_parse_build_commands 0:2: M-MouseDown3StatusLeft
+1783499626.099839 cmd_parse_build_commands 0:3 0:0: display-menu
+1783499626.099841 cmd_parse_build_commands 0:3 0:1: -t=
+1783499626.099843 cmd_parse_build_commands 0:3 0:2: -xM
+1783499626.099844 cmd_parse_build_commands 0:3 0:3: -yW
+1783499626.099846 cmd_parse_build_commands 0:3 0:4: -T
+1783499626.099848 cmd_parse_build_commands 0:3 0:5: #[align=centre]#{session_name}
+1783499626.099850 cmd_parse_build_commands 0:3 0:6: Next
+1783499626.099852 cmd_parse_build_commands 0:3 0:7: n
+1783499626.099854 cmd_parse_build_commands 0:3 0:8 0:0: switch-client
+1783499626.099856 cmd_parse_build_commands 0:3 0:8 0:1: -n
+1783499626.099858 cmd_parse_build_commands 0:3 0:9: Previous
+1783499626.099859 cmd_parse_build_commands 0:3 0:10: p
+1783499626.099861 cmd_parse_build_commands 0:3 0:11 0:0: switch-client
+1783499626.099863 cmd_parse_build_commands 0:3 0:11 0:1: -p
+1783499626.099865 cmd_parse_build_commands 0:3 0:12: 
+1783499626.099867 cmd_parse_build_commands 0:3 0:13: Renumber
+1783499626.099869 cmd_parse_build_commands 0:3 0:14: N
+1783499626.099871 cmd_parse_build_commands 0:3 0:15 0:0: move-window
+1783499626.099873 cmd_parse_build_commands 0:3 0:15 0:1: -r
+1783499626.099874 cmd_parse_build_commands 0:3 0:16: Rename
+1783499626.099876 cmd_parse_build_commands 0:3 0:17: n
+1783499626.099878 cmd_parse_build_commands 0:3 0:18 0:0: command-prompt
+1783499626.099880 cmd_parse_build_commands 0:3 0:18 0:1: -I
+1783499626.099882 cmd_parse_build_commands 0:3 0:18 0:2: #S
+1783499626.099884 cmd_parse_build_commands 0:3 0:18 0:3 0:0: rename-session
+1783499626.099886 cmd_parse_build_commands 0:3 0:18 0:3 0:1: --
+1783499626.099887 cmd_parse_build_commands 0:3 0:18 0:3 0:2: %%
+1783499626.099889 cmd_parse_build_commands 0:3 0:19: 
+1783499626.099891 cmd_parse_build_commands 0:3 0:20: New Session
+1783499626.099893 cmd_parse_build_commands 0:3 0:21: s
+1783499626.099895 cmd_parse_build_commands 0:3 0:22 0:0: new-session
+1783499626.099897 cmd_parse_build_commands 0:3 0:23: New Window
+1783499626.099898 cmd_parse_build_commands 0:3 0:24: w
+1783499626.099900 cmd_parse_build_commands 0:3 0:25 0:0: new-window
+1783499626.099904 cmd_parse_build_commands 0:0: display-menu
+1783499626.099905 cmd_parse_build_commands 0:1: -t=
+1783499626.099907 cmd_parse_build_commands 0:2: -xM
+1783499626.099908 cmd_parse_build_commands 0:3: -yW
+1783499626.099910 cmd_parse_build_commands 0:4: -T
+1783499626.099912 cmd_parse_build_commands 0:5: #[align=centre]#{session_name}
+1783499626.099914 cmd_parse_build_commands 0:6: Next
+1783499626.099915 cmd_parse_build_commands 0:7: n
+1783499626.099917 cmd_parse_build_commands 0:8 0:0: switch-client
+1783499626.099923 cmd_parse_build_commands 0:8 0:1: -n
+1783499626.099933 cmd_parse_build_commands 0:9: Previous
+1783499626.099938 cmd_parse_build_commands 0:10: p
+1783499626.099941 cmd_parse_build_commands 0:11 0:0: switch-client
+1783499626.099943 cmd_parse_build_commands 0:11 0:1: -p
+1783499626.099944 cmd_parse_build_commands 0:12: 
+1783499626.099946 cmd_parse_build_commands 0:13: Renumber
+1783499626.099948 cmd_parse_build_commands 0:14: N
+1783499626.099950 cmd_parse_build_commands 0:15 0:0: move-window
+1783499626.099952 cmd_parse_build_commands 0:15 0:1: -r
+1783499626.099953 cmd_parse_build_commands 0:16: Rename
+1783499626.099955 cmd_parse_build_commands 0:17: n
+1783499626.099957 cmd_parse_build_commands 0:18 0:0: command-prompt
+1783499626.099959 cmd_parse_build_commands 0:18 0:1: -I
+1783499626.099961 cmd_parse_build_commands 0:18 0:2: #S
+1783499626.099963 cmd_parse_build_commands 0:18 0:3 0:0: rename-session
+1783499626.099965 cmd_parse_build_commands 0:18 0:3 0:1: --
+1783499626.099966 cmd_parse_build_commands 0:18 0:3 0:2: %%
+1783499626.099968 cmd_parse_build_commands 0:19: 
+1783499626.099970 cmd_parse_build_commands 0:20: New Session
+1783499626.099971 cmd_parse_build_commands 0:21: s
+1783499626.099973 cmd_parse_build_commands 0:22 0:0: new-session
+1783499626.099975 cmd_parse_build_commands 0:23: New Window
+1783499626.099976 cmd_parse_build_commands 0:24: w
+1783499626.099978 cmd_parse_build_commands 0:25 0:0: new-window
+1783499626.099982 cmd_parse_build_commands 0:0: switch-client
+1783499626.099984 cmd_parse_build_commands 0:1: -n
+1783499626.099989 args_parse_flags: next -n
+1783499626.099990 args_parse_flags: -n
+1783499626.099992 args_parse: flags end at 2 of 2
+1783499626.099995 cmd_parse_build_commands: switch-client -n
+1783499626.100002 cmd_parse_build_commands 0:0: switch-client
+1783499626.100006 cmd_parse_build_commands 0:1: -p
+1783499626.100011 args_parse_flags: next -p
+1783499626.100012 args_parse_flags: -p
+1783499626.100014 args_parse: flags end at 2 of 2
+1783499626.100017 cmd_parse_build_commands: switch-client -p
+1783499626.100019 cmd_parse_build_commands 0:0: move-window
+1783499626.100021 cmd_parse_build_commands 0:1: -r
+1783499626.100024 args_parse_flags: next -r
+1783499626.100025 args_parse_flags: -r
+1783499626.100027 args_parse: flags end at 2 of 2
+1783499626.100029 cmd_parse_build_commands: move-window -r
+1783499626.100031 cmd_parse_build_commands 0:0: command-prompt
+1783499626.100033 cmd_parse_build_commands 0:1: -I
+1783499626.100035 cmd_parse_build_commands 0:2: #S
+1783499626.100037 cmd_parse_build_commands 0:3 0:0: rename-session
+1783499626.100038 cmd_parse_build_commands 0:3 0:1: --
+1783499626.100040 cmd_parse_build_commands 0:3 0:2: %%
+1783499626.100042 cmd_parse_build_commands 0:0: rename-session
+1783499626.100044 cmd_parse_build_commands 0:1: --
+1783499626.100045 cmd_parse_build_commands 0:2: %%
+1783499626.100049 args_parse_flags: next --
+1783499626.100050 args_parse: flags end at 2 of 3
+1783499626.100052 args_parse: 2 = %% (type STRING)
+1783499626.100056 cmd_parse_build_commands: rename-session "%%"
+1783499626.100057 args_parse_flags: next -I
+1783499626.100059 args_parse_flag_argument: -I = #S
+1783499626.100061 args_parse: flags end at 3 of 4
+1783499626.100064 args_parse: 3 = rename-session "%%" (type COMMANDS)
+1783499626.100068 cmd_parse_build_commands: command-prompt -I "#S" { rename-session "%%" }
+1783499626.100076 cmd_parse_build_commands 0:0: new-session
+1783499626.100082 args_parse: flags end at 1 of 1
+1783499626.100085 cmd_parse_build_commands: new-session
+1783499626.100093 cmd_parse_build_commands 0:0: new-window
+1783499626.100096 args_parse: flags end at 1 of 1
+1783499626.100098 cmd_parse_build_commands: new-window
+1783499626.100100 args_parse_flags: next -t=
+1783499626.100101 args_parse_flag_argument: -t = =
+1783499626.100103 args_parse_flags: next -xM
+1783499626.100104 args_parse_flag_argument: -x = M
+1783499626.100106 args_parse_flags: next -yW
+1783499626.100108 args_parse_flag_argument: -y = W
+1783499626.100109 args_parse_flags: next -T
+1783499626.100115 args_parse_flag_argument: -T = #[align=centre]#{session_name}
+1783499626.100117 args_parse_flags: next Next
+1783499626.100119 args_parse: flags end at 6 of 26
+1783499626.100121 args_parse: 6 = Next (type STRING)
+1783499626.100123 args_parse: 7 = n (type STRING)
+1783499626.100126 args_parse: 8 = switch-client -n (type COMMANDS)
+1783499626.100128 args_parse: 9 = Previous (type STRING)
+1783499626.100130 args_parse: 10 = p (type STRING)
+1783499626.100133 args_parse: 11 = switch-client -p (type COMMANDS)
+1783499626.100135 args_parse: 12 =  (type STRING)
+1783499626.100137 args_parse: 13 = Renumber (type STRING)
+1783499626.100139 args_parse: 14 = N (type STRING)
+1783499626.100142 args_parse: 15 = move-window -r (type COMMANDS)
+1783499626.100144 args_parse: 16 = Rename (type STRING)
+1783499626.100146 args_parse: 17 = n (type STRING)
+1783499626.100151 args_parse: 18 = command-prompt -I "#S" { rename-session "%%" } (type COMMANDS)
+1783499626.100153 args_parse: 19 =  (type STRING)
+1783499626.100156 args_parse: 20 = New Session (type STRING)
+1783499626.100157 args_parse: 21 = s (type STRING)
+1783499626.100160 args_parse: 22 = new-session (type COMMANDS)
+1783499626.100161 args_parse: 23 = New Window (type STRING)
+1783499626.100163 args_parse: 24 = w (type STRING)
+1783499626.100166 args_parse: 25 = new-window (type COMMANDS)
+1783499626.100189 cmd_parse_build_commands: display-menu -T "#[align=centre]#{session_name}" -t = -x M -y W Next n { switch-client -n } Previous p { switch-client -p } '' Renumber N { move-window -r } Rename n { command-prompt -I "#S" { rename-session "%%" } } '' "New Session" s { new-session } "New Window" w { new-window }
+1783499626.100191 args_parse_flags: next -n
+1783499626.100192 args_parse_flags: -n
+1783499626.100194 args_parse_flags: next M-MouseDown3StatusLeft
+1783499626.100196 args_parse: flags end at 2 of 4
+1783499626.100198 args_parse: 2 = M-MouseDown3StatusLeft (type STRING)
+1783499626.100219 args_parse: 3 = display-menu -T "#[align=centre]#{session_name}" -t = -x M -y W Next n { switch-client -n } Previous p { switch-client -p } '' Renumber N { move-window -r } Rename n { command-prompt -I "#S" { rename-session "%%" } } '' "New Session" s { new-session } "New Window" w { new-window } (type COMMANDS)
+1783499626.100242 cmd_parse_build_commands: bind-key -n M-MouseDown3StatusLeft { display-menu -T "#[align=centre]#{session_name}" -t = -x M -y W Next n { switch-client -n } Previous p { switch-client -p } '' Renumber N { move-window -r } Rename n { command-prompt -I "#S" { rename-session "%%" } } '' "New Session" s { new-session } "New Window" w { new-window } }
+1783499626.100248 cmdq_get_command: [bind-key/0x58e4724eedf0] group 986
+1783499626.100250 cmdq_append <global>: [bind-key/0x58e4724eedf0]
+1783499626.100256 yylex_token: end at WS
+1783499626.100257 yylex_token: bind
+1783499626.100259 yylex_token: end at WS
+1783499626.100261 yylex_token: -n
+1783499626.100263 yylex_token: end at WS
+1783499626.100264 yylex_token: MouseDown3Status
+1783499626.100266 yylex_token: end at WS
+1783499626.100267 yylex_token: display-menu
+1783499626.100269 yylex_token: end at WS
+1783499626.100270 yylex_token: -t=
+1783499626.100272 yylex_token: end at WS
+1783499626.100273 yylex_token: -xW
+1783499626.100274 yylex_token: end at WS
+1783499626.100276 yylex_token: -yW
+1783499626.100277 yylex_token: end at WS
+1783499626.100278 yylex_token: -T
+1783499626.100281 yylex_token: end at WS
+1783499626.100283 yylex_token: #[align=centre]#{window_index}:#{window_name}
+1783499626.100286 yylex_token: end at WS
+1783499626.100288 yylex_token: #{?#{>:#{session_windows},1},,-}Swap Left
+1783499626.100289 yylex_token: end at WS
+1783499626.100291 yylex_token: l
+1783499626.100292 yylex_token: end at WS
+1783499626.100294 yylex_token: swap-window
+1783499626.100296 yylex_token: end at }
+1783499626.100297 yylex_token: -t:-1
+1783499626.100300 yylex_token: end at WS
+1783499626.100302 yylex_token: #{?#{>:#{session_windows},1},,-}Swap Right
+1783499626.100304 yylex_token: end at WS
+1783499626.100305 yylex_token: r
+1783499626.100307 yylex_token: end at WS
+1783499626.100312 yylex_token: swap-window
+1783499626.100314 yylex_token: end at }
+1783499626.100315 yylex_token: -t:+1
+1783499626.100317 yylex_token: end at WS
+1783499626.100319 yylex_token: #{?pane_marked_set,,-}Swap Marked
+1783499626.100321 yylex_token: end at WS
+1783499626.100322 yylex_token: s
+1783499626.100324 yylex_token: end at }
+1783499626.100325 yylex_token: swap-window
+1783499626.100327 yylex_token: end at WS
+1783499626.100328 yylex_token: 
+1783499626.100330 yylex_token: end at WS
+1783499626.100331 yylex_token: Kill
+1783499626.100333 yylex_token: end at WS
+1783499626.100334 yylex_token: X
+1783499626.100336 yylex_token: end at }
+1783499626.100337 yylex_token: kill-window
+1783499626.100339 yylex_token: end at WS
+1783499626.100340 yylex_token: Respawn
+1783499626.100342 yylex_token: end at WS
+1783499626.100343 yylex_token: R
+1783499626.100345 yylex_token: end at WS
+1783499626.100346 yylex_token: respawn-window
+1783499626.100348 yylex_token: end at }
+1783499626.100349 yylex_token: -k
+1783499626.100351 yylex_token: end at WS
+1783499626.100353 yylex_token: #{?pane_marked,Unmark,Mark}
+1783499626.100354 yylex_token: end at WS
+1783499626.100355 yylex_token: m
+1783499626.100357 yylex_token: end at WS
+1783499626.100359 yylex_token: select-pane
+1783499626.100360 yylex_token: end at }
+1783499626.100361 yylex_token: -m
+1783499626.100363 yylex_token: end at WS
+1783499626.100364 yylex_token: Rename
+1783499626.100366 yylex_token: end at WS
+1783499626.100367 yylex_token: n
+1783499626.100369 yylex_token: end at WS
+1783499626.100370 yylex_token: command-prompt
+1783499626.100372 yylex_token: end at WS
+1783499626.100373 yylex_token: -FI
+1783499626.100374 yylex_token: end at WS
+1783499626.100376 yylex_token: #W
+1783499626.100377 yylex_token: end at WS
+1783499626.100379 yylex_token: rename-window
+1783499626.100380 yylex_token: end at WS
+1783499626.100381 yylex_token: -t
+1783499626.100383 yylex_token: end at WS
+1783499626.100385 yylex_token: #{window_id}
+1783499626.100386 yylex_token: end at WS
+1783499626.100387 yylex_token: --
+1783499626.100389 yylex_token: end at }
+1783499626.100390 yylex_token: %%
+1783499626.100392 yylex_token: end at WS
+1783499626.100393 yylex_token: 
+1783499626.100395 yylex_token: end at WS
+1783499626.100396 yylex_token: New After
+1783499626.100398 yylex_token: end at WS
+1783499626.100399 yylex_token: w
+1783499626.100401 yylex_token: end at WS
+1783499626.100402 yylex_token: new-window
+1783499626.100404 yylex_token: end at }
+1783499626.100405 yylex_token: -a
+1783499626.100407 yylex_token: end at WS
+1783499626.100408 yylex_token: New At End
+1783499626.100409 yylex_token: end at WS
+1783499626.100410 yylex_token: W
+1783499626.100412 yylex_token: end at }
+1783499626.100413 yylex_token: new-window
+1783499626.100417 cmd_parse_build_commands 0:0: bind
+1783499626.100418 cmd_parse_build_commands 0:1: -n
+1783499626.100420 cmd_parse_build_commands 0:2: MouseDown3Status
+1783499626.100422 cmd_parse_build_commands 0:3 0:0: display-menu
+1783499626.100424 cmd_parse_build_commands 0:3 0:1: -t=
+1783499626.100426 cmd_parse_build_commands 0:3 0:2: -xW
+1783499626.100428 cmd_parse_build_commands 0:3 0:3: -yW
+1783499626.100429 cmd_parse_build_commands 0:3 0:4: -T
+1783499626.100432 cmd_parse_build_commands 0:3 0:5: #[align=centre]#{window_index}:#{window_name}
+1783499626.100434 cmd_parse_build_commands 0:3 0:6: #{?#{>:#{session_windows},1},,-}Swap Left
+1783499626.100436 cmd_parse_build_commands 0:3 0:7: l
+1783499626.100438 cmd_parse_build_commands 0:3 0:8 0:0: swap-window
+1783499626.100440 cmd_parse_build_commands 0:3 0:8 0:1: -t:-1
+1783499626.100442 cmd_parse_build_commands 0:3 0:9: #{?#{>:#{session_windows},1},,-}Swap Right
+1783499626.100444 cmd_parse_build_commands 0:3 0:10: r
+1783499626.100446 cmd_parse_build_commands 0:3 0:11 0:0: swap-window
+1783499626.100448 cmd_parse_build_commands 0:3 0:11 0:1: -t:+1
+1783499626.100450 cmd_parse_build_commands 0:3 0:12: #{?pane_marked_set,,-}Swap Marked
+1783499626.100452 cmd_parse_build_commands 0:3 0:13: s
+1783499626.100454 cmd_parse_build_commands 0:3 0:14 0:0: swap-window
+1783499626.100459 cmd_parse_build_commands 0:3 0:15: 
+1783499626.100460 cmd_parse_build_commands 0:3 0:16: Kill
+1783499626.100462 cmd_parse_build_commands 0:3 0:17: X
+1783499626.100464 cmd_parse_build_commands 0:3 0:18 0:0: kill-window
+1783499626.100466 cmd_parse_build_commands 0:3 0:19: Respawn
+1783499626.100468 cmd_parse_build_commands 0:3 0:20: R
+1783499626.100470 cmd_parse_build_commands 0:3 0:21 0:0: respawn-window
+1783499626.100472 cmd_parse_build_commands 0:3 0:21 0:1: -k
+1783499626.100474 cmd_parse_build_commands 0:3 0:22: #{?pane_marked,Unmark,Mark}
+1783499626.100476 cmd_parse_build_commands 0:3 0:23: m
+1783499626.100478 cmd_parse_build_commands 0:3 0:24 0:0: select-pane
+1783499626.100479 cmd_parse_build_commands 0:3 0:24 0:1: -m
+1783499626.100481 cmd_parse_build_commands 0:3 0:25: Rename
+1783499626.100483 cmd_parse_build_commands 0:3 0:26: n
+1783499626.100485 cmd_parse_build_commands 0:3 0:27 0:0: command-prompt
+1783499626.100486 cmd_parse_build_commands 0:3 0:27 0:1: -FI
+1783499626.100488 cmd_parse_build_commands 0:3 0:27 0:2: #W
+1783499626.100490 cmd_parse_build_commands 0:3 0:27 0:3 0:0: rename-window
+1783499626.100492 cmd_parse_build_commands 0:3 0:27 0:3 0:1: -t
+1783499626.100494 cmd_parse_build_commands 0:3 0:27 0:3 0:2: #{window_id}
+1783499626.100496 cmd_parse_build_commands 0:3 0:27 0:3 0:3: --
+1783499626.100497 cmd_parse_build_commands 0:3 0:27 0:3 0:4: %%
+1783499626.100499 cmd_parse_build_commands 0:3 0:28: 
+1783499626.100500 cmd_parse_build_commands 0:3 0:29: New After
+1783499626.100502 cmd_parse_build_commands 0:3 0:30: w
+1783499626.100504 cmd_parse_build_commands 0:3 0:31 0:0: new-window
+1783499626.100506 cmd_parse_build_commands 0:3 0:31 0:1: -a
+1783499626.100508 cmd_parse_build_commands 0:3 0:32: New At End
+1783499626.100509 cmd_parse_build_commands 0:3 0:33: W
+1783499626.100511 cmd_parse_build_commands 0:3 0:34 0:0: new-window
+1783499626.100514 cmd_parse_build_commands 0:0: display-menu
+1783499626.100516 cmd_parse_build_commands 0:1: -t=
+1783499626.100517 cmd_parse_build_commands 0:2: -xW
+1783499626.100519 cmd_parse_build_commands 0:3: -yW
+1783499626.100520 cmd_parse_build_commands 0:4: -T
+1783499626.100529 cmd_parse_build_commands 0:5: #[align=centre]#{window_index}:#{window_name}
+1783499626.100535 cmd_parse_build_commands 0:6: #{?#{>:#{session_windows},1},,-}Swap Left
+1783499626.100536 cmd_parse_build_commands 0:7: l
+1783499626.100539 cmd_parse_build_commands 0:8 0:0: swap-window
+1783499626.100540 cmd_parse_build_commands 0:8 0:1: -t:-1
+1783499626.100542 cmd_parse_build_commands 0:9: #{?#{>:#{session_windows},1},,-}Swap Right
+1783499626.100544 cmd_parse_build_commands 0:10: r
+1783499626.100546 cmd_parse_build_commands 0:11 0:0: swap-window
+1783499626.100548 cmd_parse_build_commands 0:11 0:1: -t:+1
+1783499626.100550 cmd_parse_build_commands 0:12: #{?pane_marked_set,,-}Swap Marked
+1783499626.100552 cmd_parse_build_commands 0:13: s
+1783499626.100553 cmd_parse_build_commands 0:14 0:0: swap-window
+1783499626.100555 cmd_parse_build_commands 0:15: 
+1783499626.100557 cmd_parse_build_commands 0:16: Kill
+1783499626.100558 cmd_parse_build_commands 0:17: X
+1783499626.100560 cmd_parse_build_commands 0:18 0:0: kill-window
+1783499626.100562 cmd_parse_build_commands 0:19: Respawn
+1783499626.100564 cmd_parse_build_commands 0:20: R
+1783499626.100566 cmd_parse_build_commands 0:21 0:0: respawn-window
+1783499626.100567 cmd_parse_build_commands 0:21 0:1: -k
+1783499626.100569 cmd_parse_build_commands 0:22: #{?pane_marked,Unmark,Mark}
+1783499626.100571 cmd_parse_build_commands 0:23: m
+1783499626.100573 cmd_parse_build_commands 0:24 0:0: select-pane
+1783499626.100574 cmd_parse_build_commands 0:24 0:1: -m
+1783499626.100576 cmd_parse_build_commands 0:25: Rename
+1783499626.100577 cmd_parse_build_commands 0:26: n
+1783499626.100580 cmd_parse_build_commands 0:27 0:0: command-prompt
+1783499626.100581 cmd_parse_build_commands 0:27 0:1: -FI
+1783499626.100583 cmd_parse_build_commands 0:27 0:2: #W
+1783499626.100585 cmd_parse_build_commands 0:27 0:3 0:0: rename-window
+1783499626.100587 cmd_parse_build_commands 0:27 0:3 0:1: -t
+1783499626.100595 cmd_parse_build_commands 0:27 0:3 0:2: #{window_id}
+1783499626.100599 cmd_parse_build_commands 0:27 0:3 0:3: --
+1783499626.100601 cmd_parse_build_commands 0:27 0:3 0:4: %%
+1783499626.100602 cmd_parse_build_commands 0:28: 
+1783499626.100604 cmd_parse_build_commands 0:29: New After
+1783499626.100606 cmd_parse_build_commands 0:30: w
+1783499626.100608 cmd_parse_build_commands 0:31 0:0: new-window
+1783499626.100609 cmd_parse_build_commands 0:31 0:1: -a
+1783499626.100611 cmd_parse_build_commands 0:32: New At End
+1783499626.100613 cmd_parse_build_commands 0:33: W
+1783499626.100614 cmd_parse_build_commands 0:34 0:0: new-window
+1783499626.100618 cmd_parse_build_commands 0:0: swap-window
+1783499626.100620 cmd_parse_build_commands 0:1: -t:-1
+1783499626.100624 args_parse_flags: next -t:-1
+1783499626.100626 args_parse_flag_argument: -t = :-1
+1783499626.100628 args_parse: flags end at 2 of 2
+1783499626.100632 cmd_parse_build_commands: swap-window -t :-1
+1783499626.100634 cmd_parse_build_commands 0:0: swap-window
+1783499626.100635 cmd_parse_build_commands 0:1: -t:+1
+1783499626.100639 args_parse_flags: next -t:+1
+1783499626.100640 args_parse_flag_argument: -t = :+1
+1783499626.100642 args_parse: flags end at 2 of 2
+1783499626.100645 cmd_parse_build_commands: swap-window -t :+1
+1783499626.100647 cmd_parse_build_commands 0:0: swap-window
+1783499626.100651 args_parse: flags end at 1 of 1
+1783499626.100653 cmd_parse_build_commands: swap-window
+1783499626.100655 cmd_parse_build_commands 0:0: kill-window
+1783499626.100662 args_parse: flags end at 1 of 1
+1783499626.100666 cmd_parse_build_commands: kill-window
+1783499626.100669 cmd_parse_build_commands 0:0: respawn-window
+1783499626.100671 cmd_parse_build_commands 0:1: -k
+1783499626.100674 args_parse_flags: next -k
+1783499626.100675 args_parse_flags: -k
+1783499626.100677 args_parse: flags end at 2 of 2
+1783499626.100679 cmd_parse_build_commands: respawn-window -k
+1783499626.100681 cmd_parse_build_commands 0:0: select-pane
+1783499626.100683 cmd_parse_build_commands 0:1: -m
+1783499626.100686 args_parse_flags: next -m
+1783499626.100687 args_parse_flags: -m
+1783499626.100689 args_parse: flags end at 2 of 2
+1783499626.100691 cmd_parse_build_commands: select-pane -m
+1783499626.100698 cmd_parse_build_commands 0:0: command-prompt
+1783499626.100700 cmd_parse_build_commands 0:1: -FI
+1783499626.100702 cmd_parse_build_commands 0:2: #W
+1783499626.100704 cmd_parse_build_commands 0:3 0:0: rename-window
+1783499626.100705 cmd_parse_build_commands 0:3 0:1: -t
+1783499626.100707 cmd_parse_build_commands 0:3 0:2: #{window_id}
+1783499626.100709 cmd_parse_build_commands 0:3 0:3: --
+1783499626.100710 cmd_parse_build_commands 0:3 0:4: %%
+1783499626.100713 cmd_parse_build_commands 0:0: rename-window
+1783499626.100714 cmd_parse_build_commands 0:1: -t
+1783499626.100716 cmd_parse_build_commands 0:2: #{window_id}
+1783499626.100718 cmd_parse_build_commands 0:3: --
+1783499626.100719 cmd_parse_build_commands 0:4: %%
+1783499626.100722 args_parse_flags: next -t
+1783499626.100724 args_parse_flag_argument: -t = #{window_id}
+1783499626.100726 args_parse_flags: next --
+1783499626.100727 args_parse: flags end at 4 of 5
+1783499626.100729 args_parse: 4 = %% (type STRING)
+1783499626.100733 cmd_parse_build_commands: rename-window -t "#{window_id}" "%%"
+1783499626.100735 args_parse_flags: next -FI
+1783499626.100736 args_parse_flags: -F
+1783499626.100738 args_parse_flag_argument: -I = #W
+1783499626.100740 args_parse: flags end at 3 of 4
+1783499626.100744 args_parse: 3 = rename-window -t "#{window_id}" "%%" (type COMMANDS)
+1783499626.100749 cmd_parse_build_commands: command-prompt -F -I "#W" { rename-window -t "#{window_id}" "%%" }
+1783499626.100753 cmd_parse_build_commands 0:0: new-window
+1783499626.100755 cmd_parse_build_commands 0:1: -a
+1783499626.100758 args_parse_flags: next -a
+1783499626.100759 args_parse_flags: -a
+1783499626.100760 args_parse: flags end at 2 of 2
+1783499626.100763 cmd_parse_build_commands: new-window -a
+1783499626.100766 cmd_parse_build_commands 0:0: new-window
+1783499626.100769 args_parse: flags end at 1 of 1
+1783499626.100774 cmd_parse_build_commands: new-window
+1783499626.100776 args_parse_flags: next -t=
+1783499626.100777 args_parse_flag_argument: -t = =
+1783499626.100779 args_parse_flags: next -xW
+1783499626.100780 args_parse_flag_argument: -x = W
+1783499626.100782 args_parse_flags: next -yW
+1783499626.100783 args_parse_flag_argument: -y = W
+1783499626.100785 args_parse_flags: next -T
+1783499626.100787 args_parse_flag_argument: -T = #[align=centre]#{window_index}:#{window_name}
+1783499626.100790 args_parse_flags: next #{?#{>:#{session_windows},1},,-}Swap Left
+1783499626.100791 args_parse: flags end at 6 of 35
+1783499626.100794 args_parse: 6 = #{?#{>:#{session_windows},1},,-}Swap Left (type STRING)
+1783499626.100795 args_parse: 7 = l (type STRING)
+1783499626.100799 args_parse: 8 = swap-window -t :-1 (type COMMANDS)
+1783499626.100801 args_parse: 9 = #{?#{>:#{session_windows},1},,-}Swap Right (type STRING)
+1783499626.100803 args_parse: 10 = r (type STRING)
+1783499626.100806 args_parse: 11 = swap-window -t :+1 (type COMMANDS)
+1783499626.100808 args_parse: 12 = #{?pane_marked_set,,-}Swap Marked (type STRING)
+1783499626.100810 args_parse: 13 = s (type STRING)
+1783499626.100812 args_parse: 14 = swap-window (type COMMANDS)
+1783499626.100814 args_parse: 15 =  (type STRING)
+1783499626.100816 args_parse: 16 = Kill (type STRING)
+1783499626.100817 args_parse: 17 = X (type STRING)
+1783499626.100820 args_parse: 18 = kill-window (type COMMANDS)
+1783499626.100822 args_parse: 19 = Respawn (type STRING)
+1783499626.100823 args_parse: 20 = R (type STRING)
+1783499626.100826 args_parse: 21 = respawn-window -k (type COMMANDS)
+1783499626.100828 args_parse: 22 = #{?pane_marked,Unmark,Mark} (type STRING)
+1783499626.100830 args_parse: 23 = m (type STRING)
+1783499626.100833 args_parse: 24 = select-pane -m (type COMMANDS)
+1783499626.100834 args_parse: 25 = Rename (type STRING)
+1783499626.100836 args_parse: 26 = n (type STRING)
+1783499626.100842 args_parse: 27 = command-prompt -F -I "#W" { rename-window -t "#{window_id}" "%%" } (type COMMANDS)
+1783499626.100844 args_parse: 28 =  (type STRING)
+1783499626.100846 args_parse: 29 = New After (type STRING)
+1783499626.100864 args_parse: 30 = w (type STRING)
+1783499626.100894 args_parse: 31 = new-window -a (type COMMANDS)
+1783499626.100901 args_parse: 32 = New At End (type STRING)
+1783499626.100904 args_parse: 33 = W (type STRING)
+1783499626.100908 args_parse: 34 = new-window (type COMMANDS)
+1783499626.101005 cmd_parse_build_commands: display-menu -T "#[align=centre]#{window_index}:#{window_name}" -t = -x W -y W "#{?#{>:#{session_windows},1},,-}Swap Left" l { swap-window -t :-1 } "#{?#{>:#{session_windows},1},,-}Swap Right" r { swap-window -t :+1 } "#{?pane_marked_set,,-}Swap Marked" s { swap-window } '' Kill X { kill-window } Respawn R { respawn-window -k } "#{?pane_marked,Unmark,Mark}" m { select-pane -m } Rename n { command-prompt -F -I "#W" { rename-window -t "#{window_id}" "%%" } } '' "New After" w { new-window -a } "New At End" W { new-window }
+1783499626.101016 args_parse_flags: next -n
+1783499626.101018 args_parse_flags: -n
+1783499626.101020 args_parse_flags: next MouseDown3Status
+1783499626.101022 args_parse: flags end at 2 of 4
+1783499626.101023 args_parse: 2 = MouseDown3Status (type STRING)
+1783499626.101051 args_parse: 3 = display-menu -T "#[align=centre]#{window_index}:#{window_name}" -t = -x W -y W "#{?#{>:#{session_windows},1},,-}Swap Left" l { swap-window -t :-1 } "#{?#{>:#{session_windows},1},,-}Swap Right" r { swap-window -t :+1 } "#{?pane_marked_set,,-}Swap Marked" s { swap-window } '' Kill X { kill-window } Respawn R { respawn-window -k } "#{?pane_marked,Unmark,Mark}" m { select-pane -m } Rename n { command-prompt -F -I "#W" { rename-window -t "#{window_id}" "%%" } } '' "New After" w { new-window -a } "New At End" W { new-window } (type COMMANDS)
+1783499626.101088 cmd_parse_build_commands: bind-key -n MouseDown3Status { display-menu -T "#[align=centre]#{window_index}:#{window_name}" -t = -x W -y W "#{?#{>:#{session_windows},1},,-}Swap Left" l { swap-window -t :-1 } "#{?#{>:#{session_windows},1},,-}Swap Right" r { swap-window -t :+1 } "#{?pane_marked_set,,-}Swap Marked" s { swap-window } '' Kill X { kill-window } Respawn R { respawn-window -k } "#{?pane_marked,Unmark,Mark}" m { select-pane -m } Rename n { command-prompt -F -I "#W" { rename-window -t "#{window_id}" "%%" } } '' "New After" w { new-window -a } "New At End" W { new-window } }
+1783499626.101106 cmdq_get_command: [bind-key/0x58e4724f0620] group 1022
+1783499626.101108 cmdq_append <global>: [bind-key/0x58e4724f0620]
+1783499626.101115 yylex_token: end at WS
+1783499626.101116 yylex_token: bind
+1783499626.101118 yylex_token: end at WS
+1783499626.101119 yylex_token: -n
+1783499626.101121 yylex_token: end at WS
+1783499626.101122 yylex_token: M-MouseDown3Status
+1783499626.101124 yylex_token: end at WS
+1783499626.101125 yylex_token: display-menu
+1783499626.101126 yylex_token: end at WS
+1783499626.101127 yylex_token: -t=
+1783499626.101128 yylex_token: end at WS
+1783499626.101129 yylex_token: -xW
+1783499626.101130 yylex_token: end at WS
+1783499626.101131 yylex_token: -yW
+1783499626.101132 yylex_token: end at WS
+1783499626.101133 yylex_token: -T
+1783499626.101135 yylex_token: end at WS
+1783499626.101137 yylex_token: #[align=centre]#{window_index}:#{window_name}
+1783499626.101139 yylex_token: end at WS
+1783499626.101141 yylex_token: #{?#{>:#{session_windows},1},,-}Swap Left
+1783499626.101142 yylex_token: end at WS
+1783499626.101143 yylex_token: l
+1783499626.101144 yylex_token: end at WS
+1783499626.101146 yylex_token: swap-window
+1783499626.101147 yylex_token: end at }
+1783499626.101148 yylex_token: -t:-1
+1783499626.101151 yylex_token: end at WS
+1783499626.101152 yylex_token: #{?#{>:#{session_windows},1},,-}Swap Right
+1783499626.101153 yylex_token: end at WS
+1783499626.101154 yylex_token: r
+1783499626.101156 yylex_token: end at WS
+1783499626.101157 yylex_token: swap-window
+1783499626.101158 yylex_token: end at }
+1783499626.101159 yylex_token: -t:+1
+1783499626.101162 yylex_token: end at WS
+1783499626.101163 yylex_token: #{?pane_marked_set,,-}Swap Marked
+1783499626.101164 yylex_token: end at WS
+1783499626.101165 yylex_token: s
+1783499626.101167 yylex_token: end at }
+1783499626.101168 yylex_token: swap-window
+1783499626.101169 yylex_token: end at WS
+1783499626.101170 yylex_token: 
+1783499626.101172 yylex_token: end at WS
+1783499626.101173 yylex_token: Kill
+1783499626.101174 yylex_token: end at WS
+1783499626.101175 yylex_token: X
+1783499626.101176 yylex_token: end at }
+1783499626.101177 yylex_token: kill-window
+1783499626.101179 yylex_token: end at WS
+1783499626.101180 yylex_token: Respawn
+1783499626.101181 yylex_token: end at WS
+1783499626.101200 yylex_token: R
+1783499626.101202 yylex_token: end at WS
+1783499626.101203 yylex_token: respawn-window
+1783499626.101204 yylex_token: end at }
+1783499626.101205 yylex_token: -k
+1783499626.101207 yylex_token: end at WS
+1783499626.101209 yylex_token: #{?pane_marked,Unmark,Mark}
+1783499626.101210 yylex_token: end at WS
+1783499626.101222 yylex_token: m
+1783499626.101224 yylex_token: end at WS
+1783499626.101225 yylex_token: select-pane
+1783499626.101227 yylex_token: end at }
+1783499626.101227 yylex_token: -m
+1783499626.101229 yylex_token: end at WS
+1783499626.101230 yylex_token: Rename
+1783499626.101231 yylex_token: end at WS
+1783499626.101232 yylex_token: n
+1783499626.101234 yylex_token: end at WS
+1783499626.101235 yylex_token: command-prompt
+1783499626.101236 yylex_token: end at WS
+1783499626.101237 yylex_token: -FI
+1783499626.101239 yylex_token: end at WS
+1783499626.101239 yylex_token: #W
+1783499626.101241 yylex_token: end at WS
+1783499626.101242 yylex_token: rename-window
+1783499626.101243 yylex_token: end at WS
+1783499626.101244 yylex_token: -t
+1783499626.101246 yylex_token: end at WS
+1783499626.101247 yylex_token: #{window_id}
+1783499626.101248 yylex_token: end at WS
+1783499626.101249 yylex_token: --
+1783499626.101251 yylex_token: end at }
+1783499626.101252 yylex_token: %%
+1783499626.101254 yylex_token: end at WS
+1783499626.101255 yylex_token: 
+1783499626.101256 yylex_token: end at WS
+1783499626.101258 yylex_token: New After
+1783499626.101263 yylex_token: end at WS
+1783499626.101264 yylex_token: w
+1783499626.101265 yylex_token: end at WS
+1783499626.101266 yylex_token: new-window
+1783499626.101268 yylex_token: end at }
+1783499626.101269 yylex_token: -a
+1783499626.101270 yylex_token: end at WS
+1783499626.101272 yylex_token: New At End
+1783499626.101273 yylex_token: end at WS
+1783499626.101274 yylex_token: W
+1783499626.101275 yylex_token: end at }
+1783499626.101276 yylex_token: new-window
+1783499626.101280 cmd_parse_build_commands 0:0: bind
+1783499626.101281 cmd_parse_build_commands 0:1: -n
+1783499626.101282 cmd_parse_build_commands 0:2: M-MouseDown3Status
+1783499626.101284 cmd_parse_build_commands 0:3 0:0: display-menu
+1783499626.101286 cmd_parse_build_commands 0:3 0:1: -t=
+1783499626.101287 cmd_parse_build_commands 0:3 0:2: -xW
+1783499626.101288 cmd_parse_build_commands 0:3 0:3: -yW
+1783499626.101289 cmd_parse_build_commands 0:3 0:4: -T
+1783499626.101291 cmd_parse_build_commands 0:3 0:5: #[align=centre]#{window_index}:#{window_name}
+1783499626.101293 cmd_parse_build_commands 0:3 0:6: #{?#{>:#{session_windows},1},,-}Swap Left
+1783499626.101294 cmd_parse_build_commands 0:3 0:7: l
+1783499626.101295 cmd_parse_build_commands 0:3 0:8 0:0: swap-window
+1783499626.101297 cmd_parse_build_commands 0:3 0:8 0:1: -t:-1
+1783499626.101298 cmd_parse_build_commands 0:3 0:9: #{?#{>:#{session_windows},1},,-}Swap Right
+1783499626.101300 cmd_parse_build_commands 0:3 0:10: r
+1783499626.101301 cmd_parse_build_commands 0:3 0:11 0:0: swap-window
+1783499626.101303 cmd_parse_build_commands 0:3 0:11 0:1: -t:+1
+1783499626.101304 cmd_parse_build_commands 0:3 0:12: #{?pane_marked_set,,-}Swap Marked
+1783499626.101305 cmd_parse_build_commands 0:3 0:13: s
+1783499626.101307 cmd_parse_build_commands 0:3 0:14 0:0: swap-window
+1783499626.101308 cmd_parse_build_commands 0:3 0:15: 
+1783499626.101309 cmd_parse_build_commands 0:3 0:16: Kill
+1783499626.101311 cmd_parse_build_commands 0:3 0:17: X
+1783499626.101312 cmd_parse_build_commands 0:3 0:18 0:0: kill-window
+1783499626.101313 cmd_parse_build_commands 0:3 0:19: Respawn
+1783499626.101315 cmd_parse_build_commands 0:3 0:20: R
+1783499626.101316 cmd_parse_build_commands 0:3 0:21 0:0: respawn-window
+1783499626.101317 cmd_parse_build_commands 0:3 0:21 0:1: -k
+1783499626.101319 cmd_parse_build_commands 0:3 0:22: #{?pane_marked,Unmark,Mark}
+1783499626.101320 cmd_parse_build_commands 0:3 0:23: m
+1783499626.101321 cmd_parse_build_commands 0:3 0:24 0:0: select-pane
+1783499626.101323 cmd_parse_build_commands 0:3 0:24 0:1: -m
+1783499626.101324 cmd_parse_build_commands 0:3 0:25: Rename
+1783499626.101325 cmd_parse_build_commands 0:3 0:26: n
+1783499626.101326 cmd_parse_build_commands 0:3 0:27 0:0: command-prompt
+1783499626.101328 cmd_parse_build_commands 0:3 0:27 0:1: -FI
+1783499626.101329 cmd_parse_build_commands 0:3 0:27 0:2: #W
+1783499626.101331 cmd_parse_build_commands 0:3 0:27 0:3 0:0: rename-window
+1783499626.101332 cmd_parse_build_commands 0:3 0:27 0:3 0:1: -t
+1783499626.101333 cmd_parse_build_commands 0:3 0:27 0:3 0:2: #{window_id}
+1783499626.101335 cmd_parse_build_commands 0:3 0:27 0:3 0:3: --
+1783499626.101336 cmd_parse_build_commands 0:3 0:27 0:3 0:4: %%
+1783499626.101337 cmd_parse_build_commands 0:3 0:28: 
+1783499626.101344 cmd_parse_build_commands 0:3 0:29: New After
+1783499626.101349 cmd_parse_build_commands 0:3 0:30: w
+1783499626.101350 cmd_parse_build_commands 0:3 0:31 0:0: new-window
+1783499626.101352 cmd_parse_build_commands 0:3 0:31 0:1: -a
+1783499626.101353 cmd_parse_build_commands 0:3 0:32: New At End
+1783499626.101354 cmd_parse_build_commands 0:3 0:33: W
+1783499626.101356 cmd_parse_build_commands 0:3 0:34 0:0: new-window
+1783499626.101359 cmd_parse_build_commands 0:0: display-menu
+1783499626.101360 cmd_parse_build_commands 0:1: -t=
+1783499626.101362 cmd_parse_build_commands 0:2: -xW
+1783499626.101363 cmd_parse_build_commands 0:3: -yW
+1783499626.101364 cmd_parse_build_commands 0:4: -T
+1783499626.101365 cmd_parse_build_commands 0:5: #[align=centre]#{window_index}:#{window_name}
+1783499626.101367 cmd_parse_build_commands 0:6: #{?#{>:#{session_windows},1},,-}Swap Left
+1783499626.101453 cmd_parse_build_commands 0:7: l
+1783499626.101458 cmd_parse_build_commands 0:8 0:0: swap-window
+1783499626.101460 cmd_parse_build_commands 0:8 0:1: -t:-1
+1783499626.101462 cmd_parse_build_commands 0:9: #{?#{>:#{session_windows},1},,-}Swap Right
+1783499626.101464 cmd_parse_build_commands 0:10: r
+1783499626.101466 cmd_parse_build_commands 0:11 0:0: swap-window
+1783499626.101467 cmd_parse_build_commands 0:11 0:1: -t:+1
+1783499626.101469 cmd_parse_build_commands 0:12: #{?pane_marked_set,,-}Swap Marked
+1783499626.101470 cmd_parse_build_commands 0:13: s
+1783499626.101471 cmd_parse_build_commands 0:14 0:0: swap-window
+1783499626.101473 cmd_parse_build_commands 0:15: 
+1783499626.101474 cmd_parse_build_commands 0:16: Kill
+1783499626.101475 cmd_parse_build_commands 0:17: X
+1783499626.101477 cmd_parse_build_commands 0:18 0:0: kill-window
+1783499626.101478 cmd_parse_build_commands 0:19: Respawn
+1783499626.101479 cmd_parse_build_commands 0:20: R
+1783499626.101485 cmd_parse_build_commands 0:21 0:0: respawn-window
+1783499626.101487 cmd_parse_build_commands 0:21 0:1: -k
+1783499626.101488 cmd_parse_build_commands 0:22: #{?pane_marked,Unmark,Mark}
+1783499626.101490 cmd_parse_build_commands 0:23: m
+1783499626.101491 cmd_parse_build_commands 0:24 0:0: select-pane
+1783499626.101492 cmd_parse_build_commands 0:24 0:1: -m
+1783499626.101493 cmd_parse_build_commands 0:25: Rename
+1783499626.101495 cmd_parse_build_commands 0:26: n
+1783499626.101496 cmd_parse_build_commands 0:27 0:0: command-prompt
+1783499626.101497 cmd_parse_build_commands 0:27 0:1: -FI
+1783499626.101499 cmd_parse_build_commands 0:27 0:2: #W
+1783499626.101500 cmd_parse_build_commands 0:27 0:3 0:0: rename-window
+1783499626.101501 cmd_parse_build_commands 0:27 0:3 0:1: -t
+1783499626.101503 cmd_parse_build_commands 0:27 0:3 0:2: #{window_id}
+1783499626.101504 cmd_parse_build_commands 0:27 0:3 0:3: --
+1783499626.101506 cmd_parse_build_commands 0:27 0:3 0:4: %%
+1783499626.101507 cmd_parse_build_commands 0:28: 
+1783499626.101508 cmd_parse_build_commands 0:29: New After
+1783499626.101510 cmd_parse_build_commands 0:30: w
+1783499626.101511 cmd_parse_build_commands 0:31 0:0: new-window
+1783499626.101512 cmd_parse_build_commands 0:31 0:1: -a
+1783499626.101513 cmd_parse_build_commands 0:32: New At End
+1783499626.101515 cmd_parse_build_commands 0:33: W
+1783499626.101516 cmd_parse_build_commands 0:34 0:0: new-window
+1783499626.101520 cmd_parse_build_commands 0:0: swap-window
+1783499626.101522 cmd_parse_build_commands 0:1: -t:-1
+1783499626.101526 args_parse_flags: next -t:-1
+1783499626.101528 args_parse_flag_argument: -t = :-1
+1783499626.101529 args_parse: flags end at 2 of 2
+1783499626.101534 cmd_parse_build_commands: swap-window -t :-1
+1783499626.101536 cmd_parse_build_commands 0:0: swap-window
+1783499626.101537 cmd_parse_build_commands 0:1: -t:+1
+1783499626.101540 args_parse_flags: next -t:+1
+1783499626.101541 args_parse_flag_argument: -t = :+1
+1783499626.101543 args_parse: flags end at 2 of 2
+1783499626.101545 cmd_parse_build_commands: swap-window -t :+1
+1783499626.101547 cmd_parse_build_commands 0:0: swap-window
+1783499626.101550 args_parse: flags end at 1 of 1
+1783499626.101552 cmd_parse_build_commands: swap-window
+1783499626.101554 cmd_parse_build_commands 0:0: kill-window
+1783499626.101556 args_parse: flags end at 1 of 1
+1783499626.101558 cmd_parse_build_commands: kill-window
+1783499626.101560 cmd_parse_build_commands 0:0: respawn-window
+1783499626.101561 cmd_parse_build_commands 0:1: -k
+1783499626.101564 args_parse_flags: next -k
+1783499626.101565 args_parse_flags: -k
+1783499626.101566 args_parse: flags end at 2 of 2
+1783499626.101568 cmd_parse_build_commands: respawn-window -k
+1783499626.101570 cmd_parse_build_commands 0:0: select-pane
+1783499626.101571 cmd_parse_build_commands 0:1: -m
+1783499626.101574 args_parse_flags: next -m
+1783499626.101575 args_parse_flags: -m
+1783499626.101576 args_parse: flags end at 2 of 2
+1783499626.101578 cmd_parse_build_commands: select-pane -m
+1783499626.101582 cmd_parse_build_commands 0:0: command-prompt
+1783499626.101589 cmd_parse_build_commands 0:1: -FI
+1783499626.101590 cmd_parse_build_commands 0:2: #W
+1783499626.101592 cmd_parse_build_commands 0:3 0:0: rename-window
+1783499626.101593 cmd_parse_build_commands 0:3 0:1: -t
+1783499626.101595 cmd_parse_build_commands 0:3 0:2: #{window_id}
+1783499626.101596 cmd_parse_build_commands 0:3 0:3: --
+1783499626.101597 cmd_parse_build_commands 0:3 0:4: %%
+1783499626.101599 cmd_parse_build_commands 0:0: rename-window
+1783499626.101600 cmd_parse_build_commands 0:1: -t
+1783499626.101602 cmd_parse_build_commands 0:2: #{window_id}
+1783499626.101603 cmd_parse_build_commands 0:3: --
+1783499626.101604 cmd_parse_build_commands 0:4: %%
+1783499626.101607 args_parse_flags: next -t
+1783499626.101609 args_parse_flag_argument: -t = #{window_id}
+1783499626.101610 args_parse_flags: next --
+1783499626.101611 args_parse: flags end at 4 of 5
+1783499626.101613 args_parse: 4 = %% (type STRING)
+1783499626.101617 cmd_parse_build_commands: rename-window -t "#{window_id}" "%%"
+1783499626.101618 args_parse_flags: next -FI
+1783499626.101619 args_parse_flags: -F
+1783499626.101621 args_parse_flag_argument: -I = #W
+1783499626.101622 args_parse: flags end at 3 of 4
+1783499626.101625 args_parse: 3 = rename-window -t "#{window_id}" "%%" (type COMMANDS)
+1783499626.101630 cmd_parse_build_commands: command-prompt -F -I "#W" { rename-window -t "#{window_id}" "%%" }
+1783499626.101633 cmd_parse_build_commands 0:0: new-window
+1783499626.101635 cmd_parse_build_commands 0:1: -a
+1783499626.101637 args_parse_flags: next -a
+1783499626.101638 args_parse_flags: -a
+1783499626.101639 args_parse: flags end at 2 of 2
+1783499626.101641 cmd_parse_build_commands: new-window -a
+1783499626.101665 cmd_parse_build_commands 0:0: new-window
+1783499626.101671 args_parse: flags end at 1 of 1
+1783499626.101674 cmd_parse_build_commands: new-window
+1783499626.101675 args_parse_flags: next -t=
+1783499626.101676 args_parse_flag_argument: -t = =
+1783499626.101678 args_parse_flags: next -xW
+1783499626.101679 args_parse_flag_argument: -x = W
+1783499626.101680 args_parse_flags: next -yW
+1783499626.101681 args_parse_flag_argument: -y = W
+1783499626.101683 args_parse_flags: next -T
+1783499626.101684 args_parse_flag_argument: -T = #[align=centre]#{window_index}:#{window_name}
+1783499626.101686 args_parse_flags: next #{?#{>:#{session_windows},1},,-}Swap Left
+1783499626.101688 args_parse: flags end at 6 of 35
+1783499626.101689 args_parse: 6 = #{?#{>:#{session_windows},1},,-}Swap Left (type STRING)
+1783499626.101691 args_parse: 7 = l (type STRING)
+1783499626.101694 args_parse: 8 = swap-window -t :-1 (type COMMANDS)
+1783499626.101696 args_parse: 9 = #{?#{>:#{session_windows},1},,-}Swap Right (type STRING)
+1783499626.101697 args_parse: 10 = r (type STRING)
+1783499626.101700 args_parse: 11 = swap-window -t :+1 (type COMMANDS)
+1783499626.101702 args_parse: 12 = #{?pane_marked_set,,-}Swap Marked (type STRING)
+1783499626.101703 args_parse: 13 = s (type STRING)
+1783499626.101705 args_parse: 14 = swap-window (type COMMANDS)
+1783499626.101706 args_parse: 15 =  (type STRING)
+1783499626.101708 args_parse: 16 = Kill (type STRING)
+1783499626.101709 args_parse: 17 = X (type STRING)
+1783499626.101711 args_parse: 18 = kill-window (type COMMANDS)
+1783499626.101713 args_parse: 19 = Respawn (type STRING)
+1783499626.101714 args_parse: 20 = R (type STRING)
+1783499626.101717 args_parse: 21 = respawn-window -k (type COMMANDS)
+1783499626.101719 args_parse: 22 = #{?pane_marked,Unmark,Mark} (type STRING)
+1783499626.101720 args_parse: 23 = m (type STRING)
+1783499626.101722 args_parse: 24 = select-pane -m (type COMMANDS)
+1783499626.101724 args_parse: 25 = Rename (type STRING)
+1783499626.101725 args_parse: 26 = n (type STRING)
+1783499626.101731 args_parse: 27 = command-prompt -F -I "#W" { rename-window -t "#{window_id}" "%%" } (type COMMANDS)
+1783499626.101732 args_parse: 28 =  (type STRING)
+1783499626.101734 args_parse: 29 = New After (type STRING)
+1783499626.101735 args_parse: 30 = w (type STRING)
+1783499626.101737 args_parse: 31 = new-window -a (type COMMANDS)
+1783499626.101744 args_parse: 32 = New At End (type STRING)
+1783499626.101746 args_parse: 33 = W (type STRING)
+1783499626.101748 args_parse: 34 = new-window (type COMMANDS)
+1783499626.101775 cmd_parse_build_commands: display-menu -T "#[align=centre]#{window_index}:#{window_name}" -t = -x W -y W "#{?#{>:#{session_windows},1},,-}Swap Left" l { swap-window -t :-1 } "#{?#{>:#{session_windows},1},,-}Swap Right" r { swap-window -t :+1 } "#{?pane_marked_set,,-}Swap Marked" s { swap-window } '' Kill X { kill-window } Respawn R { respawn-window -k } "#{?pane_marked,Unmark,Mark}" m { select-pane -m } Rename n { command-prompt -F -I "#W" { rename-window -t "#{window_id}" "%%" } } '' "New After" w { new-window -a } "New At End" W { new-window }
+1783499626.101778 args_parse_flags: next -n
+1783499626.101779 args_parse_flags: -n
+1783499626.101780 args_parse_flags: next M-MouseDown3Status
+1783499626.101781 args_parse: flags end at 2 of 4
+1783499626.101783 args_parse: 2 = M-MouseDown3Status (type STRING)
+1783499626.101806 args_parse: 3 = display-menu -T "#[align=centre]#{window_index}:#{window_name}" -t = -x W -y W "#{?#{>:#{session_windows},1},,-}Swap Left" l { swap-window -t :-1 } "#{?#{>:#{session_windows},1},,-}Swap Right" r { swap-window -t :+1 } "#{?pane_marked_set,,-}Swap Marked" s { swap-window } '' Kill X { kill-window } Respawn R { respawn-window -k } "#{?pane_marked,Unmark,Mark}" m { select-pane -m } Rename n { command-prompt -F -I "#W" { rename-window -t "#{window_id}" "%%" } } '' "New After" w { new-window -a } "New At End" W { new-window } (type COMMANDS)
+1783499626.101844 cmd_parse_build_commands: bind-key -n M-MouseDown3Status { display-menu -T "#[align=centre]#{window_index}:#{window_name}" -t = -x W -y W "#{?#{>:#{session_windows},1},,-}Swap Left" l { swap-window -t :-1 } "#{?#{>:#{session_windows},1},,-}Swap Right" r { swap-window -t :+1 } "#{?pane_marked_set,,-}Swap Marked" s { swap-window } '' Kill X { kill-window } Respawn R { respawn-window -k } "#{?pane_marked,Unmark,Mark}" m { select-pane -m } Rename n { command-prompt -F -I "#W" { rename-window -t "#{window_id}" "%%" } } '' "New After" w { new-window -a } "New At End" W { new-window } }
+1783499626.101853 cmdq_get_command: [bind-key/0x58e4724f5740] group 1070
+1783499626.101854 cmdq_append <global>: [bind-key/0x58e4724f5740]
+1783499626.101925 yylex_token: end at WS
+1783499626.101932 yylex_token: bind
+1783499626.101935 yylex_token: end at WS
+1783499626.101936 yylex_token: -n
+1783499626.101939 yylex_token: end at WS
+1783499626.101940 yylex_token: MouseDown3Pane
+1783499626.101942 yylex_token: end at WS
+1783499626.101943 yylex_token: if
+1783499626.101944 yylex_token: end at WS
+1783499626.101945 yylex_token: -Ft=
+1783499626.101949 yylex_token: end at WS
+1783499626.101951 yylex_token: #{||:#{mouse_any_flag},#{&&:#{pane_in_mode},#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}}}
+1783499626.101953 yylex_token: end at WS
+1783499626.101954 yylex_token: select-pane
+1783499626.101955 yylex_token: end at ;
+1783499626.101957 yylex_token: -t=
+1783499626.101958 yylex_token: end at WS
+1783499626.101959 yylex_token: send
+1783499626.101961 yylex_token: end at WS
+1783499626.101962 yylex_token: -M
+1783499626.101964 yylex_token: end at WS
+1783499626.101965 yylex_token: display-menu
+1783499626.101967 yylex_token: end at WS
+1783499626.101968 yylex_token: -t=
+1783499626.102010 yylex_token: end at WS
+1783499626.102013 yylex_token: -xM
+1783499626.102015 yylex_token: end at WS
+1783499626.102016 yylex_token: -yM
+1783499626.102018 yylex_token: end at WS
+1783499626.102020 yylex_token: -T
+1783499626.102022 yylex_token: end at WS
+1783499626.102025 yylex_token: #[align=centre]#{pane_index} (#{pane_id})
+1783499626.102028 yylex_token: end at WS
+1783499626.102030 yylex_token: #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,}
+1783499626.102032 yylex_token: end at WS
+1783499626.102033 yylex_token: <
+1783499626.102035 yylex_token: end at WS
+1783499626.102036 yylex_token: send
+1783499626.102038 yylex_token: end at WS
+1783499626.102039 yylex_token: -X
+1783499626.102041 yylex_token: end at }
+1783499626.102043 yylex_token: history-top
+1783499626.102057 yylex_token: end at WS
+1783499626.102059 yylex_token: #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Bottom,}
+1783499626.102061 yylex_token: end at WS
+1783499626.102063 yylex_token: >
+1783499626.102064 yylex_token: end at WS
+1783499626.102065 yylex_token: send
+1783499626.102067 yylex_token: end at WS
+1783499626.102068 yylex_token: -X
+1783499626.102070 yylex_token: end at }
+1783499626.102072 yylex_token: history-bottom
+1783499626.102074 yylex_token: end at WS
+1783499626.102075 yylex_token: 
+1783499626.102078 yylex_token: end at WS
+1783499626.102080 yylex_token: #{?mouse_word,Search For #[underscore]#{=/9/...:mouse_word},}
+1783499626.102082 yylex_token: end at WS
+1783499626.102083 yylex_token: C-r
+1783499626.102085 yylex_token: end at WS
+1783499626.102086 yylex_token: if
+1783499626.102088 yylex_token: end at WS
+1783499626.102089 yylex_token: -F
+1783499626.102091 yylex_token: end at WS
+1783499626.102093 yylex_token: #{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}
+1783499626.102095 yylex_token: end at ;
+1783499626.102097 yylex_token: copy-mode -t=
+1783499626.102099 yylex_token: end at WS
+1783499626.102100 yylex_token: send
+1783499626.102102 yylex_token: end at WS
+1783499626.102103 yylex_token: -Xt=
+1783499626.102105 yylex_token: end at WS
+1783499626.102106 yylex_token: search-backward
+1783499626.102108 yylex_token: end at }
+1783499626.102110 yylex_token: #{q:mouse_word}
+1783499626.102113 yylex_token: end at WS
+1783499626.102115 yylex_token: #{?mouse_word,Type #[underscore]#{=/9/...:mouse_word},}
+1783499626.102117 yylex_token: end at WS
+1783499626.102118 yylex_token: C-y
+1783499626.102120 yylex_token: end at WS
+1783499626.102121 yylex_token: copy-mode
+1783499626.102123 yylex_token: end at ;
+1783499626.102124 yylex_token: -q
+1783499626.102126 yylex_token: end at WS
+1783499626.102127 yylex_token: send-keys
+1783499626.102129 yylex_token: end at WS
+1783499626.102130 yylex_token: -l
+1783499626.102132 yylex_token: end at WS
+1783499626.102133 yylex_token: --
+1783499626.102134 yylex_token: end at }
+1783499626.102136 yylex_token: #{q:mouse_word}
+1783499626.102139 yylex_token: end at WS
+1783499626.102142 yylex_token: #{?mouse_word,Copy #[underscore]#{=/9/...:mouse_word},}
+1783499626.102143 yylex_token: end at WS
+1783499626.102145 yylex_token: c
+1783499626.102146 yylex_token: end at WS
+1783499626.102148 yylex_token: copy-mode
+1783499626.102149 yylex_token: end at ;
+1783499626.102150 yylex_token: -q
+1783499626.102152 yylex_token: end at WS
+1783499626.102153 yylex_token: set-buffer
+1783499626.102155 yylex_token: end at WS
+1783499626.102156 yylex_token: --
+1783499626.102158 yylex_token: end at }
+1783499626.102159 yylex_token: #{q:mouse_word}
+1783499626.102162 yylex_token: end at WS
+1783499626.102163 yylex_token: #{?mouse_line,Copy Line,}
+1783499626.102165 yylex_token: end at WS
+1783499626.102166 yylex_token: l
+1783499626.102168 yylex_token: end at WS
+1783499626.102169 yylex_token: copy-mode
+1783499626.102170 yylex_token: end at ;
+1783499626.102171 yylex_token: -q
+1783499626.102173 yylex_token: end at WS
+1783499626.102175 yylex_token: set-buffer
+1783499626.102176 yylex_token: end at WS
+1783499626.102177 yylex_token: --
+1783499626.102179 yylex_token: end at }
+1783499626.102180 yylex_token: #{q:mouse_line}
+1783499626.102182 yylex_token: end at WS
+1783499626.102183 yylex_token: 
+1783499626.102186 yylex_token: end at WS
+1783499626.102190 yylex_token: #{?mouse_hyperlink,Type #[underscore]#{=/9/...:mouse_hyperlink},}
+1783499626.102192 yylex_token: end at WS
+1783499626.102194 yylex_token: C-h
+1783499626.102195 yylex_token: end at WS
+1783499626.102197 yylex_token: copy-mode
+1783499626.102198 yylex_token: end at ;
+1783499626.102199 yylex_token: -q
+1783499626.102201 yylex_token: end at WS
+1783499626.102202 yylex_token: send-keys
+1783499626.102204 yylex_token: end at WS
+1783499626.102205 yylex_token: -l
+1783499626.102207 yylex_token: end at WS
+1783499626.102208 yylex_token: --
+1783499626.102210 yylex_token: end at }
+1783499626.102211 yylex_token: #{q:mouse_hyperlink}
+1783499626.102215 yylex_token: end at WS
+1783499626.102217 yylex_token: #{?mouse_hyperlink,Copy #[underscore]#{=/9/...:mouse_hyperlink},}
+1783499626.102222 yylex_token: end at WS
+1783499626.102223 yylex_token: h
+1783499626.102225 yylex_token: end at WS
+1783499626.102226 yylex_token: copy-mode
+1783499626.102228 yylex_token: end at ;
+1783499626.102229 yylex_token: -q
+1783499626.102231 yylex_token: end at WS
+1783499626.102232 yylex_token: set-buffer
+1783499626.102233 yylex_token: end at WS
+1783499626.102235 yylex_token: --
+1783499626.102237 yylex_token: end at }
+1783499626.102238 yylex_token: #{q:mouse_hyperlink}
+1783499626.102240 yylex_token: end at WS
+1783499626.102241 yylex_token: 
+1783499626.102243 yylex_token: end at WS
+1783499626.102244 yylex_token: Horizontal Split
+1783499626.102246 yylex_token: end at WS
+1783499626.102247 yylex_token: h
+1783499626.102249 yylex_token: end at WS
+1783499626.102250 yylex_token: split-window
+1783499626.102252 yylex_token: end at }
+1783499626.102253 yylex_token: -h
+1783499626.102255 yylex_token: end at WS
+1783499626.102256 yylex_token: Vertical Split
+1783499626.102258 yylex_token: end at WS
+1783499626.102259 yylex_token: v
+1783499626.102261 yylex_token: end at WS
+1783499626.102262 yylex_token: split-window
+1783499626.102263 yylex_token: end at }
+1783499626.102264 yylex_token: -v
+1783499626.102266 yylex_token: end at WS
+1783499626.102267 yylex_token: 
+1783499626.102270 yylex_token: end at WS
+1783499626.102272 yylex_token: #{?#{>:#{window_panes},1},,-}Swap Up
+1783499626.102273 yylex_token: end at WS
+1783499626.102275 yylex_token: u
+1783499626.102276 yylex_token: end at WS
+1783499626.102278 yylex_token: swap-pane
+1783499626.102279 yylex_token: end at }
+1783499626.102280 yylex_token: -U
+1783499626.102283 yylex_token: end at WS
+1783499626.102285 yylex_token: #{?#{>:#{window_panes},1},,-}Swap Down
+1783499626.102286 yylex_token: end at WS
+1783499626.102287 yylex_token: d
+1783499626.102289 yylex_token: end at WS
+1783499626.102290 yylex_token: swap-pane
+1783499626.102292 yylex_token: end at }
+1783499626.102293 yylex_token: -D
+1783499626.102295 yylex_token: end at WS
+1783499626.102297 yylex_token: #{?pane_marked_set,,-}Swap Marked
+1783499626.102299 yylex_token: end at WS
+1783499626.102300 yylex_token: s
+1783499626.102302 yylex_token: end at }
+1783499626.102303 yylex_token: swap-pane
+1783499626.102305 yylex_token: end at WS
+1783499626.102306 yylex_token: 
+1783499626.102307 yylex_token: end at WS
+1783499626.102308 yylex_token: Kill
+1783499626.102310 yylex_token: end at WS
+1783499626.102311 yylex_token: X
+1783499626.102313 yylex_token: end at }
+1783499626.102314 yylex_token: kill-pane
+1783499626.102316 yylex_token: end at WS
+1783499626.102317 yylex_token: Respawn
+1783499626.102326 yylex_token: end at WS
+1783499626.102331 yylex_token: R
+1783499626.102333 yylex_token: end at WS
+1783499626.102335 yylex_token: respawn-pane
+1783499626.102337 yylex_token: end at }
+1783499626.102338 yylex_token: -k
+1783499626.102340 yylex_token: end at WS
+1783499626.102342 yylex_token: #{?pane_marked,Unmark,Mark}
+1783499626.102343 yylex_token: end at WS
+1783499626.102345 yylex_token: m
+1783499626.102346 yylex_token: end at WS
+1783499626.102348 yylex_token: select-pane
+1783499626.102349 yylex_token: end at }
+1783499626.102350 yylex_token: -m
+1783499626.102353 yylex_token: end at WS
+1783499626.102356 yylex_token: #{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom}
+1783499626.102358 yylex_token: end at WS
+1783499626.102359 yylex_token: z
+1783499626.102360 yylex_token: end at WS
+1783499626.102362 yylex_token: resize-pane
+1783499626.102363 yylex_token: end at }
+1783499626.102364 yylex_token: -Z
+1783499626.102370 cmd_parse_build_commands 0:0: bind
+1783499626.102372 cmd_parse_build_commands 0:1: -n
+1783499626.102373 cmd_parse_build_commands 0:2: MouseDown3Pane
+1783499626.102375 cmd_parse_build_commands 0:3 0:0: if
+1783499626.102377 cmd_parse_build_commands 0:3 0:1: -Ft=
+1783499626.102380 cmd_parse_build_commands 0:3 0:2: #{||:#{mouse_any_flag},#{&&:#{pane_in_mode},#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}}}
+1783499626.102383 cmd_parse_build_commands 0:3 0:3 0:0: select-pane
+1783499626.102388 cmd_parse_build_commands 0:3 0:3 0:1: -t=
+1783499626.102390 cmd_parse_build_commands 0:3 0:3 1:0: send
+1783499626.102392 cmd_parse_build_commands 0:3 0:3 1:1: -M
+1783499626.102394 cmd_parse_build_commands 0:3 0:4 0:0: display-menu
+1783499626.102396 cmd_parse_build_commands 0:3 0:4 0:1: -t=
+1783499626.102398 cmd_parse_build_commands 0:3 0:4 0:2: -xM
+1783499626.102399 cmd_parse_build_commands 0:3 0:4 0:3: -yM
+1783499626.102401 cmd_parse_build_commands 0:3 0:4 0:4: -T
+1783499626.102403 cmd_parse_build_commands 0:3 0:4 0:5: #[align=centre]#{pane_index} (#{pane_id})
+1783499626.102406 cmd_parse_build_commands 0:3 0:4 0:6: #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,}
+1783499626.102408 cmd_parse_build_commands 0:3 0:4 0:7: <
+1783499626.102411 cmd_parse_build_commands 0:3 0:4 0:8 0:0: send
+1783499626.102412 cmd_parse_build_commands 0:3 0:4 0:8 0:1: -X
+1783499626.102414 cmd_parse_build_commands 0:3 0:4 0:8 0:2: history-top
+1783499626.102418 cmd_parse_build_commands 0:3 0:4 0:9: #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Bottom,}
+1783499626.102420 cmd_parse_build_commands 0:3 0:4 0:10: >
+1783499626.102422 cmd_parse_build_commands 0:3 0:4 0:11 0:0: send
+1783499626.102424 cmd_parse_build_commands 0:3 0:4 0:11 0:1: -X
+1783499626.102426 cmd_parse_build_commands 0:3 0:4 0:11 0:2: history-bottom
+1783499626.102428 cmd_parse_build_commands 0:3 0:4 0:12: 
+1783499626.102430 cmd_parse_build_commands 0:3 0:4 0:13: #{?mouse_word,Search For #[underscore]#{=/9/...:mouse_word},}
+1783499626.102432 cmd_parse_build_commands 0:3 0:4 0:14: C-r
+1783499626.102434 cmd_parse_build_commands 0:3 0:4 0:15 0:0: if
+1783499626.102436 cmd_parse_build_commands 0:3 0:4 0:15 0:1: -F
+1783499626.102439 cmd_parse_build_commands 0:3 0:4 0:15 0:2: #{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}
+1783499626.102441 cmd_parse_build_commands 0:3 0:4 0:15 0:3: copy-mode -t=
+1783499626.102443 cmd_parse_build_commands 0:3 0:4 0:15 1:0: send
+1783499626.102445 cmd_parse_build_commands 0:3 0:4 0:15 1:1: -Xt=
+1783499626.102447 cmd_parse_build_commands 0:3 0:4 0:15 1:2: search-backward
+1783499626.102449 cmd_parse_build_commands 0:3 0:4 0:15 1:3: #{q:mouse_word}
+1783499626.102451 cmd_parse_build_commands 0:3 0:4 0:16: #{?mouse_word,Type #[underscore]#{=/9/...:mouse_word},}
+1783499626.102453 cmd_parse_build_commands 0:3 0:4 0:17: C-y
+1783499626.102455 cmd_parse_build_commands 0:3 0:4 0:18 0:0: copy-mode
+1783499626.102457 cmd_parse_build_commands 0:3 0:4 0:18 0:1: -q
+1783499626.102459 cmd_parse_build_commands 0:3 0:4 0:18 1:0: send-keys
+1783499626.102461 cmd_parse_build_commands 0:3 0:4 0:18 1:1: -l
+1783499626.102463 cmd_parse_build_commands 0:3 0:4 0:18 1:2: --
+1783499626.102465 cmd_parse_build_commands 0:3 0:4 0:18 1:3: #{q:mouse_word}
+1783499626.102468 cmd_parse_build_commands 0:3 0:4 0:19: #{?mouse_word,Copy #[underscore]#{=/9/...:mouse_word},}
+1783499626.102470 cmd_parse_build_commands 0:3 0:4 0:20: c
+1783499626.102472 cmd_parse_build_commands 0:3 0:4 0:21 0:0: copy-mode
+1783499626.102474 cmd_parse_build_commands 0:3 0:4 0:21 0:1: -q
+1783499626.102476 cmd_parse_build_commands 0:3 0:4 0:21 1:0: set-buffer
+1783499626.102478 cmd_parse_build_commands 0:3 0:4 0:21 1:1: --
+1783499626.102480 cmd_parse_build_commands 0:3 0:4 0:21 1:2: #{q:mouse_word}
+1783499626.102482 cmd_parse_build_commands 0:3 0:4 0:22: #{?mouse_line,Copy Line,}
+1783499626.102484 cmd_parse_build_commands 0:3 0:4 0:23: l
+1783499626.102486 cmd_parse_build_commands 0:3 0:4 0:24 0:0: copy-mode
+1783499626.102488 cmd_parse_build_commands 0:3 0:4 0:24 0:1: -q
+1783499626.102490 cmd_parse_build_commands 0:3 0:4 0:24 1:0: set-buffer
+1783499626.102492 cmd_parse_build_commands 0:3 0:4 0:24 1:1: --
+1783499626.102494 cmd_parse_build_commands 0:3 0:4 0:24 1:2: #{q:mouse_line}
+1783499626.102495 cmd_parse_build_commands 0:3 0:4 0:25: 
+1783499626.102498 cmd_parse_build_commands 0:3 0:4 0:26: #{?mouse_hyperlink,Type #[underscore]#{=/9/...:mouse_hyperlink},}
+1783499626.102500 cmd_parse_build_commands 0:3 0:4 0:27: C-h
+1783499626.102502 cmd_parse_build_commands 0:3 0:4 0:28 0:0: copy-mode
+1783499626.102504 cmd_parse_build_commands 0:3 0:4 0:28 0:1: -q
+1783499626.102508 cmd_parse_build_commands 0:3 0:4 0:28 1:0: send-keys
+1783499626.102510 cmd_parse_build_commands 0:3 0:4 0:28 1:1: -l
+1783499626.102512 cmd_parse_build_commands 0:3 0:4 0:28 1:2: --
+1783499626.102515 cmd_parse_build_commands 0:3 0:4 0:28 1:3: #{q:mouse_hyperlink}
+1783499626.102518 cmd_parse_build_commands 0:3 0:4 0:29: #{?mouse_hyperlink,Copy #[underscore]#{=/9/...:mouse_hyperlink},}
+1783499626.102520 cmd_parse_build_commands 0:3 0:4 0:30: h
+1783499626.102522 cmd_parse_build_commands 0:3 0:4 0:31 0:0: copy-mode
+1783499626.102524 cmd_parse_build_commands 0:3 0:4 0:31 0:1: -q
+1783499626.102526 cmd_parse_build_commands 0:3 0:4 0:31 1:0: set-buffer
+1783499626.102528 cmd_parse_build_commands 0:3 0:4 0:31 1:1: --
+1783499626.102530 cmd_parse_build_commands 0:3 0:4 0:31 1:2: #{q:mouse_hyperlink}
+1783499626.102531 cmd_parse_build_commands 0:3 0:4 0:32: 
+1783499626.102533 cmd_parse_build_commands 0:3 0:4 0:33: Horizontal Split
+1783499626.102535 cmd_parse_build_commands 0:3 0:4 0:34: h
+1783499626.102538 cmd_parse_build_commands 0:3 0:4 0:35 0:0: split-window
+1783499626.102540 cmd_parse_build_commands 0:3 0:4 0:35 0:1: -h
+1783499626.102541 cmd_parse_build_commands 0:3 0:4 0:36: Vertical Split
+1783499626.102543 cmd_parse_build_commands 0:3 0:4 0:37: v
+1783499626.102545 cmd_parse_build_commands 0:3 0:4 0:38 0:0: split-window
+1783499626.102547 cmd_parse_build_commands 0:3 0:4 0:38 0:1: -v
+1783499626.102549 cmd_parse_build_commands 0:3 0:4 0:39: 
+1783499626.102551 cmd_parse_build_commands 0:3 0:4 0:40: #{?#{>:#{window_panes},1},,-}Swap Up
+1783499626.102553 cmd_parse_build_commands 0:3 0:4 0:41: u
+1783499626.102555 cmd_parse_build_commands 0:3 0:4 0:42 0:0: swap-pane
+1783499626.102556 cmd_parse_build_commands 0:3 0:4 0:42 0:1: -U
+1783499626.102559 cmd_parse_build_commands 0:3 0:4 0:43: #{?#{>:#{window_panes},1},,-}Swap Down
+1783499626.102560 cmd_parse_build_commands 0:3 0:4 0:44: d
+1783499626.102569 cmd_parse_build_commands 0:3 0:4 0:45 0:0: swap-pane
+1783499626.102576 cmd_parse_build_commands 0:3 0:4 0:45 0:1: -D
+1783499626.102578 cmd_parse_build_commands 0:3 0:4 0:46: #{?pane_marked_set,,-}Swap Marked
+1783499626.102580 cmd_parse_build_commands 0:3 0:4 0:47: s
+1783499626.102582 cmd_parse_build_commands 0:3 0:4 0:48 0:0: swap-pane
+1783499626.102584 cmd_parse_build_commands 0:3 0:4 0:49: 
+1783499626.102586 cmd_parse_build_commands 0:3 0:4 0:50: Kill
+1783499626.102588 cmd_parse_build_commands 0:3 0:4 0:51: X
+1783499626.102590 cmd_parse_build_commands 0:3 0:4 0:52 0:0: kill-pane
+1783499626.102592 cmd_parse_build_commands 0:3 0:4 0:53: Respawn
+1783499626.102594 cmd_parse_build_commands 0:3 0:4 0:54: R
+1783499626.102596 cmd_parse_build_commands 0:3 0:4 0:55 0:0: respawn-pane
+1783499626.102598 cmd_parse_build_commands 0:3 0:4 0:55 0:1: -k
+1783499626.102600 cmd_parse_build_commands 0:3 0:4 0:56: #{?pane_marked,Unmark,Mark}
+1783499626.102602 cmd_parse_build_commands 0:3 0:4 0:57: m
+1783499626.102604 cmd_parse_build_commands 0:3 0:4 0:58 0:0: select-pane
+1783499626.102606 cmd_parse_build_commands 0:3 0:4 0:58 0:1: -m
+1783499626.102608 cmd_parse_build_commands 0:3 0:4 0:59: #{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom}
+1783499626.102610 cmd_parse_build_commands 0:3 0:4 0:60: z
+1783499626.102612 cmd_parse_build_commands 0:3 0:4 0:61 0:0: resize-pane
+1783499626.102614 cmd_parse_build_commands 0:3 0:4 0:61 0:1: -Z
+1783499626.102618 cmd_parse_build_commands 0:0: if
+1783499626.102620 cmd_parse_build_commands 0:1: -Ft=
+1783499626.102624 cmd_parse_build_commands 0:2: #{||:#{mouse_any_flag},#{&&:#{pane_in_mode},#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}}}
+1783499626.102627 cmd_parse_build_commands 0:3 0:0: select-pane
+1783499626.102628 cmd_parse_build_commands 0:3 0:1: -t=
+1783499626.102630 cmd_parse_build_commands 0:3 1:0: send
+1783499626.102632 cmd_parse_build_commands 0:3 1:1: -M
+1783499626.102634 cmd_parse_build_commands 0:4 0:0: display-menu
+1783499626.102636 cmd_parse_build_commands 0:4 0:1: -t=
+1783499626.102637 cmd_parse_build_commands 0:4 0:2: -xM
+1783499626.102639 cmd_parse_build_commands 0:4 0:3: -yM
+1783499626.102645 cmd_parse_build_commands 0:4 0:4: -T
+1783499626.102648 cmd_parse_build_commands 0:4 0:5: #[align=centre]#{pane_index} (#{pane_id})
+1783499626.102651 cmd_parse_build_commands 0:4 0:6: #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,}
+1783499626.102652 cmd_parse_build_commands 0:4 0:7: <
+1783499626.102654 cmd_parse_build_commands 0:4 0:8 0:0: send
+1783499626.102656 cmd_parse_build_commands 0:4 0:8 0:1: -X
+1783499626.102658 cmd_parse_build_commands 0:4 0:8 0:2: history-top
+1783499626.102661 cmd_parse_build_commands 0:4 0:9: #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Bottom,}
+1783499626.102662 cmd_parse_build_commands 0:4 0:10: >
+1783499626.102664 cmd_parse_build_commands 0:4 0:11 0:0: send
+1783499626.102666 cmd_parse_build_commands 0:4 0:11 0:1: -X
+1783499626.102668 cmd_parse_build_commands 0:4 0:11 0:2: history-bottom
+1783499626.102670 cmd_parse_build_commands 0:4 0:12: 
+1783499626.102673 cmd_parse_build_commands 0:4 0:13: #{?mouse_word,Search For #[underscore]#{=/9/...:mouse_word},}
+1783499626.102675 cmd_parse_build_commands 0:4 0:14: C-r
+1783499626.102677 cmd_parse_build_commands 0:4 0:15 0:0: if
+1783499626.102678 cmd_parse_build_commands 0:4 0:15 0:1: -F
+1783499626.102681 cmd_parse_build_commands 0:4 0:15 0:2: #{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}
+1783499626.102683 cmd_parse_build_commands 0:4 0:15 0:3: copy-mode -t=
+1783499626.102685 cmd_parse_build_commands 0:4 0:15 1:0: send
+1783499626.102686 cmd_parse_build_commands 0:4 0:15 1:1: -Xt=
+1783499626.102688 cmd_parse_build_commands 0:4 0:15 1:2: search-backward
+1783499626.102690 cmd_parse_build_commands 0:4 0:15 1:3: #{q:mouse_word}
+1783499626.102693 cmd_parse_build_commands 0:4 0:16: #{?mouse_word,Type #[underscore]#{=/9/...:mouse_word},}
+1783499626.102695 cmd_parse_build_commands 0:4 0:17: C-y
+1783499626.102697 cmd_parse_build_commands 0:4 0:18 0:0: copy-mode
+1783499626.102698 cmd_parse_build_commands 0:4 0:18 0:1: -q
+1783499626.102700 cmd_parse_build_commands 0:4 0:18 1:0: send-keys
+1783499626.102702 cmd_parse_build_commands 0:4 0:18 1:1: -l
+1783499626.102704 cmd_parse_build_commands 0:4 0:18 1:2: --
+1783499626.102706 cmd_parse_build_commands 0:4 0:18 1:3: #{q:mouse_word}
+1783499626.102708 cmd_parse_build_commands 0:4 0:19: #{?mouse_word,Copy #[underscore]#{=/9/...:mouse_word},}
+1783499626.102710 cmd_parse_build_commands 0:4 0:20: c
+1783499626.102712 cmd_parse_build_commands 0:4 0:21 0:0: copy-mode
+1783499626.102713 cmd_parse_build_commands 0:4 0:21 0:1: -q
+1783499626.102716 cmd_parse_build_commands 0:4 0:21 1:0: set-buffer
+1783499626.102718 cmd_parse_build_commands 0:4 0:21 1:1: --
+1783499626.102720 cmd_parse_build_commands 0:4 0:21 1:2: #{q:mouse_word}
+1783499626.102722 cmd_parse_build_commands 0:4 0:22: #{?mouse_line,Copy Line,}
+1783499626.102723 cmd_parse_build_commands 0:4 0:23: l
+1783499626.102726 cmd_parse_build_commands 0:4 0:24 0:0: copy-mode
+1783499626.102727 cmd_parse_build_commands 0:4 0:24 0:1: -q
+1783499626.102729 cmd_parse_build_commands 0:4 0:24 1:0: set-buffer
+1783499626.102731 cmd_parse_build_commands 0:4 0:24 1:1: --
+1783499626.102733 cmd_parse_build_commands 0:4 0:24 1:2: #{q:mouse_line}
+1783499626.102735 cmd_parse_build_commands 0:4 0:25: 
+1783499626.102737 cmd_parse_build_commands 0:4 0:26: #{?mouse_hyperlink,Type #[underscore]#{=/9/...:mouse_hyperlink},}
+1783499626.102739 cmd_parse_build_commands 0:4 0:27: C-h
+1783499626.102741 cmd_parse_build_commands 0:4 0:28 0:0: copy-mode
+1783499626.102743 cmd_parse_build_commands 0:4 0:28 0:1: -q
+1783499626.102745 cmd_parse_build_commands 0:4 0:28 1:0: send-keys
+1783499626.102746 cmd_parse_build_commands 0:4 0:28 1:1: -l
+1783499626.102748 cmd_parse_build_commands 0:4 0:28 1:2: --
+1783499626.102750 cmd_parse_build_commands 0:4 0:28 1:3: #{q:mouse_hyperlink}
+1783499626.102753 cmd_parse_build_commands 0:4 0:29: #{?mouse_hyperlink,Copy #[underscore]#{=/9/...:mouse_hyperlink},}
+1783499626.102755 cmd_parse_build_commands 0:4 0:30: h
+1783499626.102756 cmd_parse_build_commands 0:4 0:31 0:0: copy-mode
+1783499626.102758 cmd_parse_build_commands 0:4 0:31 0:1: -q
+1783499626.102764 cmd_parse_build_commands 0:4 0:31 1:0: set-buffer
+1783499626.102766 cmd_parse_build_commands 0:4 0:31 1:1: --
+1783499626.102767 cmd_parse_build_commands 0:4 0:31 1:2: #{q:mouse_hyperlink}
+1783499626.102769 cmd_parse_build_commands 0:4 0:32: 
+1783499626.102771 cmd_parse_build_commands 0:4 0:33: Horizontal Split
+1783499626.102773 cmd_parse_build_commands 0:4 0:34: h
+1783499626.102775 cmd_parse_build_commands 0:4 0:35 0:0: split-window
+1783499626.102777 cmd_parse_build_commands 0:4 0:35 0:1: -h
+1783499626.102778 cmd_parse_build_commands 0:4 0:36: Vertical Split
+1783499626.102780 cmd_parse_build_commands 0:4 0:37: v
+1783499626.102782 cmd_parse_build_commands 0:4 0:38 0:0: split-window
+1783499626.102784 cmd_parse_build_commands 0:4 0:38 0:1: -v
+1783499626.102786 cmd_parse_build_commands 0:4 0:39: 
+1783499626.102788 cmd_parse_build_commands 0:4 0:40: #{?#{>:#{window_panes},1},,-}Swap Up
+1783499626.102789 cmd_parse_build_commands 0:4 0:41: u
+1783499626.102791 cmd_parse_build_commands 0:4 0:42 0:0: swap-pane
+1783499626.102793 cmd_parse_build_commands 0:4 0:42 0:1: -U
+1783499626.102795 cmd_parse_build_commands 0:4 0:43: #{?#{>:#{window_panes},1},,-}Swap Down
+1783499626.102797 cmd_parse_build_commands 0:4 0:44: d
+1783499626.102799 cmd_parse_build_commands 0:4 0:45 0:0: swap-pane
+1783499626.102800 cmd_parse_build_commands 0:4 0:45 0:1: -D
+1783499626.102802 cmd_parse_build_commands 0:4 0:46: #{?pane_marked_set,,-}Swap Marked
+1783499626.102804 cmd_parse_build_commands 0:4 0:47: s
+1783499626.102806 cmd_parse_build_commands 0:4 0:48 0:0: swap-pane
+1783499626.102808 cmd_parse_build_commands 0:4 0:49: 
+1783499626.102810 cmd_parse_build_commands 0:4 0:50: Kill
+1783499626.102811 cmd_parse_build_commands 0:4 0:51: X
+1783499626.102814 cmd_parse_build_commands 0:4 0:52 0:0: kill-pane
+1783499626.102816 cmd_parse_build_commands 0:4 0:53: Respawn
+1783499626.102817 cmd_parse_build_commands 0:4 0:54: R
+1783499626.102819 cmd_parse_build_commands 0:4 0:55 0:0: respawn-pane
+1783499626.102821 cmd_parse_build_commands 0:4 0:55 0:1: -k
+1783499626.102823 cmd_parse_build_commands 0:4 0:56: #{?pane_marked,Unmark,Mark}
+1783499626.102825 cmd_parse_build_commands 0:4 0:57: m
+1783499626.102827 cmd_parse_build_commands 0:4 0:58 0:0: select-pane
+1783499626.102828 cmd_parse_build_commands 0:4 0:58 0:1: -m
+1783499626.102831 cmd_parse_build_commands 0:4 0:59: #{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom}
+1783499626.102833 cmd_parse_build_commands 0:4 0:60: z
+1783499626.102835 cmd_parse_build_commands 0:4 0:61 0:0: resize-pane
+1783499626.102837 cmd_parse_build_commands 0:4 0:61 0:1: -Z
+1783499626.102840 cmd_parse_build_commands 0:0: select-pane
+1783499626.102841 cmd_parse_build_commands 0:1: -t=
+1783499626.102843 cmd_parse_build_commands 1:0: send
+1783499626.102845 cmd_parse_build_commands 1:1: -M
+1783499626.102849 args_parse_flags: next -t=
+1783499626.102851 args_parse_flag_argument: -t = =
+1783499626.102853 args_parse: flags end at 2 of 2
+1783499626.102856 args_parse_flags: next -M
+1783499626.102858 args_parse_flags: -M
+1783499626.102859 args_parse: flags end at 2 of 2
+1783499626.102865 cmd_parse_build_commands: select-pane -t = ; send-keys -M
+1783499626.102867 cmd_parse_build_commands 0:0: display-menu
+1783499626.102869 cmd_parse_build_commands 0:1: -t=
+1783499626.102871 cmd_parse_build_commands 0:2: -xM
+1783499626.102872 cmd_parse_build_commands 0:3: -yM
+1783499626.102874 cmd_parse_build_commands 0:4: -T
+1783499626.102877 cmd_parse_build_commands 0:5: #[align=centre]#{pane_index} (#{pane_id})
+1783499626.102918 cmd_parse_build_commands 0:6: #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,}
+1783499626.102924 cmd_parse_build_commands 0:7: <
+1783499626.102927 cmd_parse_build_commands 0:8 0:0: send
+1783499626.102929 cmd_parse_build_commands 0:8 0:1: -X
+1783499626.102930 cmd_parse_build_commands 0:8 0:2: history-top
+1783499626.102933 cmd_parse_build_commands 0:9: #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Bottom,}
+1783499626.102934 cmd_parse_build_commands 0:10: >
+1783499626.102936 cmd_parse_build_commands 0:11 0:0: send
+1783499626.102944 cmd_parse_build_commands 0:11 0:1: -X
+1783499626.102946 cmd_parse_build_commands 0:11 0:2: history-bottom
+1783499626.102948 cmd_parse_build_commands 0:12: 
+1783499626.102950 cmd_parse_build_commands 0:13: #{?mouse_word,Search For #[underscore]#{=/9/...:mouse_word},}
+1783499626.102951 cmd_parse_build_commands 0:14: C-r
+1783499626.102953 cmd_parse_build_commands 0:15 0:0: if
+1783499626.102954 cmd_parse_build_commands 0:15 0:1: -F
+1783499626.102956 cmd_parse_build_commands 0:15 0:2: #{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}
+1783499626.102958 cmd_parse_build_commands 0:15 0:3: copy-mode -t=
+1783499626.102959 cmd_parse_build_commands 0:15 1:0: send
+1783499626.102960 cmd_parse_build_commands 0:15 1:1: -Xt=
+1783499626.102963 cmd_parse_build_commands 0:15 1:2: search-backward
+1783499626.102965 cmd_parse_build_commands 0:15 1:3: #{q:mouse_word}
+1783499626.102966 cmd_parse_build_commands 0:16: #{?mouse_word,Type #[underscore]#{=/9/...:mouse_word},}
+1783499626.102968 cmd_parse_build_commands 0:17: C-y
+1783499626.102970 cmd_parse_build_commands 0:18 0:0: copy-mode
+1783499626.102971 cmd_parse_build_commands 0:18 0:1: -q
+1783499626.102972 cmd_parse_build_commands 0:18 1:0: send-keys
+1783499626.102974 cmd_parse_build_commands 0:18 1:1: -l
+1783499626.102975 cmd_parse_build_commands 0:18 1:2: --
+1783499626.102977 cmd_parse_build_commands 0:18 1:3: #{q:mouse_word}
+1783499626.102978 cmd_parse_build_commands 0:19: #{?mouse_word,Copy #[underscore]#{=/9/...:mouse_word},}
+1783499626.102980 cmd_parse_build_commands 0:20: c
+1783499626.102982 cmd_parse_build_commands 0:21 0:0: copy-mode
+1783499626.102983 cmd_parse_build_commands 0:21 0:1: -q
+1783499626.102984 cmd_parse_build_commands 0:21 1:0: set-buffer
+1783499626.102986 cmd_parse_build_commands 0:21 1:1: --
+1783499626.102987 cmd_parse_build_commands 0:21 1:2: #{q:mouse_word}
+1783499626.102989 cmd_parse_build_commands 0:22: #{?mouse_line,Copy Line,}
+1783499626.102990 cmd_parse_build_commands 0:23: l
+1783499626.102992 cmd_parse_build_commands 0:24 0:0: copy-mode
+1783499626.102993 cmd_parse_build_commands 0:24 0:1: -q
+1783499626.102994 cmd_parse_build_commands 0:24 1:0: set-buffer
+1783499626.102996 cmd_parse_build_commands 0:24 1:1: --
+1783499626.102998 cmd_parse_build_commands 0:24 1:2: #{q:mouse_line}
+1783499626.102999 cmd_parse_build_commands 0:25: 
+1783499626.103001 cmd_parse_build_commands 0:26: #{?mouse_hyperlink,Type #[underscore]#{=/9/...:mouse_hyperlink},}
+1783499626.103003 cmd_parse_build_commands 0:27: C-h
+1783499626.103004 cmd_parse_build_commands 0:28 0:0: copy-mode
+1783499626.103006 cmd_parse_build_commands 0:28 0:1: -q
+1783499626.103007 cmd_parse_build_commands 0:28 1:0: send-keys
+1783499626.103008 cmd_parse_build_commands 0:28 1:1: -l
+1783499626.103010 cmd_parse_build_commands 0:28 1:2: --
+1783499626.103011 cmd_parse_build_commands 0:28 1:3: #{q:mouse_hyperlink}
+1783499626.103013 cmd_parse_build_commands 0:29: #{?mouse_hyperlink,Copy #[underscore]#{=/9/...:mouse_hyperlink},}
+1783499626.103014 cmd_parse_build_commands 0:30: h
+1783499626.103016 cmd_parse_build_commands 0:31 0:0: copy-mode
+1783499626.103017 cmd_parse_build_commands 0:31 0:1: -q
+1783499626.103018 cmd_parse_build_commands 0:31 1:0: set-buffer
+1783499626.103020 cmd_parse_build_commands 0:31 1:1: --
+1783499626.103021 cmd_parse_build_commands 0:31 1:2: #{q:mouse_hyperlink}
+1783499626.103023 cmd_parse_build_commands 0:32: 
+1783499626.103024 cmd_parse_build_commands 0:33: Horizontal Split
+1783499626.103025 cmd_parse_build_commands 0:34: h
+1783499626.103027 cmd_parse_build_commands 0:35 0:0: split-window
+1783499626.103028 cmd_parse_build_commands 0:35 0:1: -h
+1783499626.103030 cmd_parse_build_commands 0:36: Vertical Split
+1783499626.103031 cmd_parse_build_commands 0:37: v
+1783499626.103033 cmd_parse_build_commands 0:38 0:0: split-window
+1783499626.103035 cmd_parse_build_commands 0:38 0:1: -v
+1783499626.103036 cmd_parse_build_commands 0:39: 
+1783499626.103038 cmd_parse_build_commands 0:40: #{?#{>:#{window_panes},1},,-}Swap Up
+1783499626.103039 cmd_parse_build_commands 0:41: u
+1783499626.103041 cmd_parse_build_commands 0:42 0:0: swap-pane
+1783499626.103045 cmd_parse_build_commands 0:42 0:1: -U
+1783499626.103047 cmd_parse_build_commands 0:43: #{?#{>:#{window_panes},1},,-}Swap Down
+1783499626.103048 cmd_parse_build_commands 0:44: d
+1783499626.103050 cmd_parse_build_commands 0:45 0:0: swap-pane
+1783499626.103051 cmd_parse_build_commands 0:45 0:1: -D
+1783499626.103052 cmd_parse_build_commands 0:46: #{?pane_marked_set,,-}Swap Marked
+1783499626.103054 cmd_parse_build_commands 0:47: s
+1783499626.103055 cmd_parse_build_commands 0:48 0:0: swap-pane
+1783499626.103056 cmd_parse_build_commands 0:49: 
+1783499626.103058 cmd_parse_build_commands 0:50: Kill
+1783499626.103059 cmd_parse_build_commands 0:51: X
+1783499626.103061 cmd_parse_build_commands 0:52 0:0: kill-pane
+1783499626.103062 cmd_parse_build_commands 0:53: Respawn
+1783499626.103063 cmd_parse_build_commands 0:54: R
+1783499626.103065 cmd_parse_build_commands 0:55 0:0: respawn-pane
+1783499626.103066 cmd_parse_build_commands 0:55 0:1: -k
+1783499626.103068 cmd_parse_build_commands 0:56: #{?pane_marked,Unmark,Mark}
+1783499626.103070 cmd_parse_build_commands 0:57: m
+1783499626.103071 cmd_parse_build_commands 0:58 0:0: select-pane
+1783499626.103073 cmd_parse_build_commands 0:58 0:1: -m
+1783499626.103074 cmd_parse_build_commands 0:59: #{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom}
+1783499626.103076 cmd_parse_build_commands 0:60: z
+1783499626.103077 cmd_parse_build_commands 0:61 0:0: resize-pane
+1783499626.103079 cmd_parse_build_commands 0:61 0:1: -Z
+1783499626.103083 cmd_parse_build_commands 0:0: send
+1783499626.103085 cmd_parse_build_commands 0:1: -X
+1783499626.103086 cmd_parse_build_commands 0:2: history-top
+1783499626.103090 args_parse_flags: next -X
+1783499626.103092 args_parse_flags: -X
+1783499626.103093 args_parse_flags: next history-top
+1783499626.103095 args_parse: flags end at 2 of 3
+1783499626.103096 args_parse: 2 = history-top (type STRING)
+1783499626.103101 cmd_parse_build_commands: send-keys -X history-top
+1783499626.103104 cmd_parse_build_commands 0:0: send
+1783499626.103105 cmd_parse_build_commands 0:1: -X
+1783499626.103106 cmd_parse_build_commands 0:2: history-bottom
+1783499626.103110 args_parse_flags: next -X
+1783499626.103111 args_parse_flags: -X
+1783499626.103112 args_parse_flags: next history-bottom
+1783499626.103114 args_parse: flags end at 2 of 3
+1783499626.103115 args_parse: 2 = history-bottom (type STRING)
+1783499626.103118 cmd_parse_build_commands: send-keys -X history-bottom
+1783499626.103120 cmd_parse_build_commands 0:0: if
+1783499626.103122 cmd_parse_build_commands 0:1: -F
+1783499626.103124 cmd_parse_build_commands 0:2: #{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}
+1783499626.103126 cmd_parse_build_commands 0:3: copy-mode -t=
+1783499626.103127 cmd_parse_build_commands 1:0: send
+1783499626.103129 cmd_parse_build_commands 1:1: -Xt=
+1783499626.103130 cmd_parse_build_commands 1:2: search-backward
+1783499626.103131 cmd_parse_build_commands 1:3: #{q:mouse_word}
+1783499626.103134 args_parse_flags: next -F
+1783499626.103135 args_parse_flags: -F
+1783499626.103137 args_parse_flags: next #{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}
+1783499626.103138 args_parse: flags end at 2 of 4
+1783499626.103140 args_parse: 2 = #{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1} (type STRING)
+1783499626.103142 args_parse: 3 = copy-mode -t= (type STRING)
+1783499626.103145 args_parse_flags: next -Xt=
+1783499626.103146 args_parse_flags: -X
+1783499626.103148 args_parse_flag_argument: -t = =
+1783499626.103149 args_parse_flags: next search-backward
+1783499626.103151 args_parse: flags end at 2 of 4
+1783499626.103152 args_parse: 2 = search-backward (type STRING)
+1783499626.103153 args_parse: 3 = #{q:mouse_word} (type STRING)
+1783499626.103161 cmd_parse_build_commands: if-shell -F "#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}" "copy-mode -t=" ; send-keys -X -t = search-backward "#{q:mouse_word}"
+1783499626.103163 cmd_parse_build_commands 0:0: copy-mode
+1783499626.103165 cmd_parse_build_commands 0:1: -q
+1783499626.103166 cmd_parse_build_commands 1:0: send-keys
+1783499626.103168 cmd_parse_build_commands 1:1: -l
+1783499626.103181 cmd_parse_build_commands 1:2: --
+1783499626.103186 cmd_parse_build_commands 1:3: #{q:mouse_word}
+1783499626.103189 args_parse_flags: next -q
+1783499626.103190 args_parse_flags: -q
+1783499626.103192 args_parse: flags end at 2 of 2
+1783499626.103195 args_parse_flags: next -l
+1783499626.103196 args_parse_flags: -l
+1783499626.103198 args_parse_flags: next --
+1783499626.103199 args_parse: flags end at 3 of 4
+1783499626.103200 args_parse: 3 = #{q:mouse_word} (type STRING)
+1783499626.103205 cmd_parse_build_commands: copy-mode -q ; send-keys -l "#{q:mouse_word}"
+1783499626.103208 cmd_parse_build_commands 0:0: copy-mode
+1783499626.103209 cmd_parse_build_commands 0:1: -q
+1783499626.103211 cmd_parse_build_commands 1:0: set-buffer
+1783499626.103212 cmd_parse_build_commands 1:1: --
+1783499626.103213 cmd_parse_build_commands 1:2: #{q:mouse_word}
+1783499626.103215 args_parse_flags: next -q
+1783499626.103216 args_parse_flags: -q
+1783499626.103218 args_parse: flags end at 2 of 2
+1783499626.103221 args_parse_flags: next --
+1783499626.103222 args_parse: flags end at 2 of 3
+1783499626.103223 args_parse: 2 = #{q:mouse_word} (type STRING)
+1783499626.103227 cmd_parse_build_commands: copy-mode -q ; set-buffer "#{q:mouse_word}"
+1783499626.103229 cmd_parse_build_commands 0:0: copy-mode
+1783499626.103230 cmd_parse_build_commands 0:1: -q
+1783499626.103231 cmd_parse_build_commands 1:0: set-buffer
+1783499626.103232 cmd_parse_build_commands 1:1: --
+1783499626.103234 cmd_parse_build_commands 1:2: #{q:mouse_line}
+1783499626.103236 args_parse_flags: next -q
+1783499626.103237 args_parse_flags: -q
+1783499626.103238 args_parse: flags end at 2 of 2
+1783499626.103241 args_parse_flags: next --
+1783499626.103242 args_parse: flags end at 2 of 3
+1783499626.103243 args_parse: 2 = #{q:mouse_line} (type STRING)
+1783499626.103247 cmd_parse_build_commands: copy-mode -q ; set-buffer "#{q:mouse_line}"
+1783499626.103256 cmd_parse_build_commands 0:0: copy-mode
+1783499626.103259 cmd_parse_build_commands 0:1: -q
+1783499626.103260 cmd_parse_build_commands 1:0: send-keys
+1783499626.103262 cmd_parse_build_commands 1:1: -l
+1783499626.103263 cmd_parse_build_commands 1:2: --
+1783499626.103264 cmd_parse_build_commands 1:3: #{q:mouse_hyperlink}
+1783499626.103267 args_parse_flags: next -q
+1783499626.103268 args_parse_flags: -q
+1783499626.103270 args_parse: flags end at 2 of 2
+1783499626.103273 args_parse_flags: next -l
+1783499626.103274 args_parse_flags: -l
+1783499626.103275 args_parse_flags: next --
+1783499626.103276 args_parse: flags end at 3 of 4
+1783499626.103278 args_parse: 3 = #{q:mouse_hyperlink} (type STRING)
+1783499626.103282 cmd_parse_build_commands: copy-mode -q ; send-keys -l "#{q:mouse_hyperlink}"
+1783499626.103285 cmd_parse_build_commands 0:0: copy-mode
+1783499626.103286 cmd_parse_build_commands 0:1: -q
+1783499626.103288 cmd_parse_build_commands 1:0: set-buffer
+1783499626.103289 cmd_parse_build_commands 1:1: --
+1783499626.103290 cmd_parse_build_commands 1:2: #{q:mouse_hyperlink}
+1783499626.103292 args_parse_flags: next -q
+1783499626.103293 args_parse_flags: -q
+1783499626.103295 args_parse: flags end at 2 of 2
+1783499626.103298 args_parse_flags: next --
+1783499626.103299 args_parse: flags end at 2 of 3
+1783499626.103301 args_parse: 2 = #{q:mouse_hyperlink} (type STRING)
+1783499626.103304 cmd_parse_build_commands: copy-mode -q ; set-buffer "#{q:mouse_hyperlink}"
+1783499626.103307 cmd_parse_build_commands 0:0: split-window
+1783499626.103309 cmd_parse_build_commands 0:1: -h
+1783499626.103312 args_parse_flags: next -h
+1783499626.103313 args_parse_flags: -h
+1783499626.103314 args_parse: flags end at 2 of 2
+1783499626.103316 cmd_parse_build_commands: split-window -h
+1783499626.103319 cmd_parse_build_commands 0:0: split-window
+1783499626.103320 cmd_parse_build_commands 0:1: -v
+1783499626.103323 args_parse_flags: next -v
+1783499626.103324 args_parse_flags: -v
+1783499626.103326 args_parse: flags end at 2 of 2
+1783499626.103328 cmd_parse_build_commands: split-window -v
+1783499626.103330 cmd_parse_build_commands 0:0: swap-pane
+1783499626.103335 cmd_parse_build_commands 0:1: -U
+1783499626.103338 args_parse_flags: next -U
+1783499626.103340 args_parse_flags: -U
+1783499626.103341 args_parse: flags end at 2 of 2
+1783499626.103343 cmd_parse_build_commands: swap-pane -U
+1783499626.103345 cmd_parse_build_commands 0:0: swap-pane
+1783499626.103347 cmd_parse_build_commands 0:1: -D
+1783499626.103350 args_parse_flags: next -D
+1783499626.103351 args_parse_flags: -D
+1783499626.103352 args_parse: flags end at 2 of 2
+1783499626.103354 cmd_parse_build_commands: swap-pane -D
+1783499626.103356 cmd_parse_build_commands 0:0: swap-pane
+1783499626.103359 args_parse: flags end at 1 of 1
+1783499626.103361 cmd_parse_build_commands: swap-pane
+1783499626.103364 cmd_parse_build_commands 0:0: kill-pane
+1783499626.103366 args_parse: flags end at 1 of 1
+1783499626.103368 cmd_parse_build_commands: kill-pane
+1783499626.103371 cmd_parse_build_commands 0:0: respawn-pane
+1783499626.103372 cmd_parse_build_commands 0:1: -k
+1783499626.103375 args_parse_flags: next -k
+1783499626.103376 args_parse_flags: -k
+1783499626.103378 args_parse: flags end at 2 of 2
+1783499626.103379 cmd_parse_build_commands: respawn-pane -k
+1783499626.103382 cmd_parse_build_commands 0:0: select-pane
+1783499626.103383 cmd_parse_build_commands 0:1: -m
+1783499626.103386 args_parse_flags: next -m
+1783499626.103388 args_parse_flags: -m
+1783499626.103389 args_parse: flags end at 2 of 2
+1783499626.103391 cmd_parse_build_commands: select-pane -m
+1783499626.103400 cmd_parse_build_commands 0:0: resize-pane
+1783499626.103404 cmd_parse_build_commands 0:1: -Z
+1783499626.103407 args_parse_flags: next -Z
+1783499626.103409 args_parse_flags: -Z
+1783499626.103410 args_parse: flags end at 2 of 2
+1783499626.103412 cmd_parse_build_commands: resize-pane -Z
+1783499626.103414 args_parse_flags: next -t=
+1783499626.103415 args_parse_flag_argument: -t = =
+1783499626.103417 args_parse_flags: next -xM
+1783499626.103418 args_parse_flag_argument: -x = M
+1783499626.103419 args_parse_flags: next -yM
+1783499626.103421 args_parse_flag_argument: -y = M
+1783499626.103422 args_parse_flags: next -T
+1783499626.103424 args_parse_flag_argument: -T = #[align=centre]#{pane_index} (#{pane_id})
+1783499626.103426 args_parse_flags: next #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,}
+1783499626.103428 args_parse: flags end at 6 of 62
+1783499626.103429 args_parse: 6 = #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,} (type STRING)
+1783499626.103431 args_parse: 7 = < (type STRING)
+1783499626.103435 args_parse: 8 = send-keys -X history-top (type COMMANDS)
+1783499626.103437 args_parse: 9 = #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Bottom,} (type STRING)
+1783499626.103439 args_parse: 10 = > (type STRING)
+1783499626.103442 args_parse: 11 = send-keys -X history-bottom (type COMMANDS)
+1783499626.103444 args_parse: 12 =  (type STRING)
+1783499626.103446 args_parse: 13 = #{?mouse_word,Search For #[underscore]#{=/9/...:mouse_word},} (type STRING)
+1783499626.103448 args_parse: 14 = C-r (type STRING)
+1783499626.103455 args_parse: 15 = if-shell -F "#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}" "copy-mode -t=" ; send-keys -X -t = search-backward "#{q:mouse_word}" (type COMMANDS)
+1783499626.103629 args_parse: 16 = #{?mouse_word,Type #[underscore]#{=/9/...:mouse_word},} (type STRING)
+1783499626.103634 args_parse: 17 = C-y (type STRING)
+1783499626.103646 args_parse: 18 = copy-mode -q ; send-keys -l "#{q:mouse_word}" (type COMMANDS)
+1783499626.103649 args_parse: 19 = #{?mouse_word,Copy #[underscore]#{=/9/...:mouse_word},} (type STRING)
+1783499626.103652 args_parse: 20 = c (type STRING)
+1783499626.103658 args_parse: 21 = copy-mode -q ; set-buffer "#{q:mouse_word}" (type COMMANDS)
+1783499626.103661 args_parse: 22 = #{?mouse_line,Copy Line,} (type STRING)
+1783499626.103664 args_parse: 23 = l (type STRING)
+1783499626.103669 args_parse: 24 = copy-mode -q ; set-buffer "#{q:mouse_line}" (type COMMANDS)
+1783499626.103672 args_parse: 25 =  (type STRING)
+1783499626.103675 args_parse: 26 = #{?mouse_hyperlink,Type #[underscore]#{=/9/...:mouse_hyperlink},} (type STRING)
+1783499626.103678 args_parse: 27 = C-h (type STRING)
+1783499626.103696 args_parse: 28 = copy-mode -q ; send-keys -l "#{q:mouse_hyperlink}" (type COMMANDS)
+1783499626.103701 args_parse: 29 = #{?mouse_hyperlink,Copy #[underscore]#{=/9/...:mouse_hyperlink},} (type STRING)
+1783499626.103703 args_parse: 30 = h (type STRING)
+1783499626.103709 args_parse: 31 = copy-mode -q ; set-buffer "#{q:mouse_hyperlink}" (type COMMANDS)
+1783499626.103712 args_parse: 32 =  (type STRING)
+1783499626.103716 args_parse: 33 = Horizontal Split (type STRING)
+1783499626.103719 args_parse: 34 = h (type STRING)
+1783499626.103724 args_parse: 35 = split-window -h (type COMMANDS)
+1783499626.103728 args_parse: 36 = Vertical Split (type STRING)
+1783499626.103731 args_parse: 37 = v (type STRING)
+1783499626.103736 args_parse: 38 = split-window -v (type COMMANDS)
+1783499626.103739 args_parse: 39 =  (type STRING)
+1783499626.103744 args_parse: 40 = #{?#{>:#{window_panes},1},,-}Swap Up (type STRING)
+1783499626.103748 args_parse: 41 = u (type STRING)
+1783499626.103753 args_parse: 42 = swap-pane -U (type COMMANDS)
+1783499626.103757 args_parse: 43 = #{?#{>:#{window_panes},1},,-}Swap Down (type STRING)
+1783499626.103760 args_parse: 44 = d (type STRING)
+1783499626.103764 args_parse: 45 = swap-pane -D (type COMMANDS)
+1783499626.103768 args_parse: 46 = #{?pane_marked_set,,-}Swap Marked (type STRING)
+1783499626.103772 args_parse: 47 = s (type STRING)
+1783499626.103776 args_parse: 48 = swap-pane (type COMMANDS)
+1783499626.103779 args_parse: 49 =  (type STRING)
+1783499626.103783 args_parse: 50 = Kill (type STRING)
+1783499626.103786 args_parse: 51 = X (type STRING)
+1783499626.103790 args_parse: 52 = kill-pane (type COMMANDS)
+1783499626.103794 args_parse: 53 = Respawn (type STRING)
+1783499626.103797 args_parse: 54 = R (type STRING)
+1783499626.103802 args_parse: 55 = respawn-pane -k (type COMMANDS)
+1783499626.103806 args_parse: 56 = #{?pane_marked,Unmark,Mark} (type STRING)
+1783499626.103810 args_parse: 57 = m (type STRING)
+1783499626.103815 args_parse: 58 = select-pane -m (type COMMANDS)
+1783499626.103819 args_parse: 59 = #{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom} (type STRING)
+1783499626.103823 args_parse: 60 = z (type STRING)
+1783499626.103827 args_parse: 61 = resize-pane -Z (type COMMANDS)
+1783499626.104297 cmd_parse_build_commands: display-menu -T "#[align=centre]#{pane_index} (#{pane_id})" -t = -x M -y M "#{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,}" < { send-keys -X history-top } "#{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Bottom,}" > { send-keys -X history-bottom } '' "#{?mouse_word,Search For #[underscore]#{=/9/...:mouse_word},}" C-r { if-shell -F "#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}" "copy-mode -t=" ; send-keys -X -t = search-backward "#{q:mouse_word}" } "#{?mouse_word,Type #[underscore]#{=/9/...:mouse_word},}" C-y { copy-mode -q ; send-keys -l "#{q:mouse_word}" } "#{?mouse_word,Copy #[underscore]#{=/9/...:mouse_word},}" c { copy-mode -q ; set-buffer "#{q:mouse_word}" } "#{?mouse_line,Copy Line,}" l { copy-mode -q ; set-buffer "#{q:mouse_line}" } '' "#{?mouse_hyperlink,Type #[underscore]#{=/9/...:mouse_hyperlink},}" C-h { copy-mode -q ; send-keys -l "#{q:mouse_hyperlink}" } "#{?mouse_hyperlink,Copy #[underscore]#{=/9/...:mouse_hyperlink},}" h { copy-mode -q ; set-buffer "#{q:mouse_hyperlink}" } '' "Horizontal Split" h { split-window -h } "Vertical Split" v { split-window -v } '' "#{?#{>:#{window_panes},1},,-}Swap Up" u { swap-pane -U } "#{?#{>:#{window_panes},1},,-}Swap Down" d { swap-pane -D } "#{?pane_marked_set,,-}Swap Marked" s { swap-pane } '' Kill X { kill-pane } Respawn R { respawn-pane -k } "#{?pane_marked,Unmark,Mark}" m { select-pane -m } "#{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom}" z { resize-pane -Z }
+1783499626.104336 args_parse_flags: next -Ft=
+1783499626.104342 args_parse_flags: -F
+1783499626.104351 args_parse_flag_argument: -t = =
+1783499626.104359 args_parse_flags: next #{||:#{mouse_any_flag},#{&&:#{pane_in_mode},#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}}}
+1783499626.104366 args_parse: flags end at 2 of 5
+1783499626.104392 args_parse: 2 = #{||:#{mouse_any_flag},#{&&:#{pane_in_mode},#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}}} (type STRING)
+1783499626.104415 args_parse: 3 = select-pane -t = ; send-keys -M (type COMMANDS)
+1783499626.104663 args_parse: 4 = display-menu -T "#[align=centre]#{pane_index} (#{pane_id})" -t = -x M -y M "#{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,}" < { send-keys -X history-top } "#{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Bottom,}" > { send-keys -X history-bottom } '' "#{?mouse_word,Search For #[underscore]#{=/9/...:mouse_word},}" C-r { if-shell -F "#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}" "copy-mode -t=" ; send-keys -X -t = search-backward "#{q:mouse_word}" } "#{?mouse_word,Type #[underscore]#{=/9/...:mouse_word},}" C-y { copy-mode -q ; send-keys -l "#{q:mouse_word}" } "#{?mouse_word,Copy #[underscore]#{=/9/...:mouse_word},}" c { copy-mode -q ; set-buffer "#{q:mouse_word}" } "#{?mouse_line,Copy Line,}" l { copy-mode -q ; set-buffer "#{q:mouse_line}" } '' "#{?mouse_hyperlink,Type #[underscore]#{=/9/...:mouse_hyperlink},}" C-h { copy-mode -q ; send-keys -l "#{q:mouse_hyperlink}" } "#{?mouse_hyperlink,Copy #[underscore]#{=/9/...:mouse_hyperlink},}" h { copy-mode -q ; set-buffer "#{q:mouse_hyperlink}" } '' "Horizontal Split" h { split-window -h } "Vertical Split" v { split-window -v } '' "#{?#{>:#{window_panes},1},,-}Swap Up" u { swap-pane -U } "#{?#{>:#{window_panes},1},,-}Swap Down" d { swap-pane -D } "#{?pane_marked_set,,-}Swap Marked" s { swap-pane } '' Kill X { kill-pane } Respawn R { respawn-pane -k } "#{?pane_marked,Unmark,Mark}" m { select-pane -m } "#{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom}" z { resize-pane -Z } (type COMMANDS)
+1783499626.105058 cmd_parse_build_commands: if-shell -F -t = "#{||:#{mouse_any_flag},#{&&:#{pane_in_mode},#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}}}" { select-pane -t = ; send-keys -M } { display-menu -T "#[align=centre]#{pane_index} (#{pane_id})" -t = -x M -y M "#{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,}" < { send-keys -X history-top } "#{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Bottom,}" > { send-keys -X history-bottom } '' "#{?mouse_word,Search For #[underscore]#{=/9/...:mouse_word},}" C-r { if-shell -F "#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}" "copy-mode -t=" ; send-keys -X -t = search-backward "#{q:mouse_word}" } "#{?mouse_word,Type #[underscore]#{=/9/...:mouse_word},}" C-y { copy-mode -q ; send-keys -l "#{q:mouse_word}" } "#{?mouse_word,Copy #[underscore]#{=/9/...:mouse_word},}" c { copy-mode -q ; set-buffer "#{q:mouse_word}" } "#{?mouse_line,Copy Line,}" l { copy-mode -q ; set-buffer "#{q:mouse_line}" } '' "#{?mouse_hyperlink,Type #[underscore]#{=/9/...:mouse_hyperlink},}" C-h { copy-mode -q ; send-keys -l "#{q:mouse_hyperlink}" } "#{?mouse_hyperlink,Copy #[underscore]#{=/9/...:mouse_hyperlink},}" h { copy-mode -q ; set-buffer "#{q:mouse_hyperlink}" } '' "Horizontal Split" h { split-window -h } "Vertical Split" v { split-window -v } '' "#{?#{>:#{window_panes},1},,-}Swap Up" u { swap-pane -U } "#{?#{>:#{window_panes},1},,-}Swap Down" d { swap-pane -D } "#{?pane_marked_set,,-}Swap Marked" s { swap-pane } '' Kill X { kill-pane } Respawn R { respawn-pane -k } "#{?pane_marked,Unmark,Mark}" m { select-pane -m } "#{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom}" z { resize-pane -Z } }
+1783499626.105075 args_parse_flags: next -n
+1783499626.105079 args_parse_flags: -n
+1783499626.105082 args_parse_flags: next MouseDown3Pane
+1783499626.105085 args_parse: flags end at 2 of 4
+1783499626.105089 args_parse: 2 = MouseDown3Pane (type STRING)
+1783499626.105465 args_parse: 3 = if-shell -F -t = "#{||:#{mouse_any_flag},#{&&:#{pane_in_mode},#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}}}" { select-pane -t = ; send-keys -M } { display-menu -T "#[align=centre]#{pane_index} (#{pane_id})" -t = -x M -y M "#{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,}" < { send-keys -X history-top } "#{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Bottom,}" > { send-keys -X history-bottom } '' "#{?mouse_word,Search For #[underscore]#{=/9/...:mouse_word},}" C-r { if-shell -F "#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}" "copy-mode -t=" ; send-keys -X -t = search-backward "#{q:mouse_word}" } "#{?mouse_word,Type #[underscore]#{=/9/...:mouse_word},}" C-y { copy-mode -q ; send-keys -l "#{q:mouse_word}" } "#{?mouse_word,Copy #[underscore]#{=/9/...:mouse_word},}" c { copy-mode -q ; set-buffer "#{q:mouse_word}" } "#{?mouse_line,Copy Line,}" l { copy-mode -q ; set-buffer "#{q:mouse_line}" } '' "#{?mouse_hyperlink,Type #[underscore]#{=/9/...:mouse_hyperlink},}" C-h { copy-mode -q ; send-keys -l "#{q:mouse_hyperlink}" } "#{?mouse_hyperlink,Copy #[underscore]#{=/9/...:mouse_hyperlink},}" h { copy-mode -q ; set-buffer "#{q:mouse_hyperlink}" } '' "Horizontal Split" h { split-window -h } "Vertical Split" v { split-window -v } '' "#{?#{>:#{window_panes},1},,-}Swap Up" u { swap-pane -U } "#{?#{>:#{window_panes},1},,-}Swap Down" d { swap-pane -D } "#{?pane_marked_set,,-}Swap Marked" s { swap-pane } '' Kill X { kill-pane } Respawn R { respawn-pane -k } "#{?pane_marked,Unmark,Mark}" m { select-pane -m } "#{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom}" z { resize-pane -Z } } (type COMMANDS)
+1783499626.105658 cmd_parse_build_commands: bind-key -n MouseDown3Pane { if-shell -F -t = "#{||:#{mouse_any_flag},#{&&:#{pane_in_mode},#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}}}" { select-pane -t = ; send-keys -M } { display-menu -T "#[align=centre]#{pane_index} (#{pane_id})" -t = -x M -y M "#{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,}" < { send-keys -X history-top } "#{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Bottom,}" > { send-keys -X history-bottom } '' "#{?mouse_word,Search For #[underscore]#{=/9/...:mouse_word},}" C-r { if-shell -F "#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}" "copy-mode -t=" ; send-keys -X -t = search-backward "#{q:mouse_word}" } "#{?mouse_word,Type #[underscore]#{=/9/...:mouse_word},}" C-y { copy-mode -q ; send-keys -l "#{q:mouse_word}" } "#{?mouse_word,Copy #[underscore]#{=/9/...:mouse_word},}" c { copy-mode -q ; set-buffer "#{q:mouse_word}" } "#{?mouse_line,Copy Line,}" l { copy-mode -q ; set-buffer "#{q:mouse_line}" } '' "#{?mouse_hyperlink,Type #[underscore]#{=/9/...:mouse_hyperlink},}" C-h { copy-mode -q ; send-keys -l "#{q:mouse_hyperlink}" } "#{?mouse_hyperlink,Copy #[underscore]#{=/9/...:mouse_hyperlink},}" h { copy-mode -q ; set-buffer "#{q:mouse_hyperlink}" } '' "Horizontal Split" h { split-window -h } "Vertical Split" v { split-window -v } '' "#{?#{>:#{window_panes},1},,-}Swap Up" u { swap-pane -U } "#{?#{>:#{window_panes},1},,-}Swap Down" d { swap-pane -D } "#{?pane_marked_set,,-}Swap Marked" s { swap-pane } '' Kill X { kill-pane } Respawn R { respawn-pane -k } "#{?pane_marked,Unmark,Mark}" m { select-pane -m } "#{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom}" z { resize-pane -Z } } }
+1783499626.105685 cmdq_get_command: [bind-key/0x58e4724f8000] group 1118
+1783499626.105690 cmdq_append <global>: [bind-key/0x58e4724f8000]
+1783499626.105707 yylex_token: end at WS
+1783499626.105710 yylex_token: bind
+1783499626.105713 yylex_token: end at WS
+1783499626.105716 yylex_token: -n
+1783499626.105720 yylex_token: end at WS
+1783499626.105722 yylex_token: M-MouseDown3Pane
+1783499626.105725 yylex_token: end at WS
+1783499626.105727 yylex_token: display-menu
+1783499626.105730 yylex_token: end at WS
+1783499626.105732 yylex_token: -t=
+1783499626.105735 yylex_token: end at WS
+1783499626.105737 yylex_token: -xM
+1783499626.105739 yylex_token: end at WS
+1783499626.105741 yylex_token: -yM
+1783499626.105743 yylex_token: end at WS
+1783499626.105745 yylex_token: -T
+1783499626.105750 yylex_token: end at WS
+1783499626.105790 yylex_token: #[align=centre]#{pane_index} (#{pane_id})
+1783499626.105803 yylex_token: end at WS
+1783499626.105806 yylex_token: #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,}
+1783499626.105808 yylex_token: end at WS
+1783499626.105809 yylex_token: <
+1783499626.105811 yylex_token: end at WS
+1783499626.105812 yylex_token: send
+1783499626.105813 yylex_token: end at WS
+1783499626.105814 yylex_token: -X
+1783499626.105824 yylex_token: end at }
+1783499626.105825 yylex_token: history-top
+1783499626.105829 yylex_token: end at WS
+1783499626.105831 yylex_token: #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Bottom,}
+1783499626.105833 yylex_token: end at WS
+1783499626.105834 yylex_token: >
+1783499626.105835 yylex_token: end at WS
+1783499626.105836 yylex_token: send
+1783499626.105838 yylex_token: end at WS
+1783499626.105839 yylex_token: -X
+1783499626.105840 yylex_token: end at }
+1783499626.105841 yylex_token: history-bottom
+1783499626.105843 yylex_token: end at WS
+1783499626.105844 yylex_token: 
+1783499626.105847 yylex_token: end at WS
+1783499626.105848 yylex_token: #{?mouse_word,Search For #[underscore]#{=/9/...:mouse_word},}
+1783499626.105850 yylex_token: end at WS
+1783499626.105851 yylex_token: C-r
+1783499626.105852 yylex_token: end at WS
+1783499626.105853 yylex_token: if
+1783499626.105854 yylex_token: end at WS
+1783499626.105855 yylex_token: -F
+1783499626.105857 yylex_token: end at WS
+1783499626.105859 yylex_token: #{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}
+1783499626.105860 yylex_token: end at ;
+1783499626.105862 yylex_token: copy-mode -t=
+1783499626.105863 yylex_token: end at WS
+1783499626.105864 yylex_token: send
+1783499626.105865 yylex_token: end at WS
+1783499626.105866 yylex_token: -Xt=
+1783499626.105868 yylex_token: end at WS
+1783499626.105869 yylex_token: search-backward
+1783499626.105871 yylex_token: end at }
+1783499626.105872 yylex_token: #{q:mouse_word}
+1783499626.105875 yylex_token: end at WS
+1783499626.105876 yylex_token: #{?mouse_word,Type #[underscore]#{=/9/...:mouse_word},}
+1783499626.105878 yylex_token: end at WS
+1783499626.105878 yylex_token: C-y
+1783499626.105880 yylex_token: end at WS
+1783499626.105881 yylex_token: copy-mode
+1783499626.105882 yylex_token: end at ;
+1783499626.105883 yylex_token: -q
+1783499626.105885 yylex_token: end at WS
+1783499626.105886 yylex_token: send-keys
+1783499626.105887 yylex_token: end at WS
+1783499626.105888 yylex_token: -l
+1783499626.105890 yylex_token: end at WS
+1783499626.105891 yylex_token: --
+1783499626.105892 yylex_token: end at }
+1783499626.105893 yylex_token: #{q:mouse_word}
+1783499626.105896 yylex_token: end at WS
+1783499626.105897 yylex_token: #{?mouse_word,Copy #[underscore]#{=/9/...:mouse_word},}
+1783499626.105899 yylex_token: end at WS
+1783499626.105900 yylex_token: c
+1783499626.105901 yylex_token: end at WS
+1783499626.105902 yylex_token: copy-mode
+1783499626.105903 yylex_token: end at ;
+1783499626.105904 yylex_token: -q
+1783499626.105905 yylex_token: end at WS
+1783499626.105907 yylex_token: set-buffer
+1783499626.105908 yylex_token: end at WS
+1783499626.105909 yylex_token: --
+1783499626.105910 yylex_token: end at }
+1783499626.105911 yylex_token: #{q:mouse_word}
+1783499626.105913 yylex_token: end at WS
+1783499626.105915 yylex_token: #{?mouse_line,Copy Line,}
+1783499626.105916 yylex_token: end at WS
+1783499626.105917 yylex_token: l
+1783499626.105918 yylex_token: end at WS
+1783499626.105919 yylex_token: copy-mode
+1783499626.105920 yylex_token: end at ;
+1783499626.105921 yylex_token: -q
+1783499626.105923 yylex_token: end at WS
+1783499626.105924 yylex_token: set-buffer
+1783499626.105925 yylex_token: end at WS
+1783499626.105926 yylex_token: --
+1783499626.105927 yylex_token: end at }
+1783499626.105929 yylex_token: #{q:mouse_line}
+1783499626.105930 yylex_token: end at WS
+1783499626.105931 yylex_token: 
+1783499626.105934 yylex_token: end at WS
+1783499626.105935 yylex_token: #{?mouse_hyperlink,Type #[underscore]#{=/9/...:mouse_hyperlink},}
+1783499626.105936 yylex_token: end at WS
+1783499626.105937 yylex_token: C-h
+1783499626.105939 yylex_token: end at WS
+1783499626.105940 yylex_token: copy-mode
+1783499626.105941 yylex_token: end at ;
+1783499626.105942 yylex_token: -q
+1783499626.105943 yylex_token: end at WS
+1783499626.105944 yylex_token: send-keys
+1783499626.105946 yylex_token: end at WS
+1783499626.105946 yylex_token: -l
+1783499626.105948 yylex_token: end at WS
+1783499626.105949 yylex_token: --
+1783499626.105950 yylex_token: end at }
+1783499626.105951 yylex_token: #{q:mouse_hyperlink}
+1783499626.105957 yylex_token: end at WS
+1783499626.105959 yylex_token: #{?mouse_hyperlink,Copy #[underscore]#{=/9/...:mouse_hyperlink},}
+1783499626.105960 yylex_token: end at WS
+1783499626.105961 yylex_token: h
+1783499626.105963 yylex_token: end at WS
+1783499626.105964 yylex_token: copy-mode
+1783499626.105965 yylex_token: end at ;
+1783499626.105966 yylex_token: -q
+1783499626.105967 yylex_token: end at WS
+1783499626.105968 yylex_token: set-buffer
+1783499626.105970 yylex_token: end at WS
+1783499626.105971 yylex_token: --
+1783499626.105972 yylex_token: end at }
+1783499626.105973 yylex_token: #{q:mouse_hyperlink}
+1783499626.105975 yylex_token: end at WS
+1783499626.105976 yylex_token: 
+1783499626.105977 yylex_token: end at WS
+1783499626.105978 yylex_token: Horizontal Split
+1783499626.105980 yylex_token: end at WS
+1783499626.105981 yylex_token: h
+1783499626.105982 yylex_token: end at WS
+1783499626.105983 yylex_token: split-window
+1783499626.105984 yylex_token: end at }
+1783499626.105985 yylex_token: -h
+1783499626.105987 yylex_token: end at WS
+1783499626.105988 yylex_token: Vertical Split
+1783499626.105989 yylex_token: end at WS
+1783499626.105990 yylex_token: v
+1783499626.105992 yylex_token: end at WS
+1783499626.105993 yylex_token: split-window
+1783499626.105994 yylex_token: end at }
+1783499626.105995 yylex_token: -v
+1783499626.105996 yylex_token: end at WS
+1783499626.105997 yylex_token: 
+1783499626.105999 yylex_token: end at WS
+1783499626.106000 yylex_token: #{?#{>:#{window_panes},1},,-}Swap Up
+1783499626.106001 yylex_token: end at WS
+1783499626.106002 yylex_token: u
+1783499626.106004 yylex_token: end at WS
+1783499626.106005 yylex_token: swap-pane
+1783499626.106006 yylex_token: end at }
+1783499626.106007 yylex_token: -U
+1783499626.106009 yylex_token: end at WS
+1783499626.106010 yylex_token: #{?#{>:#{window_panes},1},,-}Swap Down
+1783499626.106011 yylex_token: end at WS
+1783499626.106012 yylex_token: d
+1783499626.106014 yylex_token: end at WS
+1783499626.106015 yylex_token: swap-pane
+1783499626.106016 yylex_token: end at }
+1783499626.106017 yylex_token: -D
+1783499626.106019 yylex_token: end at WS
+1783499626.106020 yylex_token: #{?pane_marked_set,,-}Swap Marked
+1783499626.106021 yylex_token: end at WS
+1783499626.106022 yylex_token: s
+1783499626.106024 yylex_token: end at }
+1783499626.106025 yylex_token: swap-pane
+1783499626.106026 yylex_token: end at WS
+1783499626.106027 yylex_token: 
+1783499626.106028 yylex_token: end at WS
+1783499626.106029 yylex_token: Kill
+1783499626.106030 yylex_token: end at WS
+1783499626.106031 yylex_token: X
+1783499626.106033 yylex_token: end at }
+1783499626.106034 yylex_token: kill-pane
+1783499626.106035 yylex_token: end at WS
+1783499626.106037 yylex_token: Respawn
+1783499626.106038 yylex_token: end at WS
+1783499626.106039 yylex_token: R
+1783499626.106040 yylex_token: end at WS
+1783499626.106041 yylex_token: respawn-pane
+1783499626.106043 yylex_token: end at }
+1783499626.106043 yylex_token: -k
+1783499626.106045 yylex_token: end at WS
+1783499626.106046 yylex_token: #{?pane_marked,Unmark,Mark}
+1783499626.106048 yylex_token: end at WS
+1783499626.106049 yylex_token: m
+1783499626.106050 yylex_token: end at WS
+1783499626.106051 yylex_token: select-pane
+1783499626.106052 yylex_token: end at }
+1783499626.106053 yylex_token: -m
+1783499626.106056 yylex_token: end at WS
+1783499626.106057 yylex_token: #{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom}
+1783499626.106059 yylex_token: end at WS
+1783499626.106060 yylex_token: z
+1783499626.106061 yylex_token: end at WS
+1783499626.106062 yylex_token: resize-pane
+1783499626.106063 yylex_token: end at }
+1783499626.106064 yylex_token: -Z
+1783499626.106072 cmd_parse_build_commands 0:0: bind
+1783499626.106074 cmd_parse_build_commands 0:1: -n
+1783499626.106076 cmd_parse_build_commands 0:2: M-MouseDown3Pane
+1783499626.106078 cmd_parse_build_commands 0:3 0:0: display-menu
+1783499626.106079 cmd_parse_build_commands 0:3 0:1: -t=
+1783499626.106080 cmd_parse_build_commands 0:3 0:2: -xM
+1783499626.106082 cmd_parse_build_commands 0:3 0:3: -yM
+1783499626.106083 cmd_parse_build_commands 0:3 0:4: -T
+1783499626.106087 cmd_parse_build_commands 0:3 0:5: #[align=centre]#{pane_index} (#{pane_id})
+1783499626.106089 cmd_parse_build_commands 0:3 0:6: #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,}
+1783499626.106090 cmd_parse_build_commands 0:3 0:7: <
+1783499626.106092 cmd_parse_build_commands 0:3 0:8 0:0: send
+1783499626.106093 cmd_parse_build_commands 0:3 0:8 0:1: -X
+1783499626.106095 cmd_parse_build_commands 0:3 0:8 0:2: history-top
+1783499626.106096 cmd_parse_build_commands 0:3 0:9: #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Bottom,}
+1783499626.106098 cmd_parse_build_commands 0:3 0:10: >
+1783499626.106099 cmd_parse_build_commands 0:3 0:11 0:0: send
+1783499626.106101 cmd_parse_build_commands 0:3 0:11 0:1: -X
+1783499626.106102 cmd_parse_build_commands 0:3 0:11 0:2: history-bottom
+1783499626.106103 cmd_parse_build_commands 0:3 0:12: 
+1783499626.106105 cmd_parse_build_commands 0:3 0:13: #{?mouse_word,Search For #[underscore]#{=/9/...:mouse_word},}
+1783499626.106106 cmd_parse_build_commands 0:3 0:14: C-r
+1783499626.106108 cmd_parse_build_commands 0:3 0:15 0:0: if
+1783499626.106109 cmd_parse_build_commands 0:3 0:15 0:1: -F
+1783499626.106112 cmd_parse_build_commands 0:3 0:15 0:2: #{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}
+1783499626.106113 cmd_parse_build_commands 0:3 0:15 0:3: copy-mode -t=
+1783499626.106114 cmd_parse_build_commands 0:3 0:15 1:0: send
+1783499626.106116 cmd_parse_build_commands 0:3 0:15 1:1: -Xt=
+1783499626.106117 cmd_parse_build_commands 0:3 0:15 1:2: search-backward
+1783499626.106119 cmd_parse_build_commands 0:3 0:15 1:3: #{q:mouse_word}
+1783499626.106120 cmd_parse_build_commands 0:3 0:16: #{?mouse_word,Type #[underscore]#{=/9/...:mouse_word},}
+1783499626.106122 cmd_parse_build_commands 0:3 0:17: C-y
+1783499626.106123 cmd_parse_build_commands 0:3 0:18 0:0: copy-mode
+1783499626.106124 cmd_parse_build_commands 0:3 0:18 0:1: -q
+1783499626.106126 cmd_parse_build_commands 0:3 0:18 1:0: send-keys
+1783499626.106127 cmd_parse_build_commands 0:3 0:18 1:1: -l
+1783499626.106128 cmd_parse_build_commands 0:3 0:18 1:2: --
+1783499626.106129 cmd_parse_build_commands 0:3 0:18 1:3: #{q:mouse_word}
+1783499626.106131 cmd_parse_build_commands 0:3 0:19: #{?mouse_word,Copy #[underscore]#{=/9/...:mouse_word},}
+1783499626.106132 cmd_parse_build_commands 0:3 0:20: c
+1783499626.106135 cmd_parse_build_commands 0:3 0:21 0:0: copy-mode
+1783499626.106136 cmd_parse_build_commands 0:3 0:21 0:1: -q
+1783499626.106137 cmd_parse_build_commands 0:3 0:21 1:0: set-buffer
+1783499626.106138 cmd_parse_build_commands 0:3 0:21 1:1: --
+1783499626.106140 cmd_parse_build_commands 0:3 0:21 1:2: #{q:mouse_word}
+1783499626.106141 cmd_parse_build_commands 0:3 0:22: #{?mouse_line,Copy Line,}
+1783499626.106143 cmd_parse_build_commands 0:3 0:23: l
+1783499626.106144 cmd_parse_build_commands 0:3 0:24 0:0: copy-mode
+1783499626.106145 cmd_parse_build_commands 0:3 0:24 0:1: -q
+1783499626.106146 cmd_parse_build_commands 0:3 0:24 1:0: set-buffer
+1783499626.106148 cmd_parse_build_commands 0:3 0:24 1:1: --
+1783499626.106149 cmd_parse_build_commands 0:3 0:24 1:2: #{q:mouse_line}
+1783499626.106150 cmd_parse_build_commands 0:3 0:25: 
+1783499626.106152 cmd_parse_build_commands 0:3 0:26: #{?mouse_hyperlink,Type #[underscore]#{=/9/...:mouse_hyperlink},}
+1783499626.106153 cmd_parse_build_commands 0:3 0:27: C-h
+1783499626.106155 cmd_parse_build_commands 0:3 0:28 0:0: copy-mode
+1783499626.106157 cmd_parse_build_commands 0:3 0:28 0:1: -q
+1783499626.106158 cmd_parse_build_commands 0:3 0:28 1:0: send-keys
+1783499626.106159 cmd_parse_build_commands 0:3 0:28 1:1: -l
+1783499626.106160 cmd_parse_build_commands 0:3 0:28 1:2: --
+1783499626.106161 cmd_parse_build_commands 0:3 0:28 1:3: #{q:mouse_hyperlink}
+1783499626.106163 cmd_parse_build_commands 0:3 0:29: #{?mouse_hyperlink,Copy #[underscore]#{=/9/...:mouse_hyperlink},}
+1783499626.106164 cmd_parse_build_commands 0:3 0:30: h
+1783499626.106166 cmd_parse_build_commands 0:3 0:31 0:0: copy-mode
+1783499626.106167 cmd_parse_build_commands 0:3 0:31 0:1: -q
+1783499626.106168 cmd_parse_build_commands 0:3 0:31 1:0: set-buffer
+1783499626.106172 cmd_parse_build_commands 0:3 0:31 1:1: --
+1783499626.106173 cmd_parse_build_commands 0:3 0:31 1:2: #{q:mouse_hyperlink}
+1783499626.106174 cmd_parse_build_commands 0:3 0:32: 
+1783499626.106176 cmd_parse_build_commands 0:3 0:33: Horizontal Split
+1783499626.106177 cmd_parse_build_commands 0:3 0:34: h
+1783499626.106178 cmd_parse_build_commands 0:3 0:35 0:0: split-window
+1783499626.106180 cmd_parse_build_commands 0:3 0:35 0:1: -h
+1783499626.106182 cmd_parse_build_commands 0:3 0:36: Vertical Split
+1783499626.106183 cmd_parse_build_commands 0:3 0:37: v
+1783499626.106184 cmd_parse_build_commands 0:3 0:38 0:0: split-window
+1783499626.106186 cmd_parse_build_commands 0:3 0:38 0:1: -v
+1783499626.106187 cmd_parse_build_commands 0:3 0:39: 
+1783499626.106188 cmd_parse_build_commands 0:3 0:40: #{?#{>:#{window_panes},1},,-}Swap Up
+1783499626.106190 cmd_parse_build_commands 0:3 0:41: u
+1783499626.106191 cmd_parse_build_commands 0:3 0:42 0:0: swap-pane
+1783499626.106192 cmd_parse_build_commands 0:3 0:42 0:1: -U
+1783499626.106194 cmd_parse_build_commands 0:3 0:43: #{?#{>:#{window_panes},1},,-}Swap Down
+1783499626.106195 cmd_parse_build_commands 0:3 0:44: d
+1783499626.106196 cmd_parse_build_commands 0:3 0:45 0:0: swap-pane
+1783499626.106197 cmd_parse_build_commands 0:3 0:45 0:1: -D
+1783499626.106199 cmd_parse_build_commands 0:3 0:46: #{?pane_marked_set,,-}Swap Marked
+1783499626.106200 cmd_parse_build_commands 0:3 0:47: s
+1783499626.106202 cmd_parse_build_commands 0:3 0:48 0:0: swap-pane
+1783499626.106203 cmd_parse_build_commands 0:3 0:49: 
+1783499626.106204 cmd_parse_build_commands 0:3 0:50: Kill
+1783499626.106205 cmd_parse_build_commands 0:3 0:51: X
+1783499626.106207 cmd_parse_build_commands 0:3 0:52 0:0: kill-pane
+1783499626.106208 cmd_parse_build_commands 0:3 0:53: Respawn
+1783499626.106209 cmd_parse_build_commands 0:3 0:54: R
+1783499626.106211 cmd_parse_build_commands 0:3 0:55 0:0: respawn-pane
+1783499626.106213 cmd_parse_build_commands 0:3 0:55 0:1: -k
+1783499626.106214 cmd_parse_build_commands 0:3 0:56: #{?pane_marked,Unmark,Mark}
+1783499626.106215 cmd_parse_build_commands 0:3 0:57: m
+1783499626.106217 cmd_parse_build_commands 0:3 0:58 0:0: select-pane
+1783499626.106218 cmd_parse_build_commands 0:3 0:58 0:1: -m
+1783499626.106220 cmd_parse_build_commands 0:3 0:59: #{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom}
+1783499626.106221 cmd_parse_build_commands 0:3 0:60: z
+1783499626.106222 cmd_parse_build_commands 0:3 0:61 0:0: resize-pane
+1783499626.106223 cmd_parse_build_commands 0:3 0:61 0:1: -Z
+1783499626.106228 cmd_parse_build_commands 0:0: display-menu
+1783499626.106229 cmd_parse_build_commands 0:1: -t=
+1783499626.106230 cmd_parse_build_commands 0:2: -xM
+1783499626.106231 cmd_parse_build_commands 0:3: -yM
+1783499626.106232 cmd_parse_build_commands 0:4: -T
+1783499626.106234 cmd_parse_build_commands 0:5: #[align=centre]#{pane_index} (#{pane_id})
+1783499626.106235 cmd_parse_build_commands 0:6: #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,}
+1783499626.106237 cmd_parse_build_commands 0:7: <
+1783499626.106238 cmd_parse_build_commands 0:8 0:0: send
+1783499626.106239 cmd_parse_build_commands 0:8 0:1: -X
+1783499626.106241 cmd_parse_build_commands 0:8 0:2: history-top
+1783499626.106242 cmd_parse_build_commands 0:9: #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Bottom,}
+1783499626.106243 cmd_parse_build_commands 0:10: >
+1783499626.106245 cmd_parse_build_commands 0:11 0:0: send
+1783499626.106246 cmd_parse_build_commands 0:11 0:1: -X
+1783499626.106247 cmd_parse_build_commands 0:11 0:2: history-bottom
+1783499626.106249 cmd_parse_build_commands 0:12: 
+1783499626.106250 cmd_parse_build_commands 0:13: #{?mouse_word,Search For #[underscore]#{=/9/...:mouse_word},}
+1783499626.106251 cmd_parse_build_commands 0:14: C-r
+1783499626.106253 cmd_parse_build_commands 0:15 0:0: if
+1783499626.106254 cmd_parse_build_commands 0:15 0:1: -F
+1783499626.106256 cmd_parse_build_commands 0:15 0:2: #{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}
+1783499626.106258 cmd_parse_build_commands 0:15 0:3: copy-mode -t=
+1783499626.106261 cmd_parse_build_commands 0:15 1:0: send
+1783499626.106263 cmd_parse_build_commands 0:15 1:1: -Xt=
+1783499626.106264 cmd_parse_build_commands 0:15 1:2: search-backward
+1783499626.106266 cmd_parse_build_commands 0:15 1:3: #{q:mouse_word}
+1783499626.106267 cmd_parse_build_commands 0:16: #{?mouse_word,Type #[underscore]#{=/9/...:mouse_word},}
+1783499626.106269 cmd_parse_build_commands 0:17: C-y
+1783499626.106270 cmd_parse_build_commands 0:18 0:0: copy-mode
+1783499626.106271 cmd_parse_build_commands 0:18 0:1: -q
+1783499626.106273 cmd_parse_build_commands 0:18 1:0: send-keys
+1783499626.106274 cmd_parse_build_commands 0:18 1:1: -l
+1783499626.106275 cmd_parse_build_commands 0:18 1:2: --
+1783499626.106276 cmd_parse_build_commands 0:18 1:3: #{q:mouse_word}
+1783499626.106278 cmd_parse_build_commands 0:19: #{?mouse_word,Copy #[underscore]#{=/9/...:mouse_word},}
+1783499626.106279 cmd_parse_build_commands 0:20: c
+1783499626.106280 cmd_parse_build_commands 0:21 0:0: copy-mode
+1783499626.106282 cmd_parse_build_commands 0:21 0:1: -q
+1783499626.106283 cmd_parse_build_commands 0:21 1:0: set-buffer
+1783499626.106284 cmd_parse_build_commands 0:21 1:1: --
+1783499626.106286 cmd_parse_build_commands 0:21 1:2: #{q:mouse_word}
+1783499626.106288 cmd_parse_build_commands 0:22: #{?mouse_line,Copy Line,}
+1783499626.106289 cmd_parse_build_commands 0:23: l
+1783499626.106290 cmd_parse_build_commands 0:24 0:0: copy-mode
+1783499626.106291 cmd_parse_build_commands 0:24 0:1: -q
+1783499626.106292 cmd_parse_build_commands 0:24 1:0: set-buffer
+1783499626.106294 cmd_parse_build_commands 0:24 1:1: --
+1783499626.106295 cmd_parse_build_commands 0:24 1:2: #{q:mouse_line}
+1783499626.106296 cmd_parse_build_commands 0:25: 
+1783499626.106298 cmd_parse_build_commands 0:26: #{?mouse_hyperlink,Type #[underscore]#{=/9/...:mouse_hyperlink},}
+1783499626.106299 cmd_parse_build_commands 0:27: C-h
+1783499626.106300 cmd_parse_build_commands 0:28 0:0: copy-mode
+1783499626.106301 cmd_parse_build_commands 0:28 0:1: -q
+1783499626.106303 cmd_parse_build_commands 0:28 1:0: send-keys
+1783499626.106304 cmd_parse_build_commands 0:28 1:1: -l
+1783499626.106305 cmd_parse_build_commands 0:28 1:2: --
+1783499626.106306 cmd_parse_build_commands 0:28 1:3: #{q:mouse_hyperlink}
+1783499626.106308 cmd_parse_build_commands 0:29: #{?mouse_hyperlink,Copy #[underscore]#{=/9/...:mouse_hyperlink},}
+1783499626.106309 cmd_parse_build_commands 0:30: h
+1783499626.106310 cmd_parse_build_commands 0:31 0:0: copy-mode
+1783499626.106312 cmd_parse_build_commands 0:31 0:1: -q
+1783499626.106313 cmd_parse_build_commands 0:31 1:0: set-buffer
+1783499626.106314 cmd_parse_build_commands 0:31 1:1: --
+1783499626.106316 cmd_parse_build_commands 0:31 1:2: #{q:mouse_hyperlink}
+1783499626.106318 cmd_parse_build_commands 0:32: 
+1783499626.106319 cmd_parse_build_commands 0:33: Horizontal Split
+1783499626.106320 cmd_parse_build_commands 0:34: h
+1783499626.106322 cmd_parse_build_commands 0:35 0:0: split-window
+1783499626.106323 cmd_parse_build_commands 0:35 0:1: -h
+1783499626.106324 cmd_parse_build_commands 0:36: Vertical Split
+1783499626.106325 cmd_parse_build_commands 0:37: v
+1783499626.106327 cmd_parse_build_commands 0:38 0:0: split-window
+1783499626.106328 cmd_parse_build_commands 0:38 0:1: -v
+1783499626.106329 cmd_parse_build_commands 0:39: 
+1783499626.106330 cmd_parse_build_commands 0:40: #{?#{>:#{window_panes},1},,-}Swap Up
+1783499626.106332 cmd_parse_build_commands 0:41: u
+1783499626.106333 cmd_parse_build_commands 0:42 0:0: swap-pane
+1783499626.106334 cmd_parse_build_commands 0:42 0:1: -U
+1783499626.106336 cmd_parse_build_commands 0:43: #{?#{>:#{window_panes},1},,-}Swap Down
+1783499626.106337 cmd_parse_build_commands 0:44: d
+1783499626.106338 cmd_parse_build_commands 0:45 0:0: swap-pane
+1783499626.106339 cmd_parse_build_commands 0:45 0:1: -D
+1783499626.106341 cmd_parse_build_commands 0:46: #{?pane_marked_set,,-}Swap Marked
+1783499626.106342 cmd_parse_build_commands 0:47: s
+1783499626.106343 cmd_parse_build_commands 0:48 0:0: swap-pane
+1783499626.106345 cmd_parse_build_commands 0:49: 
+1783499626.106346 cmd_parse_build_commands 0:50: Kill
+1783499626.106349 cmd_parse_build_commands 0:51: X
+1783499626.106350 cmd_parse_build_commands 0:52 0:0: kill-pane
+1783499626.106352 cmd_parse_build_commands 0:53: Respawn
+1783499626.106353 cmd_parse_build_commands 0:54: R
+1783499626.106354 cmd_parse_build_commands 0:55 0:0: respawn-pane
+1783499626.106355 cmd_parse_build_commands 0:55 0:1: -k
+1783499626.106358 cmd_parse_build_commands 0:56: #{?pane_marked,Unmark,Mark}
+1783499626.106359 cmd_parse_build_commands 0:57: m
+1783499626.106360 cmd_parse_build_commands 0:58 0:0: select-pane
+1783499626.106362 cmd_parse_build_commands 0:58 0:1: -m
+1783499626.106363 cmd_parse_build_commands 0:59: #{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom}
+1783499626.106365 cmd_parse_build_commands 0:60: z
+1783499626.106366 cmd_parse_build_commands 0:61 0:0: resize-pane
+1783499626.106367 cmd_parse_build_commands 0:61 0:1: -Z
+1783499626.106370 cmd_parse_build_commands 0:0: send
+1783499626.106372 cmd_parse_build_commands 0:1: -X
+1783499626.106373 cmd_parse_build_commands 0:2: history-top
+1783499626.106378 args_parse_flags: next -X
+1783499626.106379 args_parse_flags: -X
+1783499626.106381 args_parse_flags: next history-top
+1783499626.106382 args_parse: flags end at 2 of 3
+1783499626.106384 args_parse: 2 = history-top (type STRING)
+1783499626.106388 cmd_parse_build_commands: send-keys -X history-top
+1783499626.106390 cmd_parse_build_commands 0:0: send
+1783499626.106392 cmd_parse_build_commands 0:1: -X
+1783499626.106393 cmd_parse_build_commands 0:2: history-bottom
+1783499626.106396 args_parse_flags: next -X
+1783499626.106397 args_parse_flags: -X
+1783499626.106398 args_parse_flags: next history-bottom
+1783499626.106399 args_parse: flags end at 2 of 3
+1783499626.106401 args_parse: 2 = history-bottom (type STRING)
+1783499626.106403 cmd_parse_build_commands: send-keys -X history-bottom
+1783499626.106405 cmd_parse_build_commands 0:0: if
+1783499626.106407 cmd_parse_build_commands 0:1: -F
+1783499626.106408 cmd_parse_build_commands 0:2: #{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}
+1783499626.106409 cmd_parse_build_commands 0:3: copy-mode -t=
+1783499626.106411 cmd_parse_build_commands 1:0: send
+1783499626.106412 cmd_parse_build_commands 1:1: -Xt=
+1783499626.106413 cmd_parse_build_commands 1:2: search-backward
+1783499626.106414 cmd_parse_build_commands 1:3: #{q:mouse_word}
+1783499626.106417 args_parse_flags: next -F
+1783499626.106418 args_parse_flags: -F
+1783499626.106420 args_parse_flags: next #{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}
+1783499626.106422 args_parse: flags end at 2 of 4
+1783499626.106423 args_parse: 2 = #{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1} (type STRING)
+1783499626.106425 args_parse: 3 = copy-mode -t= (type STRING)
+1783499626.106429 args_parse_flags: next -Xt=
+1783499626.106430 args_parse_flags: -X
+1783499626.106431 args_parse_flag_argument: -t = =
+1783499626.106432 args_parse_flags: next search-backward
+1783499626.106434 args_parse: flags end at 2 of 4
+1783499626.106435 args_parse: 2 = search-backward (type STRING)
+1783499626.106436 args_parse: 3 = #{q:mouse_word} (type STRING)
+1783499626.106444 cmd_parse_build_commands: if-shell -F "#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}" "copy-mode -t=" ; send-keys -X -t = search-backward "#{q:mouse_word}"
+1783499626.106447 cmd_parse_build_commands 0:0: copy-mode
+1783499626.106448 cmd_parse_build_commands 0:1: -q
+1783499626.106449 cmd_parse_build_commands 1:0: send-keys
+1783499626.106450 cmd_parse_build_commands 1:1: -l
+1783499626.106451 cmd_parse_build_commands 1:2: --
+1783499626.106452 cmd_parse_build_commands 1:3: #{q:mouse_word}
+1783499626.106454 args_parse_flags: next -q
+1783499626.106455 args_parse_flags: -q
+1783499626.106457 args_parse: flags end at 2 of 2
+1783499626.106460 args_parse_flags: next -l
+1783499626.106461 args_parse_flags: -l
+1783499626.106462 args_parse_flags: next --
+1783499626.106463 args_parse: flags end at 3 of 4
+1783499626.106464 args_parse: 3 = #{q:mouse_word} (type STRING)
+1783499626.106468 cmd_parse_build_commands: copy-mode -q ; send-keys -l "#{q:mouse_word}"
+1783499626.106473 cmd_parse_build_commands 0:0: copy-mode
+1783499626.106474 cmd_parse_build_commands 0:1: -q
+1783499626.106475 cmd_parse_build_commands 1:0: set-buffer
+1783499626.106477 cmd_parse_build_commands 1:1: --
+1783499626.106478 cmd_parse_build_commands 1:2: #{q:mouse_word}
+1783499626.106480 args_parse_flags: next -q
+1783499626.106481 args_parse_flags: -q
+1783499626.106482 args_parse: flags end at 2 of 2
+1783499626.106485 args_parse_flags: next --
+1783499626.106486 args_parse: flags end at 2 of 3
+1783499626.106488 args_parse: 2 = #{q:mouse_word} (type STRING)
+1783499626.106491 cmd_parse_build_commands: copy-mode -q ; set-buffer "#{q:mouse_word}"
+1783499626.106493 cmd_parse_build_commands 0:0: copy-mode
+1783499626.106494 cmd_parse_build_commands 0:1: -q
+1783499626.106495 cmd_parse_build_commands 1:0: set-buffer
+1783499626.106496 cmd_parse_build_commands 1:1: --
+1783499626.106498 cmd_parse_build_commands 1:2: #{q:mouse_line}
+1783499626.106500 args_parse_flags: next -q
+1783499626.106501 args_parse_flags: -q
+1783499626.106502 args_parse: flags end at 2 of 2
+1783499626.106505 args_parse_flags: next --
+1783499626.106506 args_parse: flags end at 2 of 3
+1783499626.106507 args_parse: 2 = #{q:mouse_line} (type STRING)
+1783499626.106510 cmd_parse_build_commands: copy-mode -q ; set-buffer "#{q:mouse_line}"
+1783499626.106513 cmd_parse_build_commands 0:0: copy-mode
+1783499626.106514 cmd_parse_build_commands 0:1: -q
+1783499626.106516 cmd_parse_build_commands 1:0: send-keys
+1783499626.106517 cmd_parse_build_commands 1:1: -l
+1783499626.106518 cmd_parse_build_commands 1:2: --
+1783499626.106519 cmd_parse_build_commands 1:3: #{q:mouse_hyperlink}
+1783499626.106521 args_parse_flags: next -q
+1783499626.106522 args_parse_flags: -q
+1783499626.106523 args_parse: flags end at 2 of 2
+1783499626.106526 args_parse_flags: next -l
+1783499626.106527 args_parse_flags: -l
+1783499626.106528 args_parse_flags: next --
+1783499626.106529 args_parse: flags end at 3 of 4
+1783499626.106531 args_parse: 3 = #{q:mouse_hyperlink} (type STRING)
+1783499626.106535 cmd_parse_build_commands: copy-mode -q ; send-keys -l "#{q:mouse_hyperlink}"
+1783499626.106537 cmd_parse_build_commands 0:0: copy-mode
+1783499626.106539 cmd_parse_build_commands 0:1: -q
+1783499626.106540 cmd_parse_build_commands 1:0: set-buffer
+1783499626.106541 cmd_parse_build_commands 1:1: --
+1783499626.106543 cmd_parse_build_commands 1:2: #{q:mouse_hyperlink}
+1783499626.106544 args_parse_flags: next -q
+1783499626.106545 args_parse_flags: -q
+1783499626.106547 args_parse: flags end at 2 of 2
+1783499626.106549 args_parse_flags: next --
+1783499626.106551 args_parse: flags end at 2 of 3
+1783499626.106552 args_parse: 2 = #{q:mouse_hyperlink} (type STRING)
+1783499626.106555 cmd_parse_build_commands: copy-mode -q ; set-buffer "#{q:mouse_hyperlink}"
+1783499626.106558 cmd_parse_build_commands 0:0: split-window
+1783499626.106559 cmd_parse_build_commands 0:1: -h
+1783499626.106563 args_parse_flags: next -h
+1783499626.106564 args_parse_flags: -h
+1783499626.106565 args_parse: flags end at 2 of 2
+1783499626.106567 cmd_parse_build_commands: split-window -h
+1783499626.106569 cmd_parse_build_commands 0:0: split-window
+1783499626.106571 cmd_parse_build_commands 0:1: -v
+1783499626.106574 args_parse_flags: next -v
+1783499626.106575 args_parse_flags: -v
+1783499626.106576 args_parse: flags end at 2 of 2
+1783499626.106578 cmd_parse_build_commands: split-window -v
+1783499626.106581 cmd_parse_build_commands 0:0: swap-pane
+1783499626.106582 cmd_parse_build_commands 0:1: -U
+1783499626.106585 args_parse_flags: next -U
+1783499626.106587 args_parse_flags: -U
+1783499626.106588 args_parse: flags end at 2 of 2
+1783499626.106590 cmd_parse_build_commands: swap-pane -U
+1783499626.106592 cmd_parse_build_commands 0:0: swap-pane
+1783499626.106594 cmd_parse_build_commands 0:1: -D
+1783499626.106596 args_parse_flags: next -D
+1783499626.106597 args_parse_flags: -D
+1783499626.106599 args_parse: flags end at 2 of 2
+1783499626.106600 cmd_parse_build_commands: swap-pane -D
+1783499626.106603 cmd_parse_build_commands 0:0: swap-pane
+1783499626.106606 args_parse: flags end at 1 of 1
+1783499626.106614 cmd_parse_build_commands: swap-pane
+1783499626.106617 cmd_parse_build_commands 0:0: kill-pane
+1783499626.106620 args_parse: flags end at 1 of 1
+1783499626.106621 cmd_parse_build_commands: kill-pane
+1783499626.106624 cmd_parse_build_commands 0:0: respawn-pane
+1783499626.106625 cmd_parse_build_commands 0:1: -k
+1783499626.106627 args_parse_flags: next -k
+1783499626.106628 args_parse_flags: -k
+1783499626.106630 args_parse: flags end at 2 of 2
+1783499626.106632 cmd_parse_build_commands: respawn-pane -k
+1783499626.106634 cmd_parse_build_commands 0:0: select-pane
+1783499626.106635 cmd_parse_build_commands 0:1: -m
+1783499626.106638 args_parse_flags: next -m
+1783499626.106639 args_parse_flags: -m
+1783499626.106640 args_parse: flags end at 2 of 2
+1783499626.106642 cmd_parse_build_commands: select-pane -m
+1783499626.106644 cmd_parse_build_commands 0:0: resize-pane
+1783499626.106645 cmd_parse_build_commands 0:1: -Z
+1783499626.106648 args_parse_flags: next -Z
+1783499626.106649 args_parse_flags: -Z
+1783499626.106650 args_parse: flags end at 2 of 2
+1783499626.106652 cmd_parse_build_commands: resize-pane -Z
+1783499626.106653 args_parse_flags: next -t=
+1783499626.106654 args_parse_flag_argument: -t = =
+1783499626.106655 args_parse_flags: next -xM
+1783499626.106657 args_parse_flag_argument: -x = M
+1783499626.106658 args_parse_flags: next -yM
+1783499626.106659 args_parse_flag_argument: -y = M
+1783499626.106660 args_parse_flags: next -T
+1783499626.106662 args_parse_flag_argument: -T = #[align=centre]#{pane_index} (#{pane_id})
+1783499626.106664 args_parse_flags: next #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,}
+1783499626.106665 args_parse: flags end at 6 of 62
+1783499626.106667 args_parse: 6 = #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,} (type STRING)
+1783499626.106669 args_parse: 7 = < (type STRING)
+1783499626.106672 args_parse: 8 = send-keys -X history-top (type COMMANDS)
+1783499626.106674 args_parse: 9 = #{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Bottom,} (type STRING)
+1783499626.106675 args_parse: 10 = > (type STRING)
+1783499626.106678 args_parse: 11 = send-keys -X history-bottom (type COMMANDS)
+1783499626.106680 args_parse: 12 =  (type STRING)
+1783499626.106682 args_parse: 13 = #{?mouse_word,Search For #[underscore]#{=/9/...:mouse_word},} (type STRING)
+1783499626.106683 args_parse: 14 = C-r (type STRING)
+1783499626.106690 args_parse: 15 = if-shell -F "#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}" "copy-mode -t=" ; send-keys -X -t = search-backward "#{q:mouse_word}" (type COMMANDS)
+1783499626.106692 args_parse: 16 = #{?mouse_word,Type #[underscore]#{=/9/...:mouse_word},} (type STRING)
+1783499626.106694 args_parse: 17 = C-y (type STRING)
+1783499626.106697 args_parse: 18 = copy-mode -q ; send-keys -l "#{q:mouse_word}" (type COMMANDS)
+1783499626.106699 args_parse: 19 = #{?mouse_word,Copy #[underscore]#{=/9/...:mouse_word},} (type STRING)
+1783499626.106701 args_parse: 20 = c (type STRING)
+1783499626.106704 args_parse: 21 = copy-mode -q ; set-buffer "#{q:mouse_word}" (type COMMANDS)
+1783499626.106705 args_parse: 22 = #{?mouse_line,Copy Line,} (type STRING)
+1783499626.106707 args_parse: 23 = l (type STRING)
+1783499626.106709 args_parse: 24 = copy-mode -q ; set-buffer "#{q:mouse_line}" (type COMMANDS)
+1783499626.106711 args_parse: 25 =  (type STRING)
+1783499626.106713 args_parse: 26 = #{?mouse_hyperlink,Type #[underscore]#{=/9/...:mouse_hyperlink},} (type STRING)
+1783499626.106714 args_parse: 27 = C-h (type STRING)
+1783499626.106718 args_parse: 28 = copy-mode -q ; send-keys -l "#{q:mouse_hyperlink}" (type COMMANDS)
+1783499626.106720 args_parse: 29 = #{?mouse_hyperlink,Copy #[underscore]#{=/9/...:mouse_hyperlink},} (type STRING)
+1783499626.106721 args_parse: 30 = h (type STRING)
+1783499626.106724 args_parse: 31 = copy-mode -q ; set-buffer "#{q:mouse_hyperlink}" (type COMMANDS)
+1783499626.106727 args_parse: 32 =  (type STRING)
+1783499626.106738 args_parse: 33 = Horizontal Split (type STRING)
+1783499626.106743 args_parse: 34 = h (type STRING)
+1783499626.106746 args_parse: 35 = split-window -h (type COMMANDS)
+1783499626.106751 args_parse: 36 = Vertical Split (type STRING)
+1783499626.106753 args_parse: 37 = v (type STRING)
+1783499626.106755 args_parse: 38 = split-window -v (type COMMANDS)
+1783499626.106757 args_parse: 39 =  (type STRING)
+1783499626.106759 args_parse: 40 = #{?#{>:#{window_panes},1},,-}Swap Up (type STRING)
+1783499626.106760 args_parse: 41 = u (type STRING)
+1783499626.106763 args_parse: 42 = swap-pane -U (type COMMANDS)
+1783499626.106765 args_parse: 43 = #{?#{>:#{window_panes},1},,-}Swap Down (type STRING)
+1783499626.106767 args_parse: 44 = d (type STRING)
+1783499626.106769 args_parse: 45 = swap-pane -D (type COMMANDS)
+1783499626.106771 args_parse: 46 = #{?pane_marked_set,,-}Swap Marked (type STRING)
+1783499626.106772 args_parse: 47 = s (type STRING)
+1783499626.106774 args_parse: 48 = swap-pane (type COMMANDS)
+1783499626.106776 args_parse: 49 =  (type STRING)
+1783499626.106778 args_parse: 50 = Kill (type STRING)
+1783499626.106779 args_parse: 51 = X (type STRING)
+1783499626.106787 args_parse: 52 = kill-pane (type COMMANDS)
+1783499626.106790 args_parse: 53 = Respawn (type STRING)
+1783499626.106792 args_parse: 54 = R (type STRING)
+1783499626.106794 args_parse: 55 = respawn-pane -k (type COMMANDS)
+1783499626.106796 args_parse: 56 = #{?pane_marked,Unmark,Mark} (type STRING)
+1783499626.106798 args_parse: 57 = m (type STRING)
+1783499626.106800 args_parse: 58 = select-pane -m (type COMMANDS)
+1783499626.106803 args_parse: 59 = #{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom} (type STRING)
+1783499626.106804 args_parse: 60 = z (type STRING)
+1783499626.106806 args_parse: 61 = resize-pane -Z (type COMMANDS)
+1783499626.106873 cmd_parse_build_commands: display-menu -T "#[align=centre]#{pane_index} (#{pane_id})" -t = -x M -y M "#{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,}" < { send-keys -X history-top } "#{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Bottom,}" > { send-keys -X history-bottom } '' "#{?mouse_word,Search For #[underscore]#{=/9/...:mouse_word},}" C-r { if-shell -F "#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}" "copy-mode -t=" ; send-keys -X -t = search-backward "#{q:mouse_word}" } "#{?mouse_word,Type #[underscore]#{=/9/...:mouse_word},}" C-y { copy-mode -q ; send-keys -l "#{q:mouse_word}" } "#{?mouse_word,Copy #[underscore]#{=/9/...:mouse_word},}" c { copy-mode -q ; set-buffer "#{q:mouse_word}" } "#{?mouse_line,Copy Line,}" l { copy-mode -q ; set-buffer "#{q:mouse_line}" } '' "#{?mouse_hyperlink,Type #[underscore]#{=/9/...:mouse_hyperlink},}" C-h { copy-mode -q ; send-keys -l "#{q:mouse_hyperlink}" } "#{?mouse_hyperlink,Copy #[underscore]#{=/9/...:mouse_hyperlink},}" h { copy-mode -q ; set-buffer "#{q:mouse_hyperlink}" } '' "Horizontal Split" h { split-window -h } "Vertical Split" v { split-window -v } '' "#{?#{>:#{window_panes},1},,-}Swap Up" u { swap-pane -U } "#{?#{>:#{window_panes},1},,-}Swap Down" d { swap-pane -D } "#{?pane_marked_set,,-}Swap Marked" s { swap-pane } '' Kill X { kill-pane } Respawn R { respawn-pane -k } "#{?pane_marked,Unmark,Mark}" m { select-pane -m } "#{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom}" z { resize-pane -Z }
+1783499626.106879 args_parse_flags: next -n
+1783499626.106880 args_parse_flags: -n
+1783499626.106882 args_parse_flags: next M-MouseDown3Pane
+1783499626.106883 args_parse: flags end at 2 of 4
+1783499626.106884 args_parse: 2 = M-MouseDown3Pane (type STRING)
+1783499626.106944 args_parse: 3 = display-menu -T "#[align=centre]#{pane_index} (#{pane_id})" -t = -x M -y M "#{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,}" < { send-keys -X history-top } "#{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Bottom,}" > { send-keys -X history-bottom } '' "#{?mouse_word,Search For #[underscore]#{=/9/...:mouse_word},}" C-r { if-shell -F "#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}" "copy-mode -t=" ; send-keys -X -t = search-backward "#{q:mouse_word}" } "#{?mouse_word,Type #[underscore]#{=/9/...:mouse_word},}" C-y { copy-mode -q ; send-keys -l "#{q:mouse_word}" } "#{?mouse_word,Copy #[underscore]#{=/9/...:mouse_word},}" c { copy-mode -q ; set-buffer "#{q:mouse_word}" } "#{?mouse_line,Copy Line,}" l { copy-mode -q ; set-buffer "#{q:mouse_line}" } '' "#{?mouse_hyperlink,Type #[underscore]#{=/9/...:mouse_hyperlink},}" C-h { copy-mode -q ; send-keys -l "#{q:mouse_hyperlink}" } "#{?mouse_hyperlink,Copy #[underscore]#{=/9/...:mouse_hyperlink},}" h { copy-mode -q ; set-buffer "#{q:mouse_hyperlink}" } '' "Horizontal Split" h { split-window -h } "Vertical Split" v { split-window -v } '' "#{?#{>:#{window_panes},1},,-}Swap Up" u { swap-pane -U } "#{?#{>:#{window_panes},1},,-}Swap Down" d { swap-pane -D } "#{?pane_marked_set,,-}Swap Marked" s { swap-pane } '' Kill X { kill-pane } Respawn R { respawn-pane -k } "#{?pane_marked,Unmark,Mark}" m { select-pane -m } "#{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom}" z { resize-pane -Z } (type COMMANDS)
+1783499626.107012 cmd_parse_build_commands: bind-key -n M-MouseDown3Pane { display-menu -T "#[align=centre]#{pane_index} (#{pane_id})" -t = -x M -y M "#{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,}" < { send-keys -X history-top } "#{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Bottom,}" > { send-keys -X history-bottom } '' "#{?mouse_word,Search For #[underscore]#{=/9/...:mouse_word},}" C-r { if-shell -F "#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}" "copy-mode -t=" ; send-keys -X -t = search-backward "#{q:mouse_word}" } "#{?mouse_word,Type #[underscore]#{=/9/...:mouse_word},}" C-y { copy-mode -q ; send-keys -l "#{q:mouse_word}" } "#{?mouse_word,Copy #[underscore]#{=/9/...:mouse_word},}" c { copy-mode -q ; set-buffer "#{q:mouse_word}" } "#{?mouse_line,Copy Line,}" l { copy-mode -q ; set-buffer "#{q:mouse_line}" } '' "#{?mouse_hyperlink,Type #[underscore]#{=/9/...:mouse_hyperlink},}" C-h { copy-mode -q ; send-keys -l "#{q:mouse_hyperlink}" } "#{?mouse_hyperlink,Copy #[underscore]#{=/9/...:mouse_hyperlink},}" h { copy-mode -q ; set-buffer "#{q:mouse_hyperlink}" } '' "Horizontal Split" h { split-window -h } "Vertical Split" v { split-window -v } '' "#{?#{>:#{window_panes},1},,-}Swap Up" u { swap-pane -U } "#{?#{>:#{window_panes},1},,-}Swap Down" d { swap-pane -D } "#{?pane_marked_set,,-}Swap Marked" s { swap-pane } '' Kill X { kill-pane } Respawn R { respawn-pane -k } "#{?pane_marked,Unmark,Mark}" m { select-pane -m } "#{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom}" z { resize-pane -Z } }
+1783499626.107025 cmdq_get_command: [bind-key/0x58e4724e0b40] group 1209
+1783499626.107027 cmdq_append <global>: [bind-key/0x58e4724e0b40]
+1783499626.107036 yylex_token: end at WS
+1783499626.107037 yylex_token: bind
+1783499626.107039 yylex_token: end at WS
+1783499626.107040 yylex_token: -Tcopy-mode
+1783499626.107041 yylex_token: end at WS
+1783499626.107043 yylex_token: C-Space
+1783499626.107044 yylex_token: end at WS
+1783499626.107045 yylex_token: send
+1783499626.107046 yylex_token: end at WS
+1783499626.107047 yylex_token: -X
+1783499626.107048 yylex_token: end at WS
+1783499626.107049 yylex_token: begin-selection
+1783499626.107052 cmd_parse_build_commands 0:0: bind
+1783499626.107053 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.107054 cmd_parse_build_commands 0:2: C-Space
+1783499626.107056 cmd_parse_build_commands 0:3 0:0: send
+1783499626.107057 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.107058 cmd_parse_build_commands 0:3 0:2: begin-selection
+1783499626.107061 cmd_parse_build_commands 0:0: send
+1783499626.107062 cmd_parse_build_commands 0:1: -X
+1783499626.107064 cmd_parse_build_commands 0:2: begin-selection
+1783499626.107067 args_parse_flags: next -X
+1783499626.107068 args_parse_flags: -X
+1783499626.107069 args_parse_flags: next begin-selection
+1783499626.107071 args_parse: flags end at 2 of 3
+1783499626.107072 args_parse: 2 = begin-selection (type STRING)
+1783499626.107075 cmd_parse_build_commands: send-keys -X begin-selection
+1783499626.107076 args_parse_flags: next -Tcopy-mode
+1783499626.107078 args_parse_flag_argument: -T = copy-mode
+1783499626.107079 args_parse_flags: next C-Space
+1783499626.107080 args_parse: flags end at 2 of 4
+1783499626.107081 args_parse: 2 = C-Space (type STRING)
+1783499626.107087 args_parse: 3 = send-keys -X begin-selection (type COMMANDS)
+1783499626.107092 cmd_parse_build_commands: bind-key -T copy-mode C-Space { send-keys -X begin-selection }
+1783499626.107095 cmdq_get_command: [bind-key/0x58e4724f8560] group 1291
+1783499626.107096 cmdq_append <global>: [bind-key/0x58e4724f8560]
+1783499626.107098 yylex_token: end at WS
+1783499626.107099 yylex_token: bind
+1783499626.107101 yylex_token: end at WS
+1783499626.107102 yylex_token: -Tcopy-mode
+1783499626.107103 yylex_token: end at WS
+1783499626.107104 yylex_token: C-a
+1783499626.107105 yylex_token: end at WS
+1783499626.107106 yylex_token: send
+1783499626.107107 yylex_token: end at WS
+1783499626.107108 yylex_token: -X
+1783499626.107110 yylex_token: end at WS
+1783499626.107111 yylex_token: start-of-line
+1783499626.107113 cmd_parse_build_commands 0:0: bind
+1783499626.107114 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.107115 cmd_parse_build_commands 0:2: C-a
+1783499626.107116 cmd_parse_build_commands 0:3 0:0: send
+1783499626.107118 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.107119 cmd_parse_build_commands 0:3 0:2: start-of-line
+1783499626.107121 cmd_parse_build_commands 0:0: send
+1783499626.107122 cmd_parse_build_commands 0:1: -X
+1783499626.107123 cmd_parse_build_commands 0:2: start-of-line
+1783499626.107126 args_parse_flags: next -X
+1783499626.107127 args_parse_flags: -X
+1783499626.107129 args_parse_flags: next start-of-line
+1783499626.107130 args_parse: flags end at 2 of 3
+1783499626.107131 args_parse: 2 = start-of-line (type STRING)
+1783499626.107133 cmd_parse_build_commands: send-keys -X start-of-line
+1783499626.107135 args_parse_flags: next -Tcopy-mode
+1783499626.107136 args_parse_flag_argument: -T = copy-mode
+1783499626.107137 args_parse_flags: next C-a
+1783499626.107139 args_parse: flags end at 2 of 4
+1783499626.107140 args_parse: 2 = C-a (type STRING)
+1783499626.107142 args_parse: 3 = send-keys -X start-of-line (type COMMANDS)
+1783499626.107146 cmd_parse_build_commands: bind-key -T copy-mode C-a { send-keys -X start-of-line }
+1783499626.107149 cmdq_get_command: [bind-key/0x58e4724ffce0] group 1299
+1783499626.107150 cmdq_append <global>: [bind-key/0x58e4724ffce0]
+1783499626.107153 yylex_token: end at WS
+1783499626.107154 yylex_token: bind
+1783499626.107155 yylex_token: end at WS
+1783499626.107156 yylex_token: -Tcopy-mode
+1783499626.107158 yylex_token: end at WS
+1783499626.107159 yylex_token: C-c
+1783499626.107160 yylex_token: end at WS
+1783499626.107161 yylex_token: send
+1783499626.107162 yylex_token: end at WS
+1783499626.107163 yylex_token: -X
+1783499626.107164 yylex_token: end at WS
+1783499626.107165 yylex_token: cancel
+1783499626.107167 cmd_parse_build_commands 0:0: bind
+1783499626.107168 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.107169 cmd_parse_build_commands 0:2: C-c
+1783499626.107171 cmd_parse_build_commands 0:3 0:0: send
+1783499626.107172 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.107173 cmd_parse_build_commands 0:3 0:2: cancel
+1783499626.107175 cmd_parse_build_commands 0:0: send
+1783499626.107176 cmd_parse_build_commands 0:1: -X
+1783499626.107177 cmd_parse_build_commands 0:2: cancel
+1783499626.107180 args_parse_flags: next -X
+1783499626.107181 args_parse_flags: -X
+1783499626.107182 args_parse_flags: next cancel
+1783499626.107183 args_parse: flags end at 2 of 3
+1783499626.107184 args_parse: 2 = cancel (type STRING)
+1783499626.107187 cmd_parse_build_commands: send-keys -X cancel
+1783499626.107188 args_parse_flags: next -Tcopy-mode
+1783499626.107190 args_parse_flag_argument: -T = copy-mode
+1783499626.107191 args_parse_flags: next C-c
+1783499626.107192 args_parse: flags end at 2 of 4
+1783499626.107193 args_parse: 2 = C-c (type STRING)
+1783499626.107195 args_parse: 3 = send-keys -X cancel (type COMMANDS)
+1783499626.107199 cmd_parse_build_commands: bind-key -T copy-mode C-c { send-keys -X cancel }
+1783499626.107201 cmdq_get_command: [bind-key/0x58e4724f8cd0] group 1307
+1783499626.107203 cmdq_append <global>: [bind-key/0x58e4724f8cd0]
+1783499626.107206 yylex_token: end at WS
+1783499626.107207 yylex_token: bind
+1783499626.107211 yylex_token: end at WS
+1783499626.107212 yylex_token: -Tcopy-mode
+1783499626.107213 yylex_token: end at WS
+1783499626.107214 yylex_token: C-e
+1783499626.107215 yylex_token: end at WS
+1783499626.107216 yylex_token: send
+1783499626.107217 yylex_token: end at WS
+1783499626.107218 yylex_token: -X
+1783499626.107219 yylex_token: end at WS
+1783499626.107220 yylex_token: end-of-line
+1783499626.107222 cmd_parse_build_commands 0:0: bind
+1783499626.107224 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.107225 cmd_parse_build_commands 0:2: C-e
+1783499626.107226 cmd_parse_build_commands 0:3 0:0: send
+1783499626.107227 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.107228 cmd_parse_build_commands 0:3 0:2: end-of-line
+1783499626.107230 cmd_parse_build_commands 0:0: send
+1783499626.107231 cmd_parse_build_commands 0:1: -X
+1783499626.107232 cmd_parse_build_commands 0:2: end-of-line
+1783499626.107235 args_parse_flags: next -X
+1783499626.107236 args_parse_flags: -X
+1783499626.107237 args_parse_flags: next end-of-line
+1783499626.107239 args_parse: flags end at 2 of 3
+1783499626.107240 args_parse: 2 = end-of-line (type STRING)
+1783499626.107242 cmd_parse_build_commands: send-keys -X end-of-line
+1783499626.107244 args_parse_flags: next -Tcopy-mode
+1783499626.107245 args_parse_flag_argument: -T = copy-mode
+1783499626.107246 args_parse_flags: next C-e
+1783499626.107247 args_parse: flags end at 2 of 4
+1783499626.107249 args_parse: 2 = C-e (type STRING)
+1783499626.107251 args_parse: 3 = send-keys -X end-of-line (type COMMANDS)
+1783499626.107255 cmd_parse_build_commands: bind-key -T copy-mode C-e { send-keys -X end-of-line }
+1783499626.107257 cmdq_get_command: [bind-key/0x58e4724f0410] group 1315
+1783499626.107258 cmdq_append <global>: [bind-key/0x58e4724f0410]
+1783499626.107261 yylex_token: end at WS
+1783499626.107262 yylex_token: bind
+1783499626.107263 yylex_token: end at WS
+1783499626.107264 yylex_token: -Tcopy-mode
+1783499626.107265 yylex_token: end at WS
+1783499626.107266 yylex_token: C-f
+1783499626.107267 yylex_token: end at WS
+1783499626.107268 yylex_token: send
+1783499626.107269 yylex_token: end at WS
+1783499626.107270 yylex_token: -X
+1783499626.107272 yylex_token: end at WS
+1783499626.107273 yylex_token: cursor-right
+1783499626.107274 cmd_parse_build_commands 0:0: bind
+1783499626.107276 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.107277 cmd_parse_build_commands 0:2: C-f
+1783499626.107278 cmd_parse_build_commands 0:3 0:0: send
+1783499626.107279 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.107280 cmd_parse_build_commands 0:3 0:2: cursor-right
+1783499626.107282 cmd_parse_build_commands 0:0: send
+1783499626.107284 cmd_parse_build_commands 0:1: -X
+1783499626.107285 cmd_parse_build_commands 0:2: cursor-right
+1783499626.107288 args_parse_flags: next -X
+1783499626.107289 args_parse_flags: -X
+1783499626.107290 args_parse_flags: next cursor-right
+1783499626.107291 args_parse: flags end at 2 of 3
+1783499626.107292 args_parse: 2 = cursor-right (type STRING)
+1783499626.107295 cmd_parse_build_commands: send-keys -X cursor-right
+1783499626.107296 args_parse_flags: next -Tcopy-mode
+1783499626.107297 args_parse_flag_argument: -T = copy-mode
+1783499626.107299 args_parse_flags: next C-f
+1783499626.107300 args_parse: flags end at 2 of 4
+1783499626.107301 args_parse: 2 = C-f (type STRING)
+1783499626.107303 args_parse: 3 = send-keys -X cursor-right (type COMMANDS)
+1783499626.107307 cmd_parse_build_commands: bind-key -T copy-mode C-f { send-keys -X cursor-right }
+1783499626.107309 cmdq_get_command: [bind-key/0x58e4725000a0] group 1323
+1783499626.107310 cmdq_append <global>: [bind-key/0x58e4725000a0]
+1783499626.107313 yylex_token: end at WS
+1783499626.107314 yylex_token: bind
+1783499626.107315 yylex_token: end at WS
+1783499626.107316 yylex_token: -Tcopy-mode
+1783499626.107318 yylex_token: end at WS
+1783499626.107318 yylex_token: C-b
+1783499626.107320 yylex_token: end at WS
+1783499626.107321 yylex_token: send
+1783499626.107322 yylex_token: end at WS
+1783499626.107323 yylex_token: -X
+1783499626.107324 yylex_token: end at WS
+1783499626.107327 yylex_token: cursor-left
+1783499626.107329 cmd_parse_build_commands 0:0: bind
+1783499626.107330 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.107331 cmd_parse_build_commands 0:2: C-b
+1783499626.107333 cmd_parse_build_commands 0:3 0:0: send
+1783499626.107334 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.107335 cmd_parse_build_commands 0:3 0:2: cursor-left
+1783499626.107337 cmd_parse_build_commands 0:0: send
+1783499626.107338 cmd_parse_build_commands 0:1: -X
+1783499626.107339 cmd_parse_build_commands 0:2: cursor-left
+1783499626.107342 args_parse_flags: next -X
+1783499626.107343 args_parse_flags: -X
+1783499626.107344 args_parse_flags: next cursor-left
+1783499626.107345 args_parse: flags end at 2 of 3
+1783499626.107375 args_parse: 2 = cursor-left (type STRING)
+1783499626.107385 cmd_parse_build_commands: send-keys -X cursor-left
+1783499626.107388 args_parse_flags: next -Tcopy-mode
+1783499626.107390 args_parse_flag_argument: -T = copy-mode
+1783499626.107392 args_parse_flags: next C-b
+1783499626.107393 args_parse: flags end at 2 of 4
+1783499626.107395 args_parse: 2 = C-b (type STRING)
+1783499626.107398 args_parse: 3 = send-keys -X cursor-left (type COMMANDS)
+1783499626.107403 cmd_parse_build_commands: bind-key -T copy-mode C-b { send-keys -X cursor-left }
+1783499626.107406 cmdq_get_command: [bind-key/0x58e472500e70] group 1331
+1783499626.107408 cmdq_append <global>: [bind-key/0x58e472500e70]
+1783499626.107411 yylex_token: end at WS
+1783499626.107412 yylex_token: bind
+1783499626.107414 yylex_token: end at WS
+1783499626.107416 yylex_token: -Tcopy-mode
+1783499626.107417 yylex_token: end at WS
+1783499626.107419 yylex_token: C-g
+1783499626.107420 yylex_token: end at WS
+1783499626.107421 yylex_token: send
+1783499626.107422 yylex_token: end at WS
+1783499626.107424 yylex_token: -X
+1783499626.107425 yylex_token: end at WS
+1783499626.107427 yylex_token: clear-selection
+1783499626.107429 cmd_parse_build_commands 0:0: bind
+1783499626.107431 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.107432 cmd_parse_build_commands 0:2: C-g
+1783499626.107434 cmd_parse_build_commands 0:3 0:0: send
+1783499626.107435 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.107437 cmd_parse_build_commands 0:3 0:2: clear-selection
+1783499626.107440 cmd_parse_build_commands 0:0: send
+1783499626.107441 cmd_parse_build_commands 0:1: -X
+1783499626.107443 cmd_parse_build_commands 0:2: clear-selection
+1783499626.107446 args_parse_flags: next -X
+1783499626.107447 args_parse_flags: -X
+1783499626.107449 args_parse_flags: next clear-selection
+1783499626.107450 args_parse: flags end at 2 of 3
+1783499626.107452 args_parse: 2 = clear-selection (type STRING)
+1783499626.107455 cmd_parse_build_commands: send-keys -X clear-selection
+1783499626.107457 args_parse_flags: next -Tcopy-mode
+1783499626.107458 args_parse_flag_argument: -T = copy-mode
+1783499626.107459 args_parse_flags: next C-g
+1783499626.107461 args_parse: flags end at 2 of 4
+1783499626.107462 args_parse: 2 = C-g (type STRING)
+1783499626.107465 args_parse: 3 = send-keys -X clear-selection (type COMMANDS)
+1783499626.107470 cmd_parse_build_commands: bind-key -T copy-mode C-g { send-keys -X clear-selection }
+1783499626.107472 cmdq_get_command: [bind-key/0x58e4724ff2a0] group 1339
+1783499626.107474 cmdq_append <global>: [bind-key/0x58e4724ff2a0]
+1783499626.107477 yylex_token: end at WS
+1783499626.107478 yylex_token: bind
+1783499626.107479 yylex_token: end at WS
+1783499626.107481 yylex_token: -Tcopy-mode
+1783499626.107482 yylex_token: end at WS
+1783499626.107483 yylex_token: C-k
+1783499626.107484 yylex_token: end at WS
+1783499626.107486 yylex_token: send
+1783499626.107487 yylex_token: end at WS
+1783499626.107488 yylex_token: -X
+1783499626.107490 yylex_token: end at WS
+1783499626.107491 yylex_token: copy-pipe-end-of-line-and-cancel
+1783499626.107494 cmd_parse_build_commands 0:0: bind
+1783499626.107495 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.107496 cmd_parse_build_commands 0:2: C-k
+1783499626.107498 cmd_parse_build_commands 0:3 0:0: send
+1783499626.107499 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.107506 cmd_parse_build_commands 0:3 0:2: copy-pipe-end-of-line-and-cancel
+1783499626.107508 cmd_parse_build_commands 0:0: send
+1783499626.107509 cmd_parse_build_commands 0:1: -X
+1783499626.107511 cmd_parse_build_commands 0:2: copy-pipe-end-of-line-and-cancel
+1783499626.107514 args_parse_flags: next -X
+1783499626.107516 args_parse_flags: -X
+1783499626.107517 args_parse_flags: next copy-pipe-end-of-line-and-cancel
+1783499626.107518 args_parse: flags end at 2 of 3
+1783499626.107520 args_parse: 2 = copy-pipe-end-of-line-and-cancel (type STRING)
+1783499626.107524 cmd_parse_build_commands: send-keys -X copy-pipe-end-of-line-and-cancel
+1783499626.107525 args_parse_flags: next -Tcopy-mode
+1783499626.107527 args_parse_flag_argument: -T = copy-mode
+1783499626.107528 args_parse_flags: next C-k
+1783499626.107529 args_parse: flags end at 2 of 4
+1783499626.107531 args_parse: 2 = C-k (type STRING)
+1783499626.107534 args_parse: 3 = send-keys -X copy-pipe-end-of-line-and-cancel (type COMMANDS)
+1783499626.107539 cmd_parse_build_commands: bind-key -T copy-mode C-k { send-keys -X copy-pipe-end-of-line-and-cancel }
+1783499626.107542 cmdq_get_command: [bind-key/0x58e472500f70] group 1347
+1783499626.107543 cmdq_append <global>: [bind-key/0x58e472500f70]
+1783499626.107546 yylex_token: end at WS
+1783499626.107547 yylex_token: bind
+1783499626.107549 yylex_token: end at WS
+1783499626.107550 yylex_token: -Tcopy-mode
+1783499626.107551 yylex_token: end at WS
+1783499626.107552 yylex_token: C-n
+1783499626.107554 yylex_token: end at WS
+1783499626.107555 yylex_token: send
+1783499626.107556 yylex_token: end at WS
+1783499626.107557 yylex_token: -X
+1783499626.107558 yylex_token: end at WS
+1783499626.107560 yylex_token: cursor-down
+1783499626.107562 cmd_parse_build_commands 0:0: bind
+1783499626.107563 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.107564 cmd_parse_build_commands 0:2: C-n
+1783499626.107566 cmd_parse_build_commands 0:3 0:0: send
+1783499626.107567 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.107569 cmd_parse_build_commands 0:3 0:2: cursor-down
+1783499626.107570 cmd_parse_build_commands 0:0: send
+1783499626.107572 cmd_parse_build_commands 0:1: -X
+1783499626.107573 cmd_parse_build_commands 0:2: cursor-down
+1783499626.107576 args_parse_flags: next -X
+1783499626.107577 args_parse_flags: -X
+1783499626.107579 args_parse_flags: next cursor-down
+1783499626.107580 args_parse: flags end at 2 of 3
+1783499626.107581 args_parse: 2 = cursor-down (type STRING)
+1783499626.107584 cmd_parse_build_commands: send-keys -X cursor-down
+1783499626.107586 args_parse_flags: next -Tcopy-mode
+1783499626.107587 args_parse_flag_argument: -T = copy-mode
+1783499626.107588 args_parse_flags: next C-n
+1783499626.107590 args_parse: flags end at 2 of 4
+1783499626.107591 args_parse: 2 = C-n (type STRING)
+1783499626.107593 args_parse: 3 = send-keys -X cursor-down (type COMMANDS)
+1783499626.107597 cmd_parse_build_commands: bind-key -T copy-mode C-n { send-keys -X cursor-down }
+1783499626.107600 cmdq_get_command: [bind-key/0x58e472504b90] group 1355
+1783499626.107601 cmdq_append <global>: [bind-key/0x58e472504b90]
+1783499626.107604 yylex_token: end at WS
+1783499626.107605 yylex_token: bind
+1783499626.107606 yylex_token: end at WS
+1783499626.107607 yylex_token: -Tcopy-mode
+1783499626.107609 yylex_token: end at WS
+1783499626.107610 yylex_token: C-p
+1783499626.107611 yylex_token: end at WS
+1783499626.107612 yylex_token: send
+1783499626.107613 yylex_token: end at WS
+1783499626.107614 yylex_token: -X
+1783499626.107616 yylex_token: end at WS
+1783499626.107617 yylex_token: cursor-up
+1783499626.107619 cmd_parse_build_commands 0:0: bind
+1783499626.107620 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.107621 cmd_parse_build_commands 0:2: C-p
+1783499626.107623 cmd_parse_build_commands 0:3 0:0: send
+1783499626.107624 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.107625 cmd_parse_build_commands 0:3 0:2: cursor-up
+1783499626.107627 cmd_parse_build_commands 0:0: send
+1783499626.107628 cmd_parse_build_commands 0:1: -X
+1783499626.107630 cmd_parse_build_commands 0:2: cursor-up
+1783499626.107637 args_parse_flags: next -X
+1783499626.107638 args_parse_flags: -X
+1783499626.107639 args_parse_flags: next cursor-up
+1783499626.107640 args_parse: flags end at 2 of 3
+1783499626.107642 args_parse: 2 = cursor-up (type STRING)
+1783499626.107645 cmd_parse_build_commands: send-keys -X cursor-up
+1783499626.107646 args_parse_flags: next -Tcopy-mode
+1783499626.107648 args_parse_flag_argument: -T = copy-mode
+1783499626.107649 args_parse_flags: next C-p
+1783499626.107650 args_parse: flags end at 2 of 4
+1783499626.107651 args_parse: 2 = C-p (type STRING)
+1783499626.107654 args_parse: 3 = send-keys -X cursor-up (type COMMANDS)
+1783499626.107658 cmd_parse_build_commands: bind-key -T copy-mode C-p { send-keys -X cursor-up }
+1783499626.107662 cmdq_get_command: [bind-key/0x58e472505120] group 1363
+1783499626.107663 cmdq_append <global>: [bind-key/0x58e472505120]
+1783499626.107665 yylex_token: end at WS
+1783499626.107666 yylex_token: bind
+1783499626.107668 yylex_token: end at WS
+1783499626.107669 yylex_token: -Tcopy-mode
+1783499626.107670 yylex_token: end at WS
+1783499626.107671 yylex_token: C-r
+1783499626.107673 yylex_token: end at WS
+1783499626.107674 yylex_token: command-prompt
+1783499626.107675 yylex_token: end at WS
+1783499626.107676 yylex_token: -T
+1783499626.107678 yylex_token: end at WS
+1783499626.107679 yylex_token: search
+1783499626.107680 yylex_token: end at WS
+1783499626.107682 yylex_token: -ip(search up)
+1783499626.107683 yylex_token: end at WS
+1783499626.107685 yylex_token: -I#{pane_search_string}
+1783499626.107686 yylex_token: end at WS
+1783499626.107687 yylex_token: send
+1783499626.107688 yylex_token: end at WS
+1783499626.107689 yylex_token: -X
+1783499626.107691 yylex_token: end at WS
+1783499626.107692 yylex_token: search-backward-incremental
+1783499626.107694 yylex_token: end at WS
+1783499626.107695 yylex_token: %%
+1783499626.107697 cmd_parse_build_commands 0:0: bind
+1783499626.107699 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.107700 cmd_parse_build_commands 0:2: C-r
+1783499626.107702 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.107703 cmd_parse_build_commands 0:3 0:1: -T
+1783499626.107704 cmd_parse_build_commands 0:3 0:2: search
+1783499626.107706 cmd_parse_build_commands 0:3 0:3: -ip(search up)
+1783499626.107707 cmd_parse_build_commands 0:3 0:4: -I#{pane_search_string}
+1783499626.107709 cmd_parse_build_commands 0:3 0:5 0:0: send
+1783499626.107710 cmd_parse_build_commands 0:3 0:5 0:1: -X
+1783499626.107712 cmd_parse_build_commands 0:3 0:5 0:2: search-backward-incremental
+1783499626.107714 cmd_parse_build_commands 0:3 0:5 0:3: %%
+1783499626.107716 cmd_parse_build_commands 0:0: command-prompt
+1783499626.107717 cmd_parse_build_commands 0:1: -T
+1783499626.107719 cmd_parse_build_commands 0:2: search
+1783499626.107720 cmd_parse_build_commands 0:3: -ip(search up)
+1783499626.107721 cmd_parse_build_commands 0:4: -I#{pane_search_string}
+1783499626.107723 cmd_parse_build_commands 0:5 0:0: send
+1783499626.107724 cmd_parse_build_commands 0:5 0:1: -X
+1783499626.107725 cmd_parse_build_commands 0:5 0:2: search-backward-incremental
+1783499626.107727 cmd_parse_build_commands 0:5 0:3: %%
+1783499626.107729 cmd_parse_build_commands 0:0: send
+1783499626.107730 cmd_parse_build_commands 0:1: -X
+1783499626.107732 cmd_parse_build_commands 0:2: search-backward-incremental
+1783499626.107733 cmd_parse_build_commands 0:3: %%
+1783499626.107737 args_parse_flags: next -X
+1783499626.107738 args_parse_flags: -X
+1783499626.107739 args_parse_flags: next search-backward-incremental
+1783499626.107740 args_parse: flags end at 2 of 4
+1783499626.107742 args_parse: 2 = search-backward-incremental (type STRING)
+1783499626.107744 args_parse: 3 = %% (type STRING)
+1783499626.107748 cmd_parse_build_commands: send-keys -X search-backward-incremental "%%"
+1783499626.107750 args_parse_flags: next -T
+1783499626.107751 args_parse_flag_argument: -T = search
+1783499626.107753 args_parse_flags: next -ip(search up)
+1783499626.107754 args_parse_flags: -i
+1783499626.107755 args_parse_flag_argument: -p = (search up)
+1783499626.107759 args_parse_flags: next -I#{pane_search_string}
+1783499626.107761 args_parse_flag_argument: -I = #{pane_search_string}
+1783499626.107763 args_parse: flags end at 5 of 6
+1783499626.107767 args_parse: 5 = send-keys -X search-backward-incremental "%%" (type COMMANDS)
+1783499626.107776 cmd_parse_build_commands: command-prompt -i -I "#{pane_search_string}" -T search -p "(search up)" { send-keys -X search-backward-incremental "%%" }
+1783499626.107778 args_parse_flags: next -Tcopy-mode
+1783499626.107779 args_parse_flag_argument: -T = copy-mode
+1783499626.107780 args_parse_flags: next C-r
+1783499626.107781 args_parse: flags end at 2 of 4
+1783499626.107783 args_parse: 2 = C-r (type STRING)
+1783499626.107790 args_parse: 3 = command-prompt -i -I "#{pane_search_string}" -T search -p "(search up)" { send-keys -X search-backward-incremental "%%" } (type COMMANDS)
+1783499626.107799 cmd_parse_build_commands: bind-key -T copy-mode C-r { command-prompt -i -I "#{pane_search_string}" -T search -p "(search up)" { send-keys -X search-backward-incremental "%%" } }
+1783499626.107802 cmdq_get_command: [bind-key/0x58e472506120] group 1371
+1783499626.107804 cmdq_append <global>: [bind-key/0x58e472506120]
+1783499626.107806 yylex_token: end at WS
+1783499626.107807 yylex_token: bind
+1783499626.107809 yylex_token: end at WS
+1783499626.107810 yylex_token: -Tcopy-mode
+1783499626.107811 yylex_token: end at WS
+1783499626.107812 yylex_token: C-s
+1783499626.107813 yylex_token: end at WS
+1783499626.107815 yylex_token: command-prompt
+1783499626.107816 yylex_token: end at WS
+1783499626.107817 yylex_token: -T
+1783499626.107818 yylex_token: end at WS
+1783499626.107819 yylex_token: search
+1783499626.107821 yylex_token: end at WS
+1783499626.107822 yylex_token: -ip(search down)
+1783499626.107824 yylex_token: end at WS
+1783499626.107825 yylex_token: -I#{pane_search_string}
+1783499626.107826 yylex_token: end at WS
+1783499626.107827 yylex_token: send
+1783499626.107828 yylex_token: end at WS
+1783499626.107829 yylex_token: -X
+1783499626.107831 yylex_token: end at WS
+1783499626.107833 yylex_token: search-forward-incremental
+1783499626.107834 yylex_token: end at WS
+1783499626.107835 yylex_token: %%
+1783499626.107838 cmd_parse_build_commands 0:0: bind
+1783499626.107839 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.107840 cmd_parse_build_commands 0:2: C-s
+1783499626.107842 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.107844 cmd_parse_build_commands 0:3 0:1: -T
+1783499626.107845 cmd_parse_build_commands 0:3 0:2: search
+1783499626.107846 cmd_parse_build_commands 0:3 0:3: -ip(search down)
+1783499626.107848 cmd_parse_build_commands 0:3 0:4: -I#{pane_search_string}
+1783499626.107850 cmd_parse_build_commands 0:3 0:5 0:0: send
+1783499626.107851 cmd_parse_build_commands 0:3 0:5 0:1: -X
+1783499626.107853 cmd_parse_build_commands 0:3 0:5 0:2: search-forward-incremental
+1783499626.107854 cmd_parse_build_commands 0:3 0:5 0:3: %%
+1783499626.107856 cmd_parse_build_commands 0:0: command-prompt
+1783499626.107857 cmd_parse_build_commands 0:1: -T
+1783499626.107859 cmd_parse_build_commands 0:2: search
+1783499626.107860 cmd_parse_build_commands 0:3: -ip(search down)
+1783499626.107862 cmd_parse_build_commands 0:4: -I#{pane_search_string}
+1783499626.107863 cmd_parse_build_commands 0:5 0:0: send
+1783499626.107865 cmd_parse_build_commands 0:5 0:1: -X
+1783499626.107866 cmd_parse_build_commands 0:5 0:2: search-forward-incremental
+1783499626.107868 cmd_parse_build_commands 0:5 0:3: %%
+1783499626.107870 cmd_parse_build_commands 0:0: send
+1783499626.107871 cmd_parse_build_commands 0:1: -X
+1783499626.107872 cmd_parse_build_commands 0:2: search-forward-incremental
+1783499626.107874 cmd_parse_build_commands 0:3: %%
+1783499626.107877 args_parse_flags: next -X
+1783499626.107878 args_parse_flags: -X
+1783499626.107880 args_parse_flags: next search-forward-incremental
+1783499626.107881 args_parse: flags end at 2 of 4
+1783499626.107883 args_parse: 2 = search-forward-incremental (type STRING)
+1783499626.107884 args_parse: 3 = %% (type STRING)
+1783499626.107887 cmd_parse_build_commands: send-keys -X search-forward-incremental "%%"
+1783499626.107892 args_parse_flags: next -T
+1783499626.107893 args_parse_flag_argument: -T = search
+1783499626.107895 args_parse_flags: next -ip(search down)
+1783499626.107896 args_parse_flags: -i
+1783499626.107897 args_parse_flag_argument: -p = (search down)
+1783499626.107899 args_parse_flags: next -I#{pane_search_string}
+1783499626.107901 args_parse_flag_argument: -I = #{pane_search_string}
+1783499626.107903 args_parse: flags end at 5 of 6
+1783499626.107906 args_parse: 5 = send-keys -X search-forward-incremental "%%" (type COMMANDS)
+1783499626.107913 cmd_parse_build_commands: command-prompt -i -I "#{pane_search_string}" -T search -p "(search down)" { send-keys -X search-forward-incremental "%%" }
+1783499626.107915 args_parse_flags: next -Tcopy-mode
+1783499626.107916 args_parse_flag_argument: -T = copy-mode
+1783499626.107917 args_parse_flags: next C-s
+1783499626.107918 args_parse: flags end at 2 of 4
+1783499626.107920 args_parse: 2 = C-s (type STRING)
+1783499626.107926 args_parse: 3 = command-prompt -i -I "#{pane_search_string}" -T search -p "(search down)" { send-keys -X search-forward-incremental "%%" } (type COMMANDS)
+1783499626.107934 cmd_parse_build_commands: bind-key -T copy-mode C-s { command-prompt -i -I "#{pane_search_string}" -T search -p "(search down)" { send-keys -X search-forward-incremental "%%" } }
+1783499626.107937 cmdq_get_command: [bind-key/0x58e472506920] group 1383
+1783499626.107939 cmdq_append <global>: [bind-key/0x58e472506920]
+1783499626.107941 yylex_token: end at WS
+1783499626.107942 yylex_token: bind
+1783499626.107944 yylex_token: end at WS
+1783499626.107945 yylex_token: -Tcopy-mode
+1783499626.107946 yylex_token: end at WS
+1783499626.107947 yylex_token: C-v
+1783499626.107948 yylex_token: end at WS
+1783499626.107949 yylex_token: send
+1783499626.107950 yylex_token: end at WS
+1783499626.107951 yylex_token: -X
+1783499626.107953 yylex_token: end at WS
+1783499626.107954 yylex_token: page-down
+1783499626.107956 cmd_parse_build_commands 0:0: bind
+1783499626.107958 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.107959 cmd_parse_build_commands 0:2: C-v
+1783499626.107960 cmd_parse_build_commands 0:3 0:0: send
+1783499626.107962 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.107963 cmd_parse_build_commands 0:3 0:2: page-down
+1783499626.107965 cmd_parse_build_commands 0:0: send
+1783499626.107966 cmd_parse_build_commands 0:1: -X
+1783499626.107968 cmd_parse_build_commands 0:2: page-down
+1783499626.107970 args_parse_flags: next -X
+1783499626.107972 args_parse_flags: -X
+1783499626.107973 args_parse_flags: next page-down
+1783499626.107974 args_parse: flags end at 2 of 3
+1783499626.107975 args_parse: 2 = page-down (type STRING)
+1783499626.107978 cmd_parse_build_commands: send-keys -X page-down
+1783499626.107979 args_parse_flags: next -Tcopy-mode
+1783499626.107981 args_parse_flag_argument: -T = copy-mode
+1783499626.107982 args_parse_flags: next C-v
+1783499626.107983 args_parse: flags end at 2 of 4
+1783499626.107985 args_parse: 2 = C-v (type STRING)
+1783499626.107987 args_parse: 3 = send-keys -X page-down (type COMMANDS)
+1783499626.107991 cmd_parse_build_commands: bind-key -T copy-mode C-v { send-keys -X page-down }
+1783499626.107994 cmdq_get_command: [bind-key/0x58e4725075c0] group 1395
+1783499626.107995 cmdq_append <global>: [bind-key/0x58e4725075c0]
+1783499626.108007 yylex_token: end at WS
+1783499626.108011 yylex_token: bind
+1783499626.108013 yylex_token: end at WS
+1783499626.108014 yylex_token: -Tcopy-mode
+1783499626.108015 yylex_token: end at WS
+1783499626.108017 yylex_token: C-w
+1783499626.108018 yylex_token: end at WS
+1783499626.108019 yylex_token: send
+1783499626.108020 yylex_token: end at WS
+1783499626.108021 yylex_token: -X
+1783499626.108023 yylex_token: end at WS
+1783499626.108024 yylex_token: copy-pipe-and-cancel
+1783499626.108026 cmd_parse_build_commands 0:0: bind
+1783499626.108027 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.108029 cmd_parse_build_commands 0:2: C-w
+1783499626.108030 cmd_parse_build_commands 0:3 0:0: send
+1783499626.108032 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.108036 cmd_parse_build_commands 0:3 0:2: copy-pipe-and-cancel
+1783499626.108039 cmd_parse_build_commands 0:0: send
+1783499626.108040 cmd_parse_build_commands 0:1: -X
+1783499626.108041 cmd_parse_build_commands 0:2: copy-pipe-and-cancel
+1783499626.108045 args_parse_flags: next -X
+1783499626.108046 args_parse_flags: -X
+1783499626.108047 args_parse_flags: next copy-pipe-and-cancel
+1783499626.108049 args_parse: flags end at 2 of 3
+1783499626.108050 args_parse: 2 = copy-pipe-and-cancel (type STRING)
+1783499626.108054 cmd_parse_build_commands: send-keys -X copy-pipe-and-cancel
+1783499626.108055 args_parse_flags: next -Tcopy-mode
+1783499626.108056 args_parse_flag_argument: -T = copy-mode
+1783499626.108058 args_parse_flags: next C-w
+1783499626.108059 args_parse: flags end at 2 of 4
+1783499626.108060 args_parse: 2 = C-w (type STRING)
+1783499626.108063 args_parse: 3 = send-keys -X copy-pipe-and-cancel (type COMMANDS)
+1783499626.108067 cmd_parse_build_commands: bind-key -T copy-mode C-w { send-keys -X copy-pipe-and-cancel }
+1783499626.108069 cmdq_get_command: [bind-key/0x58e4725079f0] group 1403
+1783499626.108071 cmdq_append <global>: [bind-key/0x58e4725079f0]
+1783499626.108074 yylex_token: end at WS
+1783499626.108075 yylex_token: bind
+1783499626.108076 yylex_token: end at WS
+1783499626.108077 yylex_token: -Tcopy-mode
+1783499626.108079 yylex_token: end at WS
+1783499626.108080 yylex_token: Escape
+1783499626.108081 yylex_token: end at WS
+1783499626.108082 yylex_token: send
+1783499626.108083 yylex_token: end at WS
+1783499626.108084 yylex_token: -X
+1783499626.108086 yylex_token: end at WS
+1783499626.108087 yylex_token: cancel
+1783499626.108089 cmd_parse_build_commands 0:0: bind
+1783499626.108090 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.108091 cmd_parse_build_commands 0:2: Escape
+1783499626.108093 cmd_parse_build_commands 0:3 0:0: send
+1783499626.108094 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.108095 cmd_parse_build_commands 0:3 0:2: cancel
+1783499626.108097 cmd_parse_build_commands 0:0: send
+1783499626.108098 cmd_parse_build_commands 0:1: -X
+1783499626.108099 cmd_parse_build_commands 0:2: cancel
+1783499626.108102 args_parse_flags: next -X
+1783499626.108103 args_parse_flags: -X
+1783499626.108105 args_parse_flags: next cancel
+1783499626.108106 args_parse: flags end at 2 of 3
+1783499626.108107 args_parse: 2 = cancel (type STRING)
+1783499626.108110 cmd_parse_build_commands: send-keys -X cancel
+1783499626.108111 args_parse_flags: next -Tcopy-mode
+1783499626.108113 args_parse_flag_argument: -T = copy-mode
+1783499626.108114 args_parse_flags: next Escape
+1783499626.108115 args_parse: flags end at 2 of 4
+1783499626.108116 args_parse: 2 = Escape (type STRING)
+1783499626.108119 args_parse: 3 = send-keys -X cancel (type COMMANDS)
+1783499626.108123 cmd_parse_build_commands: bind-key -T copy-mode Escape { send-keys -X cancel }
+1783499626.108125 cmdq_get_command: [bind-key/0x58e472507e20] group 1411
+1783499626.108127 cmdq_append <global>: [bind-key/0x58e472507e20]
+1783499626.108129 yylex_token: end at WS
+1783499626.108130 yylex_token: bind
+1783499626.108132 yylex_token: end at WS
+1783499626.108133 yylex_token: -Tcopy-mode
+1783499626.108134 yylex_token: end at WS
+1783499626.108136 yylex_token: Space
+1783499626.108137 yylex_token: end at WS
+1783499626.108138 yylex_token: send
+1783499626.108139 yylex_token: end at WS
+1783499626.108140 yylex_token: -X
+1783499626.108141 yylex_token: end at WS
+1783499626.108142 yylex_token: page-down
+1783499626.108144 cmd_parse_build_commands 0:0: bind
+1783499626.108145 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.108147 cmd_parse_build_commands 0:2: Space
+1783499626.108148 cmd_parse_build_commands 0:3 0:0: send
+1783499626.108150 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.108151 cmd_parse_build_commands 0:3 0:2: page-down
+1783499626.108153 cmd_parse_build_commands 0:0: send
+1783499626.108154 cmd_parse_build_commands 0:1: -X
+1783499626.108155 cmd_parse_build_commands 0:2: page-down
+1783499626.108158 args_parse_flags: next -X
+1783499626.108159 args_parse_flags: -X
+1783499626.108163 args_parse_flags: next page-down
+1783499626.108164 args_parse: flags end at 2 of 3
+1783499626.108166 args_parse: 2 = page-down (type STRING)
+1783499626.108168 cmd_parse_build_commands: send-keys -X page-down
+1783499626.108170 args_parse_flags: next -Tcopy-mode
+1783499626.108171 args_parse_flag_argument: -T = copy-mode
+1783499626.108172 args_parse_flags: next Space
+1783499626.108174 args_parse: flags end at 2 of 4
+1783499626.108175 args_parse: 2 = Space (type STRING)
+1783499626.108177 args_parse: 3 = send-keys -X page-down (type COMMANDS)
+1783499626.108182 cmd_parse_build_commands: bind-key -T copy-mode Space { send-keys -X page-down }
+1783499626.108184 cmdq_get_command: [bind-key/0x58e4725083e0] group 1419
+1783499626.108185 cmdq_append <global>: [bind-key/0x58e4725083e0]
+1783499626.108254 yylex_token: end at WS
+1783499626.108261 yylex_token: bind
+1783499626.108264 yylex_token: end at WS
+1783499626.108266 yylex_token: -Tcopy-mode
+1783499626.108268 yylex_token: end at WS
+1783499626.108269 yylex_token: ,
+1783499626.108271 yylex_token: end at WS
+1783499626.108272 yylex_token: send
+1783499626.108274 yylex_token: end at WS
+1783499626.108275 yylex_token: -X
+1783499626.108277 yylex_token: end at WS
+1783499626.108278 yylex_token: jump-reverse
+1783499626.108281 cmd_parse_build_commands 0:0: bind
+1783499626.108283 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.108285 cmd_parse_build_commands 0:2: ,
+1783499626.108286 cmd_parse_build_commands 0:3 0:0: send
+1783499626.108288 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.108289 cmd_parse_build_commands 0:3 0:2: jump-reverse
+1783499626.108293 cmd_parse_build_commands 0:0: send
+1783499626.108294 cmd_parse_build_commands 0:1: -X
+1783499626.108295 cmd_parse_build_commands 0:2: jump-reverse
+1783499626.108299 args_parse_flags: next -X
+1783499626.108301 args_parse_flags: -X
+1783499626.108302 args_parse_flags: next jump-reverse
+1783499626.108304 args_parse: flags end at 2 of 3
+1783499626.108305 args_parse: 2 = jump-reverse (type STRING)
+1783499626.108310 cmd_parse_build_commands: send-keys -X jump-reverse
+1783499626.108312 args_parse_flags: next -Tcopy-mode
+1783499626.108313 args_parse_flag_argument: -T = copy-mode
+1783499626.108315 args_parse_flags: next ,
+1783499626.108316 args_parse: flags end at 2 of 4
+1783499626.108318 args_parse: 2 = , (type STRING)
+1783499626.108321 args_parse: 3 = send-keys -X jump-reverse (type COMMANDS)
+1783499626.108326 cmd_parse_build_commands: bind-key -T copy-mode , { send-keys -X jump-reverse }
+1783499626.108329 cmdq_get_command: [bind-key/0x58e472508850] group 1427
+1783499626.108330 cmdq_append <global>: [bind-key/0x58e472508850]
+1783499626.108334 yylex_token: end at WS
+1783499626.108335 yylex_token: bind
+1783499626.108337 yylex_token: end at WS
+1783499626.108338 yylex_token: -Tcopy-mode
+1783499626.108339 yylex_token: end at WS
+1783499626.108340 yylex_token: ;
+1783499626.108342 yylex_token: end at WS
+1783499626.108343 yylex_token: send
+1783499626.108344 yylex_token: end at WS
+1783499626.108345 yylex_token: -X
+1783499626.108347 yylex_token: end at WS
+1783499626.108348 yylex_token: jump-again
+1783499626.108350 cmd_parse_build_commands 0:0: bind
+1783499626.108352 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.108353 cmd_parse_build_commands 0:2: ;
+1783499626.108355 cmd_parse_build_commands 0:3 0:0: send
+1783499626.108356 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.108357 cmd_parse_build_commands 0:3 0:2: jump-again
+1783499626.108359 cmd_parse_build_commands 0:0: send
+1783499626.108361 cmd_parse_build_commands 0:1: -X
+1783499626.108362 cmd_parse_build_commands 0:2: jump-again
+1783499626.108365 args_parse_flags: next -X
+1783499626.108366 args_parse_flags: -X
+1783499626.108368 args_parse_flags: next jump-again
+1783499626.108369 args_parse: flags end at 2 of 3
+1783499626.108371 args_parse: 2 = jump-again (type STRING)
+1783499626.108374 cmd_parse_build_commands: send-keys -X jump-again
+1783499626.108375 args_parse_flags: next -Tcopy-mode
+1783499626.108377 args_parse_flag_argument: -T = copy-mode
+1783499626.108378 args_parse_flags: next ;
+1783499626.108386 args_parse: flags end at 2 of 4
+1783499626.108388 args_parse: 2 = ; (type STRING)
+1783499626.108391 args_parse: 3 = send-keys -X jump-again (type COMMANDS)
+1783499626.108396 cmd_parse_build_commands: bind-key -T copy-mode \\; { send-keys -X jump-again }
+1783499626.108398 cmdq_get_command: [bind-key/0x58e472508b30] group 1435
+1783499626.108400 cmdq_append <global>: [bind-key/0x58e472508b30]
+1783499626.108403 yylex_token: end at WS
+1783499626.108404 yylex_token: bind
+1783499626.108405 yylex_token: end at WS
+1783499626.108406 yylex_token: -Tcopy-mode
+1783499626.108408 yylex_token: end at WS
+1783499626.108409 yylex_token: F
+1783499626.108411 yylex_token: end at WS
+1783499626.108412 yylex_token: command-prompt
+1783499626.108414 yylex_token: end at WS
+1783499626.108415 yylex_token: -1p(jump backward)
+1783499626.108416 yylex_token: end at WS
+1783499626.108417 yylex_token: send
+1783499626.108419 yylex_token: end at WS
+1783499626.108420 yylex_token: -X
+1783499626.108421 yylex_token: end at WS
+1783499626.108423 yylex_token: jump-backward
+1783499626.108424 yylex_token: end at WS
+1783499626.108425 yylex_token: %%
+1783499626.108433 cmd_parse_build_commands 0:0: bind
+1783499626.108438 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.108439 cmd_parse_build_commands 0:2: F
+1783499626.108441 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.108443 cmd_parse_build_commands 0:3 0:1: -1p(jump backward)
+1783499626.108445 cmd_parse_build_commands 0:3 0:2 0:0: send
+1783499626.108446 cmd_parse_build_commands 0:3 0:2 0:1: -X
+1783499626.108448 cmd_parse_build_commands 0:3 0:2 0:2: jump-backward
+1783499626.108449 cmd_parse_build_commands 0:3 0:2 0:3: %%
+1783499626.108452 cmd_parse_build_commands 0:0: command-prompt
+1783499626.108453 cmd_parse_build_commands 0:1: -1p(jump backward)
+1783499626.108455 cmd_parse_build_commands 0:2 0:0: send
+1783499626.108456 cmd_parse_build_commands 0:2 0:1: -X
+1783499626.108458 cmd_parse_build_commands 0:2 0:2: jump-backward
+1783499626.108459 cmd_parse_build_commands 0:2 0:3: %%
+1783499626.108461 cmd_parse_build_commands 0:0: send
+1783499626.108462 cmd_parse_build_commands 0:1: -X
+1783499626.108464 cmd_parse_build_commands 0:2: jump-backward
+1783499626.108465 cmd_parse_build_commands 0:3: %%
+1783499626.108468 args_parse_flags: next -X
+1783499626.108470 args_parse_flags: -X
+1783499626.108471 args_parse_flags: next jump-backward
+1783499626.108472 args_parse: flags end at 2 of 4
+1783499626.108474 args_parse: 2 = jump-backward (type STRING)
+1783499626.108475 args_parse: 3 = %% (type STRING)
+1783499626.108479 cmd_parse_build_commands: send-keys -X jump-backward "%%"
+1783499626.108481 args_parse_flags: next -1p(jump backward)
+1783499626.108482 args_parse_flags: -1
+1783499626.108484 args_parse_flag_argument: -p = (jump backward)
+1783499626.108486 args_parse: flags end at 2 of 3
+1783499626.108489 args_parse: 2 = send-keys -X jump-backward "%%" (type COMMANDS)
+1783499626.108494 cmd_parse_build_commands: command-prompt -1 -p "(jump backward)" { send-keys -X jump-backward "%%" }
+1783499626.108496 args_parse_flags: next -Tcopy-mode
+1783499626.108497 args_parse_flag_argument: -T = copy-mode
+1783499626.108498 args_parse_flags: next F
+1783499626.108500 args_parse: flags end at 2 of 4
+1783499626.108501 args_parse: 2 = F (type STRING)
+1783499626.108506 args_parse: 3 = command-prompt -1 -p "(jump backward)" { send-keys -X jump-backward "%%" } (type COMMANDS)
+1783499626.108512 cmd_parse_build_commands: bind-key -T copy-mode F { command-prompt -1 -p "(jump backward)" { send-keys -X jump-backward "%%" } }
+1783499626.108515 cmdq_get_command: [bind-key/0x58e472509ac0] group 1443
+1783499626.108517 cmdq_append <global>: [bind-key/0x58e472509ac0]
+1783499626.108526 yylex_token: end at WS
+1783499626.108529 yylex_token: bind
+1783499626.108531 yylex_token: end at WS
+1783499626.108532 yylex_token: -Tcopy-mode
+1783499626.108534 yylex_token: end at WS
+1783499626.108535 yylex_token: N
+1783499626.108536 yylex_token: end at WS
+1783499626.108537 yylex_token: send
+1783499626.108539 yylex_token: end at WS
+1783499626.108615 yylex_token: -X
+1783499626.108622 yylex_token: end at WS
+1783499626.108624 yylex_token: search-reverse
+1783499626.108628 cmd_parse_build_commands 0:0: bind
+1783499626.108630 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.108631 cmd_parse_build_commands 0:2: N
+1783499626.108633 cmd_parse_build_commands 0:3 0:0: send
+1783499626.108635 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.108636 cmd_parse_build_commands 0:3 0:2: search-reverse
+1783499626.108639 cmd_parse_build_commands 0:0: send
+1783499626.108641 cmd_parse_build_commands 0:1: -X
+1783499626.108642 cmd_parse_build_commands 0:2: search-reverse
+1783499626.108646 args_parse_flags: next -X
+1783499626.108647 args_parse_flags: -X
+1783499626.108649 args_parse_flags: next search-reverse
+1783499626.108650 args_parse: flags end at 2 of 3
+1783499626.108652 args_parse: 2 = search-reverse (type STRING)
+1783499626.108657 cmd_parse_build_commands: send-keys -X search-reverse
+1783499626.108659 args_parse_flags: next -Tcopy-mode
+1783499626.108660 args_parse_flag_argument: -T = copy-mode
+1783499626.108661 args_parse_flags: next N
+1783499626.108663 args_parse: flags end at 2 of 4
+1783499626.108664 args_parse: 2 = N (type STRING)
+1783499626.108668 args_parse: 3 = send-keys -X search-reverse (type COMMANDS)
+1783499626.108673 cmd_parse_build_commands: bind-key -T copy-mode N { send-keys -X search-reverse }
+1783499626.108676 cmdq_get_command: [bind-key/0x58e472508d90] group 1455
+1783499626.108678 cmdq_append <global>: [bind-key/0x58e472508d90]
+1783499626.108681 yylex_token: end at WS
+1783499626.108682 yylex_token: bind
+1783499626.108684 yylex_token: end at WS
+1783499626.108685 yylex_token: -Tcopy-mode
+1783499626.108687 yylex_token: end at WS
+1783499626.108688 yylex_token: P
+1783499626.108689 yylex_token: end at WS
+1783499626.108691 yylex_token: send
+1783499626.108692 yylex_token: end at WS
+1783499626.108693 yylex_token: -X
+1783499626.108695 yylex_token: end at WS
+1783499626.108696 yylex_token: toggle-position
+1783499626.108698 cmd_parse_build_commands 0:0: bind
+1783499626.108700 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.108701 cmd_parse_build_commands 0:2: P
+1783499626.108702 cmd_parse_build_commands 0:3 0:0: send
+1783499626.108704 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.108705 cmd_parse_build_commands 0:3 0:2: toggle-position
+1783499626.108707 cmd_parse_build_commands 0:0: send
+1783499626.108709 cmd_parse_build_commands 0:1: -X
+1783499626.108710 cmd_parse_build_commands 0:2: toggle-position
+1783499626.108713 args_parse_flags: next -X
+1783499626.108714 args_parse_flags: -X
+1783499626.108716 args_parse_flags: next toggle-position
+1783499626.108717 args_parse: flags end at 2 of 3
+1783499626.108719 args_parse: 2 = toggle-position (type STRING)
+1783499626.108722 cmd_parse_build_commands: send-keys -X toggle-position
+1783499626.108724 args_parse_flags: next -Tcopy-mode
+1783499626.108725 args_parse_flag_argument: -T = copy-mode
+1783499626.108726 args_parse_flags: next P
+1783499626.108728 args_parse: flags end at 2 of 4
+1783499626.108729 args_parse: 2 = P (type STRING)
+1783499626.108732 args_parse: 3 = send-keys -X toggle-position (type COMMANDS)
+1783499626.108736 cmd_parse_build_commands: bind-key -T copy-mode P { send-keys -X toggle-position }
+1783499626.108738 cmdq_get_command: [bind-key/0x58e472509e80] group 1463
+1783499626.108740 cmdq_append <global>: [bind-key/0x58e472509e80]
+1783499626.108743 yylex_token: end at WS
+1783499626.108744 yylex_token: bind
+1783499626.108745 yylex_token: end at WS
+1783499626.108747 yylex_token: -Tcopy-mode
+1783499626.108748 yylex_token: end at WS
+1783499626.108749 yylex_token: R
+1783499626.108751 yylex_token: end at WS
+1783499626.108752 yylex_token: send
+1783499626.108753 yylex_token: end at WS
+1783499626.108754 yylex_token: -X
+1783499626.108756 yylex_token: end at WS
+1783499626.108757 yylex_token: rectangle-toggle
+1783499626.108759 cmd_parse_build_commands 0:0: bind
+1783499626.108761 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.108762 cmd_parse_build_commands 0:2: R
+1783499626.108763 cmd_parse_build_commands 0:3 0:0: send
+1783499626.108770 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.108772 cmd_parse_build_commands 0:3 0:2: rectangle-toggle
+1783499626.108774 cmd_parse_build_commands 0:0: send
+1783499626.108775 cmd_parse_build_commands 0:1: -X
+1783499626.108777 cmd_parse_build_commands 0:2: rectangle-toggle
+1783499626.108780 args_parse_flags: next -X
+1783499626.108781 args_parse_flags: -X
+1783499626.108782 args_parse_flags: next rectangle-toggle
+1783499626.108784 args_parse: flags end at 2 of 3
+1783499626.108785 args_parse: 2 = rectangle-toggle (type STRING)
+1783499626.108788 cmd_parse_build_commands: send-keys -X rectangle-toggle
+1783499626.108790 args_parse_flags: next -Tcopy-mode
+1783499626.108791 args_parse_flag_argument: -T = copy-mode
+1783499626.108792 args_parse_flags: next R
+1783499626.108794 args_parse: flags end at 2 of 4
+1783499626.108795 args_parse: 2 = R (type STRING)
+1783499626.108798 args_parse: 3 = send-keys -X rectangle-toggle (type COMMANDS)
+1783499626.108802 cmd_parse_build_commands: bind-key -T copy-mode R { send-keys -X rectangle-toggle }
+1783499626.108805 cmdq_get_command: [bind-key/0x58e47250a200] group 1471
+1783499626.108806 cmdq_append <global>: [bind-key/0x58e47250a200]
+1783499626.108809 yylex_token: end at WS
+1783499626.108810 yylex_token: bind
+1783499626.108812 yylex_token: end at WS
+1783499626.108813 yylex_token: -Tcopy-mode
+1783499626.108814 yylex_token: end at WS
+1783499626.108815 yylex_token: T
+1783499626.108817 yylex_token: end at WS
+1783499626.108818 yylex_token: command-prompt
+1783499626.108820 yylex_token: end at WS
+1783499626.108822 yylex_token: -1p(jump to backward)
+1783499626.108823 yylex_token: end at WS
+1783499626.108824 yylex_token: send
+1783499626.108825 yylex_token: end at WS
+1783499626.108827 yylex_token: -X
+1783499626.108828 yylex_token: end at WS
+1783499626.108829 yylex_token: jump-to-backward
+1783499626.108831 yylex_token: end at WS
+1783499626.108832 yylex_token: %%
+1783499626.108834 cmd_parse_build_commands 0:0: bind
+1783499626.108836 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.108837 cmd_parse_build_commands 0:2: T
+1783499626.108839 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.108841 cmd_parse_build_commands 0:3 0:1: -1p(jump to backward)
+1783499626.108842 cmd_parse_build_commands 0:3 0:2 0:0: send
+1783499626.108843 cmd_parse_build_commands 0:3 0:2 0:1: -X
+1783499626.108845 cmd_parse_build_commands 0:3 0:2 0:2: jump-to-backward
+1783499626.108846 cmd_parse_build_commands 0:3 0:2 0:3: %%
+1783499626.108848 cmd_parse_build_commands 0:0: command-prompt
+1783499626.108850 cmd_parse_build_commands 0:1: -1p(jump to backward)
+1783499626.108852 cmd_parse_build_commands 0:2 0:0: send
+1783499626.108853 cmd_parse_build_commands 0:2 0:1: -X
+1783499626.108854 cmd_parse_build_commands 0:2 0:2: jump-to-backward
+1783499626.108856 cmd_parse_build_commands 0:2 0:3: %%
+1783499626.108858 cmd_parse_build_commands 0:0: send
+1783499626.108859 cmd_parse_build_commands 0:1: -X
+1783499626.108860 cmd_parse_build_commands 0:2: jump-to-backward
+1783499626.108862 cmd_parse_build_commands 0:3: %%
+1783499626.108865 args_parse_flags: next -X
+1783499626.108866 args_parse_flags: -X
+1783499626.108868 args_parse_flags: next jump-to-backward
+1783499626.108869 args_parse: flags end at 2 of 4
+1783499626.108871 args_parse: 2 = jump-to-backward (type STRING)
+1783499626.108873 args_parse: 3 = %% (type STRING)
+1783499626.108876 cmd_parse_build_commands: send-keys -X jump-to-backward "%%"
+1783499626.108878 args_parse_flags: next -1p(jump to backward)
+1783499626.108879 args_parse_flags: -1
+1783499626.108881 args_parse_flag_argument: -p = (jump to backward)
+1783499626.108882 args_parse: flags end at 2 of 3
+1783499626.108885 args_parse: 2 = send-keys -X jump-to-backward "%%" (type COMMANDS)
+1783499626.108890 cmd_parse_build_commands: command-prompt -1 -p "(jump to backward)" { send-keys -X jump-to-backward "%%" }
+1783499626.108892 args_parse_flags: next -Tcopy-mode
+1783499626.108893 args_parse_flag_argument: -T = copy-mode
+1783499626.108895 args_parse_flags: next T
+1783499626.108896 args_parse: flags end at 2 of 4
+1783499626.108901 args_parse: 2 = T (type STRING)
+1783499626.108914 args_parse: 3 = command-prompt -1 -p "(jump to backward)" { send-keys -X jump-to-backward "%%" } (type COMMANDS)
+1783499626.108925 cmd_parse_build_commands: bind-key -T copy-mode T { command-prompt -1 -p "(jump to backward)" { send-keys -X jump-to-backward "%%" } }
+1783499626.108928 cmdq_get_command: [bind-key/0x58e47250b1e0] group 1479
+1783499626.108930 cmdq_append <global>: [bind-key/0x58e47250b1e0]
+1783499626.108934 yylex_token: end at WS
+1783499626.108935 yylex_token: bind
+1783499626.108937 yylex_token: end at WS
+1783499626.108939 yylex_token: -Tcopy-mode
+1783499626.108940 yylex_token: end at WS
+1783499626.108941 yylex_token: X
+1783499626.108943 yylex_token: end at WS
+1783499626.108944 yylex_token: send
+1783499626.108945 yylex_token: end at WS
+1783499626.108946 yylex_token: -X
+1783499626.108948 yylex_token: end at WS
+1783499626.108949 yylex_token: set-mark
+1783499626.108951 cmd_parse_build_commands 0:0: bind
+1783499626.108952 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.108954 cmd_parse_build_commands 0:2: X
+1783499626.108955 cmd_parse_build_commands 0:3 0:0: send
+1783499626.108957 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.108958 cmd_parse_build_commands 0:3 0:2: set-mark
+1783499626.108960 cmd_parse_build_commands 0:0: send
+1783499626.108961 cmd_parse_build_commands 0:1: -X
+1783499626.108962 cmd_parse_build_commands 0:2: set-mark
+1783499626.108966 args_parse_flags: next -X
+1783499626.108967 args_parse_flags: -X
+1783499626.108968 args_parse_flags: next set-mark
+1783499626.108969 args_parse: flags end at 2 of 3
+1783499626.108971 args_parse: 2 = set-mark (type STRING)
+1783499626.108974 cmd_parse_build_commands: send-keys -X set-mark
+1783499626.108975 args_parse_flags: next -Tcopy-mode
+1783499626.108976 args_parse_flag_argument: -T = copy-mode
+1783499626.108978 args_parse_flags: next X
+1783499626.108979 args_parse: flags end at 2 of 4
+1783499626.108980 args_parse: 2 = X (type STRING)
+1783499626.108983 args_parse: 3 = send-keys -X set-mark (type COMMANDS)
+1783499626.108987 cmd_parse_build_commands: bind-key -T copy-mode X { send-keys -X set-mark }
+1783499626.108990 cmdq_get_command: [bind-key/0x58e47250a450] group 1491
+1783499626.108991 cmdq_append <global>: [bind-key/0x58e47250a450]
+1783499626.108994 yylex_token: end at WS
+1783499626.108995 yylex_token: bind
+1783499626.108997 yylex_token: end at WS
+1783499626.108998 yylex_token: -Tcopy-mode
+1783499626.109000 yylex_token: end at WS
+1783499626.109001 yylex_token: f
+1783499626.109003 yylex_token: end at WS
+1783499626.109004 yylex_token: command-prompt
+1783499626.109006 yylex_token: end at WS
+1783499626.109007 yylex_token: -1p(jump forward)
+1783499626.109008 yylex_token: end at WS
+1783499626.109009 yylex_token: send
+1783499626.109010 yylex_token: end at WS
+1783499626.109012 yylex_token: -X
+1783499626.109013 yylex_token: end at WS
+1783499626.109014 yylex_token: jump-forward
+1783499626.109016 yylex_token: end at WS
+1783499626.109017 yylex_token: %%
+1783499626.109019 cmd_parse_build_commands 0:0: bind
+1783499626.109021 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.109022 cmd_parse_build_commands 0:2: f
+1783499626.109023 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.109025 cmd_parse_build_commands 0:3 0:1: -1p(jump forward)
+1783499626.109027 cmd_parse_build_commands 0:3 0:2 0:0: send
+1783499626.109028 cmd_parse_build_commands 0:3 0:2 0:1: -X
+1783499626.109029 cmd_parse_build_commands 0:3 0:2 0:2: jump-forward
+1783499626.109031 cmd_parse_build_commands 0:3 0:2 0:3: %%
+1783499626.109033 cmd_parse_build_commands 0:0: command-prompt
+1783499626.109034 cmd_parse_build_commands 0:1: -1p(jump forward)
+1783499626.109036 cmd_parse_build_commands 0:2 0:0: send
+1783499626.109037 cmd_parse_build_commands 0:2 0:1: -X
+1783499626.109038 cmd_parse_build_commands 0:2 0:2: jump-forward
+1783499626.109040 cmd_parse_build_commands 0:2 0:3: %%
+1783499626.109041 cmd_parse_build_commands 0:0: send
+1783499626.109043 cmd_parse_build_commands 0:1: -X
+1783499626.109044 cmd_parse_build_commands 0:2: jump-forward
+1783499626.109048 cmd_parse_build_commands 0:3: %%
+1783499626.109052 args_parse_flags: next -X
+1783499626.109053 args_parse_flags: -X
+1783499626.109054 args_parse_flags: next jump-forward
+1783499626.109055 args_parse: flags end at 2 of 4
+1783499626.109057 args_parse: 2 = jump-forward (type STRING)
+1783499626.109058 args_parse: 3 = %% (type STRING)
+1783499626.109062 cmd_parse_build_commands: send-keys -X jump-forward "%%"
+1783499626.109063 args_parse_flags: next -1p(jump forward)
+1783499626.109065 args_parse_flags: -1
+1783499626.109066 args_parse_flag_argument: -p = (jump forward)
+1783499626.109067 args_parse: flags end at 2 of 3
+1783499626.109070 args_parse: 2 = send-keys -X jump-forward "%%" (type COMMANDS)
+1783499626.109075 cmd_parse_build_commands: command-prompt -1 -p "(jump forward)" { send-keys -X jump-forward "%%" }
+1783499626.109076 args_parse_flags: next -Tcopy-mode
+1783499626.109078 args_parse_flag_argument: -T = copy-mode
+1783499626.109079 args_parse_flags: next f
+1783499626.109080 args_parse: flags end at 2 of 4
+1783499626.109081 args_parse: 2 = f (type STRING)
+1783499626.109086 args_parse: 3 = command-prompt -1 -p "(jump forward)" { send-keys -X jump-forward "%%" } (type COMMANDS)
+1783499626.109091 cmd_parse_build_commands: bind-key -T copy-mode f { command-prompt -1 -p "(jump forward)" { send-keys -X jump-forward "%%" } }
+1783499626.109101 cmdq_get_command: [bind-key/0x58e47250c050] group 1499
+1783499626.109105 cmdq_append <global>: [bind-key/0x58e47250c050]
+1783499626.109110 yylex_token: end at WS
+1783499626.109111 yylex_token: bind
+1783499626.109113 yylex_token: end at WS
+1783499626.109114 yylex_token: -Tcopy-mode
+1783499626.109115 yylex_token: end at WS
+1783499626.109116 yylex_token: g
+1783499626.109118 yylex_token: end at WS
+1783499626.109119 yylex_token: command-prompt
+1783499626.109121 yylex_token: end at WS
+1783499626.109122 yylex_token: -p(goto line)
+1783499626.109123 yylex_token: end at WS
+1783499626.109124 yylex_token: send
+1783499626.109125 yylex_token: end at WS
+1783499626.109126 yylex_token: -X
+1783499626.109128 yylex_token: end at WS
+1783499626.109129 yylex_token: goto-line
+1783499626.109131 yylex_token: end at WS
+1783499626.109132 yylex_token: %%
+1783499626.109134 cmd_parse_build_commands 0:0: bind
+1783499626.109135 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.109136 cmd_parse_build_commands 0:2: g
+1783499626.109138 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.109139 cmd_parse_build_commands 0:3 0:1: -p(goto line)
+1783499626.109141 cmd_parse_build_commands 0:3 0:2 0:0: send
+1783499626.109142 cmd_parse_build_commands 0:3 0:2 0:1: -X
+1783499626.109144 cmd_parse_build_commands 0:3 0:2 0:2: goto-line
+1783499626.109145 cmd_parse_build_commands 0:3 0:2 0:3: %%
+1783499626.109147 cmd_parse_build_commands 0:0: command-prompt
+1783499626.109149 cmd_parse_build_commands 0:1: -p(goto line)
+1783499626.109150 cmd_parse_build_commands 0:2 0:0: send
+1783499626.109151 cmd_parse_build_commands 0:2 0:1: -X
+1783499626.109152 cmd_parse_build_commands 0:2 0:2: goto-line
+1783499626.109154 cmd_parse_build_commands 0:2 0:3: %%
+1783499626.109155 cmd_parse_build_commands 0:0: send
+1783499626.109156 cmd_parse_build_commands 0:1: -X
+1783499626.109158 cmd_parse_build_commands 0:2: goto-line
+1783499626.109159 cmd_parse_build_commands 0:3: %%
+1783499626.109162 args_parse_flags: next -X
+1783499626.109163 args_parse_flags: -X
+1783499626.109164 args_parse_flags: next goto-line
+1783499626.109166 args_parse: flags end at 2 of 4
+1783499626.109167 args_parse: 2 = goto-line (type STRING)
+1783499626.109168 args_parse: 3 = %% (type STRING)
+1783499626.109172 cmd_parse_build_commands: send-keys -X goto-line "%%"
+1783499626.109174 args_parse_flags: next -p(goto line)
+1783499626.109175 args_parse_flag_argument: -p = (goto line)
+1783499626.109176 args_parse: flags end at 2 of 3
+1783499626.109179 args_parse: 2 = send-keys -X goto-line "%%" (type COMMANDS)
+1783499626.109238 cmd_parse_build_commands: command-prompt -p "(goto line)" { send-keys -X goto-line "%%" }
+1783499626.109253 args_parse_flags: next -Tcopy-mode
+1783499626.109261 args_parse_flag_argument: -T = copy-mode
+1783499626.109263 args_parse_flags: next g
+1783499626.109265 args_parse: flags end at 2 of 4
+1783499626.109267 args_parse: 2 = g (type STRING)
+1783499626.109273 args_parse: 3 = command-prompt -p "(goto line)" { send-keys -X goto-line "%%" } (type COMMANDS)
+1783499626.109280 cmd_parse_build_commands: bind-key -T copy-mode g { command-prompt -p "(goto line)" { send-keys -X goto-line "%%" } }
+1783499626.109283 cmdq_get_command: [bind-key/0x58e47250c6c0] group 1511
+1783499626.109285 cmdq_append <global>: [bind-key/0x58e47250c6c0]
+1783499626.109297 yylex_token: end at WS
+1783499626.109301 yylex_token: bind
+1783499626.109303 yylex_token: end at WS
+1783499626.109305 yylex_token: -Tcopy-mode
+1783499626.109306 yylex_token: end at WS
+1783499626.109307 yylex_token: n
+1783499626.109309 yylex_token: end at WS
+1783499626.109310 yylex_token: send
+1783499626.109312 yylex_token: end at WS
+1783499626.109313 yylex_token: -X
+1783499626.109315 yylex_token: end at WS
+1783499626.109316 yylex_token: search-again
+1783499626.109320 cmd_parse_build_commands 0:0: bind
+1783499626.109321 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.109322 cmd_parse_build_commands 0:2: n
+1783499626.109324 cmd_parse_build_commands 0:3 0:0: send
+1783499626.109325 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.109327 cmd_parse_build_commands 0:3 0:2: search-again
+1783499626.109330 cmd_parse_build_commands 0:0: send
+1783499626.109331 cmd_parse_build_commands 0:1: -X
+1783499626.109333 cmd_parse_build_commands 0:2: search-again
+1783499626.109336 args_parse_flags: next -X
+1783499626.109337 args_parse_flags: -X
+1783499626.109339 args_parse_flags: next search-again
+1783499626.109340 args_parse: flags end at 2 of 3
+1783499626.109342 args_parse: 2 = search-again (type STRING)
+1783499626.109345 cmd_parse_build_commands: send-keys -X search-again
+1783499626.109347 args_parse_flags: next -Tcopy-mode
+1783499626.109348 args_parse_flag_argument: -T = copy-mode
+1783499626.109350 args_parse_flags: next n
+1783499626.109351 args_parse: flags end at 2 of 4
+1783499626.109353 args_parse: 2 = n (type STRING)
+1783499626.109356 args_parse: 3 = send-keys -X search-again (type COMMANDS)
+1783499626.109360 cmd_parse_build_commands: bind-key -T copy-mode n { send-keys -X search-again }
+1783499626.109382 cmdq_get_command: [bind-key/0x58e47250bd00] group 1523
+1783499626.109389 cmdq_append <global>: [bind-key/0x58e47250bd00]
+1783499626.109394 yylex_token: end at WS
+1783499626.109396 yylex_token: bind
+1783499626.109399 yylex_token: end at WS
+1783499626.109401 yylex_token: -Tcopy-mode
+1783499626.109403 yylex_token: end at WS
+1783499626.109404 yylex_token: q
+1783499626.109406 yylex_token: end at WS
+1783499626.109407 yylex_token: send
+1783499626.109409 yylex_token: end at WS
+1783499626.109410 yylex_token: -X
+1783499626.109412 yylex_token: end at WS
+1783499626.109414 yylex_token: cancel
+1783499626.109417 cmd_parse_build_commands 0:0: bind
+1783499626.109419 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.109420 cmd_parse_build_commands 0:2: q
+1783499626.109423 cmd_parse_build_commands 0:3 0:0: send
+1783499626.109424 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.109426 cmd_parse_build_commands 0:3 0:2: cancel
+1783499626.109429 cmd_parse_build_commands 0:0: send
+1783499626.109431 cmd_parse_build_commands 0:1: -X
+1783499626.109433 cmd_parse_build_commands 0:2: cancel
+1783499626.109437 args_parse_flags: next -X
+1783499626.109438 args_parse_flags: -X
+1783499626.109440 args_parse_flags: next cancel
+1783499626.109441 args_parse: flags end at 2 of 3
+1783499626.109443 args_parse: 2 = cancel (type STRING)
+1783499626.109448 cmd_parse_build_commands: send-keys -X cancel
+1783499626.109450 args_parse_flags: next -Tcopy-mode
+1783499626.109452 args_parse_flag_argument: -T = copy-mode
+1783499626.109453 args_parse_flags: next q
+1783499626.109455 args_parse: flags end at 2 of 4
+1783499626.109456 args_parse: 2 = q (type STRING)
+1783499626.109460 args_parse: 3 = send-keys -X cancel (type COMMANDS)
+1783499626.109465 cmd_parse_build_commands: bind-key -T copy-mode q { send-keys -X cancel }
+1783499626.109475 cmdq_get_command: [bind-key/0x58e47250ca30] group 1531
+1783499626.109477 cmdq_append <global>: [bind-key/0x58e47250ca30]
+1783499626.109480 yylex_token: end at WS
+1783499626.109481 yylex_token: bind
+1783499626.109483 yylex_token: end at WS
+1783499626.109485 yylex_token: -Tcopy-mode
+1783499626.109486 yylex_token: end at WS
+1783499626.109487 yylex_token: r
+1783499626.109489 yylex_token: end at WS
+1783499626.109490 yylex_token: send
+1783499626.109492 yylex_token: end at WS
+1783499626.109493 yylex_token: -X
+1783499626.109495 yylex_token: end at WS
+1783499626.109497 yylex_token: refresh-from-pane
+1783499626.109499 cmd_parse_build_commands 0:0: bind
+1783499626.109501 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.109503 cmd_parse_build_commands 0:2: r
+1783499626.109505 cmd_parse_build_commands 0:3 0:0: send
+1783499626.109506 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.109508 cmd_parse_build_commands 0:3 0:2: refresh-from-pane
+1783499626.109511 cmd_parse_build_commands 0:0: send
+1783499626.109513 cmd_parse_build_commands 0:1: -X
+1783499626.109515 cmd_parse_build_commands 0:2: refresh-from-pane
+1783499626.109518 args_parse_flags: next -X
+1783499626.109520 args_parse_flags: -X
+1783499626.109522 args_parse_flags: next refresh-from-pane
+1783499626.109523 args_parse: flags end at 2 of 3
+1783499626.109525 args_parse: 2 = refresh-from-pane (type STRING)
+1783499626.109529 cmd_parse_build_commands: send-keys -X refresh-from-pane
+1783499626.109531 args_parse_flags: next -Tcopy-mode
+1783499626.109533 args_parse_flag_argument: -T = copy-mode
+1783499626.109534 args_parse_flags: next r
+1783499626.109536 args_parse: flags end at 2 of 4
+1783499626.109538 args_parse: 2 = r (type STRING)
+1783499626.109541 args_parse: 3 = send-keys -X refresh-from-pane (type COMMANDS)
+1783499626.109546 cmd_parse_build_commands: bind-key -T copy-mode r { send-keys -X refresh-from-pane }
+1783499626.109549 cmdq_get_command: [bind-key/0x58e47250ceb0] group 1539
+1783499626.109551 cmdq_append <global>: [bind-key/0x58e47250ceb0]
+1783499626.109554 yylex_token: end at WS
+1783499626.109555 yylex_token: bind
+1783499626.109557 yylex_token: end at WS
+1783499626.109559 yylex_token: -Tcopy-mode
+1783499626.109560 yylex_token: end at WS
+1783499626.109561 yylex_token: t
+1783499626.109563 yylex_token: end at WS
+1783499626.109565 yylex_token: command-prompt
+1783499626.109567 yylex_token: end at WS
+1783499626.109568 yylex_token: -1p(jump to forward)
+1783499626.109570 yylex_token: end at WS
+1783499626.109571 yylex_token: send
+1783499626.109573 yylex_token: end at WS
+1783499626.109574 yylex_token: -X
+1783499626.109576 yylex_token: end at WS
+1783499626.109577 yylex_token: jump-to-forward
+1783499626.109579 yylex_token: end at WS
+1783499626.109580 yylex_token: %%
+1783499626.109583 cmd_parse_build_commands 0:0: bind
+1783499626.109585 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.109586 cmd_parse_build_commands 0:2: t
+1783499626.109588 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.109590 cmd_parse_build_commands 0:3 0:1: -1p(jump to forward)
+1783499626.109592 cmd_parse_build_commands 0:3 0:2 0:0: send
+1783499626.109594 cmd_parse_build_commands 0:3 0:2 0:1: -X
+1783499626.109596 cmd_parse_build_commands 0:3 0:2 0:2: jump-to-forward
+1783499626.109598 cmd_parse_build_commands 0:3 0:2 0:3: %%
+1783499626.109600 cmd_parse_build_commands 0:0: command-prompt
+1783499626.109602 cmd_parse_build_commands 0:1: -1p(jump to forward)
+1783499626.109604 cmd_parse_build_commands 0:2 0:0: send
+1783499626.109606 cmd_parse_build_commands 0:2 0:1: -X
+1783499626.109607 cmd_parse_build_commands 0:2 0:2: jump-to-forward
+1783499626.109609 cmd_parse_build_commands 0:2 0:3: %%
+1783499626.109611 cmd_parse_build_commands 0:0: send
+1783499626.109613 cmd_parse_build_commands 0:1: -X
+1783499626.109615 cmd_parse_build_commands 0:2: jump-to-forward
+1783499626.109616 cmd_parse_build_commands 0:3: %%
+1783499626.109620 args_parse_flags: next -X
+1783499626.109621 args_parse_flags: -X
+1783499626.109623 args_parse_flags: next jump-to-forward
+1783499626.109629 args_parse: flags end at 2 of 4
+1783499626.109631 args_parse: 2 = jump-to-forward (type STRING)
+1783499626.109633 args_parse: 3 = %% (type STRING)
+1783499626.109637 cmd_parse_build_commands: send-keys -X jump-to-forward "%%"
+1783499626.109639 args_parse_flags: next -1p(jump to forward)
+1783499626.109641 args_parse_flags: -1
+1783499626.109643 args_parse_flag_argument: -p = (jump to forward)
+1783499626.109645 args_parse: flags end at 2 of 3
+1783499626.109648 args_parse: 2 = send-keys -X jump-to-forward "%%" (type COMMANDS)
+1783499626.109654 cmd_parse_build_commands: command-prompt -1 -p "(jump to forward)" { send-keys -X jump-to-forward "%%" }
+1783499626.109656 args_parse_flags: next -Tcopy-mode
+1783499626.109658 args_parse_flag_argument: -T = copy-mode
+1783499626.109660 args_parse_flags: next t
+1783499626.109661 args_parse: flags end at 2 of 4
+1783499626.109663 args_parse: 2 = t (type STRING)
+1783499626.109668 args_parse: 3 = command-prompt -1 -p "(jump to forward)" { send-keys -X jump-to-forward "%%" } (type COMMANDS)
+1783499626.109676 cmd_parse_build_commands: bind-key -T copy-mode t { command-prompt -1 -p "(jump to forward)" { send-keys -X jump-to-forward "%%" } }
+1783499626.109692 cmdq_get_command: [bind-key/0x58e47250dec0] group 1547
+1783499626.109698 cmdq_append <global>: [bind-key/0x58e47250dec0]
+1783499626.109704 yylex_token: end at WS
+1783499626.109705 yylex_token: bind
+1783499626.109707 yylex_token: end at WS
+1783499626.109709 yylex_token: -Tcopy-mode
+1783499626.109710 yylex_token: end at WS
+1783499626.109712 yylex_token: Home
+1783499626.109713 yylex_token: end at WS
+1783499626.109715 yylex_token: send
+1783499626.109716 yylex_token: end at WS
+1783499626.109718 yylex_token: -X
+1783499626.109720 yylex_token: end at WS
+1783499626.109721 yylex_token: start-of-line
+1783499626.109724 cmd_parse_build_commands 0:0: bind
+1783499626.109725 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.109727 cmd_parse_build_commands 0:2: Home
+1783499626.109729 cmd_parse_build_commands 0:3 0:0: send
+1783499626.109731 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.109732 cmd_parse_build_commands 0:3 0:2: start-of-line
+1783499626.109735 cmd_parse_build_commands 0:0: send
+1783499626.109737 cmd_parse_build_commands 0:1: -X
+1783499626.109738 cmd_parse_build_commands 0:2: start-of-line
+1783499626.109742 args_parse_flags: next -X
+1783499626.109744 args_parse_flags: -X
+1783499626.109745 args_parse_flags: next start-of-line
+1783499626.109747 args_parse: flags end at 2 of 3
+1783499626.109749 args_parse: 2 = start-of-line (type STRING)
+1783499626.109752 cmd_parse_build_commands: send-keys -X start-of-line
+1783499626.109754 args_parse_flags: next -Tcopy-mode
+1783499626.109756 args_parse_flag_argument: -T = copy-mode
+1783499626.109758 args_parse_flags: next Home
+1783499626.109759 args_parse: flags end at 2 of 4
+1783499626.109761 args_parse: 2 = Home (type STRING)
+1783499626.109764 args_parse: 3 = send-keys -X start-of-line (type COMMANDS)
+1783499626.109769 cmd_parse_build_commands: bind-key -T copy-mode Home { send-keys -X start-of-line }
+1783499626.109772 cmdq_get_command: [bind-key/0x58e47250dbb0] group 1559
+1783499626.109774 cmdq_append <global>: [bind-key/0x58e47250dbb0]
+1783499626.109777 yylex_token: end at WS
+1783499626.109779 yylex_token: bind
+1783499626.109780 yylex_token: end at WS
+1783499626.109782 yylex_token: -Tcopy-mode
+1783499626.109783 yylex_token: end at WS
+1783499626.109785 yylex_token: End
+1783499626.109786 yylex_token: end at WS
+1783499626.109787 yylex_token: send
+1783499626.109789 yylex_token: end at WS
+1783499626.109790 yylex_token: -X
+1783499626.109792 yylex_token: end at WS
+1783499626.109793 yylex_token: end-of-line
+1783499626.109796 cmd_parse_build_commands 0:0: bind
+1783499626.109798 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.109799 cmd_parse_build_commands 0:2: End
+1783499626.109801 cmd_parse_build_commands 0:3 0:0: send
+1783499626.109803 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.109804 cmd_parse_build_commands 0:3 0:2: end-of-line
+1783499626.109806 cmd_parse_build_commands 0:0: send
+1783499626.109811 cmd_parse_build_commands 0:1: -X
+1783499626.109813 cmd_parse_build_commands 0:2: end-of-line
+1783499626.109817 args_parse_flags: next -X
+1783499626.109818 args_parse_flags: -X
+1783499626.109820 args_parse_flags: next end-of-line
+1783499626.109821 args_parse: flags end at 2 of 3
+1783499626.109823 args_parse: 2 = end-of-line (type STRING)
+1783499626.109826 cmd_parse_build_commands: send-keys -X end-of-line
+1783499626.109828 args_parse_flags: next -Tcopy-mode
+1783499626.109830 args_parse_flag_argument: -T = copy-mode
+1783499626.109831 args_parse_flags: next End
+1783499626.109833 args_parse: flags end at 2 of 4
+1783499626.109834 args_parse: 2 = End (type STRING)
+1783499626.109837 args_parse: 3 = send-keys -X end-of-line (type COMMANDS)
+1783499626.109842 cmd_parse_build_commands: bind-key -T copy-mode End { send-keys -X end-of-line }
+1783499626.109845 cmdq_get_command: [bind-key/0x58e47250e240] group 1567
+1783499626.109847 cmdq_append <global>: [bind-key/0x58e47250e240]
+1783499626.109849 yylex_token: end at WS
+1783499626.109851 yylex_token: bind
+1783499626.109852 yylex_token: end at WS
+1783499626.109854 yylex_token: -Tcopy-mode
+1783499626.109855 yylex_token: end at WS
+1783499626.109857 yylex_token: MouseDown1Pane
+1783499626.109858 yylex_token: end at EOF
+1783499626.109860 yylex_token: select-pane
+1783499626.109862 cmd_parse_build_commands 0:0: bind
+1783499626.109864 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.109865 cmd_parse_build_commands 0:2: MouseDown1Pane
+1783499626.109867 cmd_parse_build_commands 0:3: select-pane
+1783499626.109869 args_parse_flags: next -Tcopy-mode
+1783499626.109871 args_parse_flag_argument: -T = copy-mode
+1783499626.109873 args_parse_flags: next MouseDown1Pane
+1783499626.109874 args_parse: flags end at 2 of 4
+1783499626.109876 args_parse: 2 = MouseDown1Pane (type STRING)
+1783499626.109878 args_parse: 3 = select-pane (type STRING)
+1783499626.109882 cmd_parse_build_commands: bind-key -T copy-mode MouseDown1Pane select-pane
+1783499626.109884 cmdq_get_command: [bind-key/0x58e47250e500] group 1575
+1783499626.109886 cmdq_append <global>: [bind-key/0x58e47250e500]
+1783499626.109894 yylex_token: end at WS
+1783499626.109897 yylex_token: bind
+1783499626.109899 yylex_token: end at WS
+1783499626.109901 yylex_token: -Tcopy-mode
+1783499626.109902 yylex_token: end at WS
+1783499626.109904 yylex_token: MouseDrag1Pane
+1783499626.109906 yylex_token: end at ;
+1783499626.109907 yylex_token: select-pane
+1783499626.109909 yylex_token: end at WS
+1783499626.109910 yylex_token: send
+1783499626.109911 yylex_token: end at WS
+1783499626.109913 yylex_token: -X
+1783499626.109914 yylex_token: end at WS
+1783499626.109916 yylex_token: begin-selection
+1783499626.109918 cmd_parse_build_commands 0:0: bind
+1783499626.109920 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.109922 cmd_parse_build_commands 0:2: MouseDrag1Pane
+1783499626.109923 cmd_parse_build_commands 0:3 0:0: select-pane
+1783499626.109925 cmd_parse_build_commands 0:3 1:0: send
+1783499626.109927 cmd_parse_build_commands 0:3 1:1: -X
+1783499626.109928 cmd_parse_build_commands 0:3 1:2: begin-selection
+1783499626.109931 cmd_parse_build_commands 0:0: select-pane
+1783499626.109932 cmd_parse_build_commands 1:0: send
+1783499626.109934 cmd_parse_build_commands 1:1: -X
+1783499626.109936 cmd_parse_build_commands 1:2: begin-selection
+1783499626.109939 args_parse: flags end at 1 of 1
+1783499626.109942 args_parse_flags: next -X
+1783499626.109944 args_parse_flags: -X
+1783499626.109945 args_parse_flags: next begin-selection
+1783499626.109947 args_parse: flags end at 2 of 3
+1783499626.109949 args_parse: 2 = begin-selection (type STRING)
+1783499626.109953 cmd_parse_build_commands: select-pane ; send-keys -X begin-selection
+1783499626.109955 args_parse_flags: next -Tcopy-mode
+1783499626.109957 args_parse_flag_argument: -T = copy-mode
+1783499626.109958 args_parse_flags: next MouseDrag1Pane
+1783499626.109960 args_parse: flags end at 2 of 4
+1783499626.109961 args_parse: 2 = MouseDrag1Pane (type STRING)
+1783499626.109965 args_parse: 3 = select-pane ; send-keys -X begin-selection (type COMMANDS)
+1783499626.109975 cmd_parse_build_commands: bind-key -T copy-mode MouseDrag1Pane { select-pane ; send-keys -X begin-selection }
+1783499626.109978 cmdq_get_command: [bind-key/0x58e47250eef0] group 1579
+1783499626.109980 cmdq_append <global>: [bind-key/0x58e47250eef0]
+1783499626.109983 yylex_token: end at WS
+1783499626.109984 yylex_token: bind
+1783499626.109986 yylex_token: end at WS
+1783499626.109987 yylex_token: -Tcopy-mode
+1783499626.109989 yylex_token: end at WS
+1783499626.109990 yylex_token: MouseDragEnd1Pane
+1783499626.109992 yylex_token: end at WS
+1783499626.109993 yylex_token: send
+1783499626.109994 yylex_token: end at WS
+1783499626.109996 yylex_token: -X
+1783499626.109997 yylex_token: end at WS
+1783499626.109999 yylex_token: copy-pipe-and-cancel
+1783499626.110001 cmd_parse_build_commands 0:0: bind
+1783499626.110003 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.110005 cmd_parse_build_commands 0:2: MouseDragEnd1Pane
+1783499626.110006 cmd_parse_build_commands 0:3 0:0: send
+1783499626.110008 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.110010 cmd_parse_build_commands 0:3 0:2: copy-pipe-and-cancel
+1783499626.110012 cmd_parse_build_commands 0:0: send
+1783499626.110013 cmd_parse_build_commands 0:1: -X
+1783499626.110015 cmd_parse_build_commands 0:2: copy-pipe-and-cancel
+1783499626.110019 args_parse_flags: next -X
+1783499626.110020 args_parse_flags: -X
+1783499626.110022 args_parse_flags: next copy-pipe-and-cancel
+1783499626.110023 args_parse: flags end at 2 of 3
+1783499626.110025 args_parse: 2 = copy-pipe-and-cancel (type STRING)
+1783499626.110029 cmd_parse_build_commands: send-keys -X copy-pipe-and-cancel
+1783499626.110030 args_parse_flags: next -Tcopy-mode
+1783499626.110032 args_parse_flag_argument: -T = copy-mode
+1783499626.110034 args_parse_flags: next MouseDragEnd1Pane
+1783499626.110035 args_parse: flags end at 2 of 4
+1783499626.110037 args_parse: 2 = MouseDragEnd1Pane (type STRING)
+1783499626.110040 args_parse: 3 = send-keys -X copy-pipe-and-cancel (type COMMANDS)
+1783499626.110046 cmd_parse_build_commands: bind-key -T copy-mode MouseDragEnd1Pane { send-keys -X copy-pipe-and-cancel }
+1783499626.110049 cmdq_get_command: [bind-key/0x58e47250f250] group 1588
+1783499626.110050 cmdq_append <global>: [bind-key/0x58e47250f250]
+1783499626.110053 yylex_token: end at WS
+1783499626.110055 yylex_token: bind
+1783499626.110056 yylex_token: end at WS
+1783499626.110057 yylex_token: -Tcopy-mode
+1783499626.110059 yylex_token: end at WS
+1783499626.110060 yylex_token: WheelUpPane
+1783499626.110062 yylex_token: end at ;
+1783499626.110064 yylex_token: select-pane
+1783499626.110065 yylex_token: end at WS
+1783499626.110066 yylex_token: send
+1783499626.110068 yylex_token: end at WS
+1783499626.110069 yylex_token: -N5
+1783499626.110070 yylex_token: end at WS
+1783499626.110071 yylex_token: -X
+1783499626.110073 yylex_token: end at WS
+1783499626.110074 yylex_token: scroll-up
+1783499626.110077 cmd_parse_build_commands 0:0: bind
+1783499626.110079 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.110080 cmd_parse_build_commands 0:2: WheelUpPane
+1783499626.110082 cmd_parse_build_commands 0:3 0:0: select-pane
+1783499626.110084 cmd_parse_build_commands 0:3 1:0: send
+1783499626.110086 cmd_parse_build_commands 0:3 1:1: -N5
+1783499626.110087 cmd_parse_build_commands 0:3 1:2: -X
+1783499626.110089 cmd_parse_build_commands 0:3 1:3: scroll-up
+1783499626.110091 cmd_parse_build_commands 0:0: select-pane
+1783499626.110093 cmd_parse_build_commands 1:0: send
+1783499626.110094 cmd_parse_build_commands 1:1: -N5
+1783499626.110095 cmd_parse_build_commands 1:2: -X
+1783499626.110097 cmd_parse_build_commands 1:3: scroll-up
+1783499626.110101 args_parse: flags end at 1 of 1
+1783499626.110104 args_parse_flags: next -N5
+1783499626.110106 args_parse_flag_argument: -N = 5
+1783499626.110107 args_parse_flags: next -X
+1783499626.110108 args_parse_flags: -X
+1783499626.110110 args_parse_flags: next scroll-up
+1783499626.110111 args_parse: flags end at 3 of 4
+1783499626.110113 args_parse: 3 = scroll-up (type STRING)
+1783499626.110117 cmd_parse_build_commands: select-pane ; send-keys -X -N 5 scroll-up
+1783499626.110121 args_parse_flags: next -Tcopy-mode
+1783499626.110123 args_parse_flag_argument: -T = copy-mode
+1783499626.110125 args_parse_flags: next WheelUpPane
+1783499626.110126 args_parse: flags end at 2 of 4
+1783499626.110128 args_parse: 2 = WheelUpPane (type STRING)
+1783499626.110132 args_parse: 3 = select-pane ; send-keys -X -N 5 scroll-up (type COMMANDS)
+1783499626.110138 cmd_parse_build_commands: bind-key -T copy-mode WheelUpPane { select-pane ; send-keys -X -N 5 scroll-up }
+1783499626.110140 cmdq_get_command: [bind-key/0x58e47250fc00] group 1596
+1783499626.110142 cmdq_append <global>: [bind-key/0x58e47250fc00]
+1783499626.110153 yylex_token: end at WS
+1783499626.110157 yylex_token: bind
+1783499626.110159 yylex_token: end at WS
+1783499626.110160 yylex_token: -Tcopy-mode
+1783499626.110162 yylex_token: end at WS
+1783499626.110163 yylex_token: WheelDownPane
+1783499626.110165 yylex_token: end at ;
+1783499626.110167 yylex_token: select-pane
+1783499626.110168 yylex_token: end at WS
+1783499626.110169 yylex_token: send
+1783499626.110171 yylex_token: end at WS
+1783499626.110172 yylex_token: -N5
+1783499626.110173 yylex_token: end at WS
+1783499626.110175 yylex_token: -X
+1783499626.110176 yylex_token: end at WS
+1783499626.110178 yylex_token: scroll-down
+1783499626.110181 cmd_parse_build_commands 0:0: bind
+1783499626.110182 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.110184 cmd_parse_build_commands 0:2: WheelDownPane
+1783499626.110186 cmd_parse_build_commands 0:3 0:0: select-pane
+1783499626.110187 cmd_parse_build_commands 0:3 1:0: send
+1783499626.110189 cmd_parse_build_commands 0:3 1:1: -N5
+1783499626.110190 cmd_parse_build_commands 0:3 1:2: -X
+1783499626.110192 cmd_parse_build_commands 0:3 1:3: scroll-down
+1783499626.110194 cmd_parse_build_commands 0:0: select-pane
+1783499626.110196 cmd_parse_build_commands 1:0: send
+1783499626.110198 cmd_parse_build_commands 1:1: -N5
+1783499626.110199 cmd_parse_build_commands 1:2: -X
+1783499626.110201 cmd_parse_build_commands 1:3: scroll-down
+1783499626.110205 args_parse: flags end at 1 of 1
+1783499626.110208 args_parse_flags: next -N5
+1783499626.110210 args_parse_flag_argument: -N = 5
+1783499626.110211 args_parse_flags: next -X
+1783499626.110213 args_parse_flags: -X
+1783499626.110214 args_parse_flags: next scroll-down
+1783499626.110216 args_parse: flags end at 3 of 4
+1783499626.110217 args_parse: 3 = scroll-down (type STRING)
+1783499626.110222 cmd_parse_build_commands: select-pane ; send-keys -X -N 5 scroll-down
+1783499626.110224 args_parse_flags: next -Tcopy-mode
+1783499626.110225 args_parse_flag_argument: -T = copy-mode
+1783499626.110227 args_parse_flags: next WheelDownPane
+1783499626.110228 args_parse: flags end at 2 of 4
+1783499626.110230 args_parse: 2 = WheelDownPane (type STRING)
+1783499626.110234 args_parse: 3 = select-pane ; send-keys -X -N 5 scroll-down (type COMMANDS)
+1783499626.110240 cmd_parse_build_commands: bind-key -T copy-mode WheelDownPane { select-pane ; send-keys -X -N 5 scroll-down }
+1783499626.110243 cmdq_get_command: [bind-key/0x58e472510220] group 1605
+1783499626.110244 cmdq_append <global>: [bind-key/0x58e472510220]
+1783499626.110248 yylex_token: end at WS
+1783499626.110249 yylex_token: bind
+1783499626.110251 yylex_token: end at WS
+1783499626.110252 yylex_token: -Tcopy-mode
+1783499626.110254 yylex_token: end at WS
+1783499626.110255 yylex_token: DoubleClick1Pane
+1783499626.110257 yylex_token: end at ;
+1783499626.110258 yylex_token: select-pane
+1783499626.110260 yylex_token: end at WS
+1783499626.110261 yylex_token: send
+1783499626.110262 yylex_token: end at WS
+1783499626.110264 yylex_token: -X
+1783499626.110265 yylex_token: end at ;
+1783499626.110266 yylex_token: select-word
+1783499626.110268 yylex_token: end at WS
+1783499626.110269 yylex_token: run
+1783499626.110271 yylex_token: end at ;
+1783499626.110272 yylex_token: -d0.3
+1783499626.110274 yylex_token: end at WS
+1783499626.110275 yylex_token: send
+1783499626.110276 yylex_token: end at WS
+1783499626.110278 yylex_token: -X
+1783499626.110279 yylex_token: end at WS
+1783499626.110284 yylex_token: copy-pipe-and-cancel
+1783499626.110286 cmd_parse_build_commands 0:0: bind
+1783499626.110288 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.110290 cmd_parse_build_commands 0:2: DoubleClick1Pane
+1783499626.110291 cmd_parse_build_commands 0:3 0:0: select-pane
+1783499626.110293 cmd_parse_build_commands 0:3 1:0: send
+1783499626.110295 cmd_parse_build_commands 0:3 1:1: -X
+1783499626.110296 cmd_parse_build_commands 0:3 1:2: select-word
+1783499626.110298 cmd_parse_build_commands 0:3 2:0: run
+1783499626.110299 cmd_parse_build_commands 0:3 2:1: -d0.3
+1783499626.110301 cmd_parse_build_commands 0:3 3:0: send
+1783499626.110302 cmd_parse_build_commands 0:3 3:1: -X
+1783499626.110304 cmd_parse_build_commands 0:3 3:2: copy-pipe-and-cancel
+1783499626.110306 cmd_parse_build_commands 0:0: select-pane
+1783499626.110308 cmd_parse_build_commands 1:0: send
+1783499626.110310 cmd_parse_build_commands 1:1: -X
+1783499626.110311 cmd_parse_build_commands 1:2: select-word
+1783499626.110313 cmd_parse_build_commands 2:0: run
+1783499626.110314 cmd_parse_build_commands 2:1: -d0.3
+1783499626.110316 cmd_parse_build_commands 3:0: send
+1783499626.110317 cmd_parse_build_commands 3:1: -X
+1783499626.110319 cmd_parse_build_commands 3:2: copy-pipe-and-cancel
+1783499626.110322 args_parse: flags end at 1 of 1
+1783499626.110325 args_parse_flags: next -X
+1783499626.110326 args_parse_flags: -X
+1783499626.110328 args_parse_flags: next select-word
+1783499626.110330 args_parse: flags end at 2 of 3
+1783499626.110331 args_parse: 2 = select-word (type STRING)
+1783499626.110334 args_parse_flags: next -d0.3
+1783499626.110336 args_parse_flag_argument: -d = 0.3
+1783499626.110337 args_parse: flags end at 2 of 2
+1783499626.110340 args_parse_flags: next -X
+1783499626.110342 args_parse_flags: -X
+1783499626.110343 args_parse_flags: next copy-pipe-and-cancel
+1783499626.110345 args_parse: flags end at 2 of 3
+1783499626.110347 args_parse: 2 = copy-pipe-and-cancel (type STRING)
+1783499626.110353 cmd_parse_build_commands: select-pane ; send-keys -X select-word ; run-shell -d 0.3 ; send-keys -X copy-pipe-and-cancel
+1783499626.110355 args_parse_flags: next -Tcopy-mode
+1783499626.110357 args_parse_flag_argument: -T = copy-mode
+1783499626.110358 args_parse_flags: next DoubleClick1Pane
+1783499626.110360 args_parse: flags end at 2 of 4
+1783499626.110361 args_parse: 2 = DoubleClick1Pane (type STRING)
+1783499626.110372 args_parse: 3 = select-pane ; send-keys -X select-word ; run-shell -d 0.3 ; send-keys -X copy-pipe-and-cancel (type COMMANDS)
+1783499626.110385 cmd_parse_build_commands: bind-key -T copy-mode DoubleClick1Pane { select-pane ; send-keys -X select-word ; run-shell -d 0.3 ; send-keys -X copy-pipe-and-cancel }
+1783499626.110389 cmdq_get_command: [bind-key/0x58e472510f30] group 1614
+1783499626.110391 cmdq_append <global>: [bind-key/0x58e472510f30]
+1783499626.110396 yylex_token: end at WS
+1783499626.110397 yylex_token: bind
+1783499626.110399 yylex_token: end at WS
+1783499626.110400 yylex_token: -Tcopy-mode
+1783499626.110402 yylex_token: end at WS
+1783499626.110403 yylex_token: TripleClick1Pane
+1783499626.110405 yylex_token: end at ;
+1783499626.110406 yylex_token: select-pane
+1783499626.110408 yylex_token: end at WS
+1783499626.110409 yylex_token: send
+1783499626.110410 yylex_token: end at WS
+1783499626.110411 yylex_token: -X
+1783499626.110413 yylex_token: end at ;
+1783499626.110414 yylex_token: select-line
+1783499626.110416 yylex_token: end at WS
+1783499626.110417 yylex_token: run
+1783499626.110419 yylex_token: end at ;
+1783499626.110420 yylex_token: -d0.3
+1783499626.110422 yylex_token: end at WS
+1783499626.110423 yylex_token: send
+1783499626.110424 yylex_token: end at WS
+1783499626.110425 yylex_token: -X
+1783499626.110427 yylex_token: end at WS
+1783499626.110429 yylex_token: copy-pipe-and-cancel
+1783499626.110431 cmd_parse_build_commands 0:0: bind
+1783499626.110432 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.110434 cmd_parse_build_commands 0:2: TripleClick1Pane
+1783499626.110436 cmd_parse_build_commands 0:3 0:0: select-pane
+1783499626.110441 cmd_parse_build_commands 0:3 1:0: send
+1783499626.110442 cmd_parse_build_commands 0:3 1:1: -X
+1783499626.110444 cmd_parse_build_commands 0:3 1:2: select-line
+1783499626.110446 cmd_parse_build_commands 0:3 2:0: run
+1783499626.110447 cmd_parse_build_commands 0:3 2:1: -d0.3
+1783499626.110449 cmd_parse_build_commands 0:3 3:0: send
+1783499626.110450 cmd_parse_build_commands 0:3 3:1: -X
+1783499626.110452 cmd_parse_build_commands 0:3 3:2: copy-pipe-and-cancel
+1783499626.110454 cmd_parse_build_commands 0:0: select-pane
+1783499626.110456 cmd_parse_build_commands 1:0: send
+1783499626.110458 cmd_parse_build_commands 1:1: -X
+1783499626.110459 cmd_parse_build_commands 1:2: select-line
+1783499626.110461 cmd_parse_build_commands 2:0: run
+1783499626.110462 cmd_parse_build_commands 2:1: -d0.3
+1783499626.110464 cmd_parse_build_commands 3:0: send
+1783499626.110465 cmd_parse_build_commands 3:1: -X
+1783499626.110467 cmd_parse_build_commands 3:2: copy-pipe-and-cancel
+1783499626.110471 args_parse: flags end at 1 of 1
+1783499626.110474 args_parse_flags: next -X
+1783499626.110475 args_parse_flags: -X
+1783499626.110477 args_parse_flags: next select-line
+1783499626.110478 args_parse: flags end at 2 of 3
+1783499626.110480 args_parse: 2 = select-line (type STRING)
+1783499626.110483 args_parse_flags: next -d0.3
+1783499626.110485 args_parse_flag_argument: -d = 0.3
+1783499626.110486 args_parse: flags end at 2 of 2
+1783499626.110489 args_parse_flags: next -X
+1783499626.110490 args_parse_flags: -X
+1783499626.110492 args_parse_flags: next copy-pipe-and-cancel
+1783499626.110493 args_parse: flags end at 2 of 3
+1783499626.110495 args_parse: 2 = copy-pipe-and-cancel (type STRING)
+1783499626.110501 cmd_parse_build_commands: select-pane ; send-keys -X select-line ; run-shell -d 0.3 ; send-keys -X copy-pipe-and-cancel
+1783499626.110503 args_parse_flags: next -Tcopy-mode
+1783499626.110505 args_parse_flag_argument: -T = copy-mode
+1783499626.110507 args_parse_flags: next TripleClick1Pane
+1783499626.110508 args_parse: flags end at 2 of 4
+1783499626.110510 args_parse: 2 = TripleClick1Pane (type STRING)
+1783499626.110515 args_parse: 3 = select-pane ; send-keys -X select-line ; run-shell -d 0.3 ; send-keys -X copy-pipe-and-cancel (type COMMANDS)
+1783499626.110523 cmd_parse_build_commands: bind-key -T copy-mode TripleClick1Pane { select-pane ; send-keys -X select-line ; run-shell -d 0.3 ; send-keys -X copy-pipe-and-cancel }
+1783499626.110526 cmdq_get_command: [bind-key/0x58e472511570] group 1625
+1783499626.110527 cmdq_append <global>: [bind-key/0x58e472511570]
+1783499626.110537 yylex_token: end at WS
+1783499626.110541 yylex_token: bind
+1783499626.110542 yylex_token: end at WS
+1783499626.110544 yylex_token: -Tcopy-mode
+1783499626.110545 yylex_token: end at WS
+1783499626.110547 yylex_token: NPage
+1783499626.110548 yylex_token: end at WS
+1783499626.110549 yylex_token: send
+1783499626.110551 yylex_token: end at WS
+1783499626.110552 yylex_token: -X
+1783499626.110554 yylex_token: end at WS
+1783499626.110555 yylex_token: page-down
+1783499626.110558 cmd_parse_build_commands 0:0: bind
+1783499626.110559 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.110561 cmd_parse_build_commands 0:2: NPage
+1783499626.110563 cmd_parse_build_commands 0:3 0:0: send
+1783499626.110564 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.110566 cmd_parse_build_commands 0:3 0:2: page-down
+1783499626.110568 cmd_parse_build_commands 0:0: send
+1783499626.110569 cmd_parse_build_commands 0:1: -X
+1783499626.110571 cmd_parse_build_commands 0:2: page-down
+1783499626.110574 args_parse_flags: next -X
+1783499626.110576 args_parse_flags: -X
+1783499626.110577 args_parse_flags: next page-down
+1783499626.110579 args_parse: flags end at 2 of 3
+1783499626.110580 args_parse: 2 = page-down (type STRING)
+1783499626.110584 cmd_parse_build_commands: send-keys -X page-down
+1783499626.110585 args_parse_flags: next -Tcopy-mode
+1783499626.110587 args_parse_flag_argument: -T = copy-mode
+1783499626.110589 args_parse_flags: next NPage
+1783499626.110590 args_parse: flags end at 2 of 4
+1783499626.110592 args_parse: 2 = NPage (type STRING)
+1783499626.110597 args_parse: 3 = send-keys -X page-down (type COMMANDS)
+1783499626.110602 cmd_parse_build_commands: bind-key -T copy-mode NPage { send-keys -X page-down }
+1783499626.110605 cmdq_get_command: [bind-key/0x58e472510ba0] group 1636
+1783499626.110607 cmdq_append <global>: [bind-key/0x58e472510ba0]
+1783499626.110610 yylex_token: end at WS
+1783499626.110611 yylex_token: bind
+1783499626.110613 yylex_token: end at WS
+1783499626.110614 yylex_token: -Tcopy-mode
+1783499626.110616 yylex_token: end at WS
+1783499626.110617 yylex_token: PPage
+1783499626.110618 yylex_token: end at WS
+1783499626.110620 yylex_token: send
+1783499626.110621 yylex_token: end at WS
+1783499626.110622 yylex_token: -X
+1783499626.110624 yylex_token: end at WS
+1783499626.110625 yylex_token: page-up
+1783499626.110627 cmd_parse_build_commands 0:0: bind
+1783499626.110629 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.110630 cmd_parse_build_commands 0:2: PPage
+1783499626.110632 cmd_parse_build_commands 0:3 0:0: send
+1783499626.110634 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.110636 cmd_parse_build_commands 0:3 0:2: page-up
+1783499626.110638 cmd_parse_build_commands 0:0: send
+1783499626.110639 cmd_parse_build_commands 0:1: -X
+1783499626.110641 cmd_parse_build_commands 0:2: page-up
+1783499626.110644 args_parse_flags: next -X
+1783499626.110645 args_parse_flags: -X
+1783499626.110647 args_parse_flags: next page-up
+1783499626.110648 args_parse: flags end at 2 of 3
+1783499626.110650 args_parse: 2 = page-up (type STRING)
+1783499626.110653 cmd_parse_build_commands: send-keys -X page-up
+1783499626.110655 args_parse_flags: next -Tcopy-mode
+1783499626.110656 args_parse_flag_argument: -T = copy-mode
+1783499626.110658 args_parse_flags: next PPage
+1783499626.110659 args_parse: flags end at 2 of 4
+1783499626.110661 args_parse: 2 = PPage (type STRING)
+1783499626.110664 args_parse: 3 = send-keys -X page-up (type COMMANDS)
+1783499626.110668 cmd_parse_build_commands: bind-key -T copy-mode PPage { send-keys -X page-up }
+1783499626.110671 cmdq_get_command: [bind-key/0x58e472511860] group 1644
+1783499626.110673 cmdq_append <global>: [bind-key/0x58e472511860]
+1783499626.110675 yylex_token: end at WS
+1783499626.110677 yylex_token: bind
+1783499626.110678 yylex_token: end at WS
+1783499626.110679 yylex_token: -Tcopy-mode
+1783499626.110681 yylex_token: end at WS
+1783499626.110682 yylex_token: Up
+1783499626.110683 yylex_token: end at WS
+1783499626.110685 yylex_token: send
+1783499626.110686 yylex_token: end at WS
+1783499626.110687 yylex_token: -X
+1783499626.110689 yylex_token: end at WS
+1783499626.110690 yylex_token: cursor-up
+1783499626.110692 cmd_parse_build_commands 0:0: bind
+1783499626.110694 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.110695 cmd_parse_build_commands 0:2: Up
+1783499626.110697 cmd_parse_build_commands 0:3 0:0: send
+1783499626.110698 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.110700 cmd_parse_build_commands 0:3 0:2: cursor-up
+1783499626.110702 cmd_parse_build_commands 0:0: send
+1783499626.110704 cmd_parse_build_commands 0:1: -X
+1783499626.110705 cmd_parse_build_commands 0:2: cursor-up
+1783499626.110708 args_parse_flags: next -X
+1783499626.110710 args_parse_flags: -X
+1783499626.110711 args_parse_flags: next cursor-up
+1783499626.110713 args_parse: flags end at 2 of 3
+1783499626.110715 args_parse: 2 = cursor-up (type STRING)
+1783499626.110718 cmd_parse_build_commands: send-keys -X cursor-up
+1783499626.110719 args_parse_flags: next -Tcopy-mode
+1783499626.110721 args_parse_flag_argument: -T = copy-mode
+1783499626.110723 args_parse_flags: next Up
+1783499626.110724 args_parse: flags end at 2 of 4
+1783499626.110725 args_parse: 2 = Up (type STRING)
+1783499626.110728 args_parse: 3 = send-keys -X cursor-up (type COMMANDS)
+1783499626.110733 cmd_parse_build_commands: bind-key -T copy-mode Up { send-keys -X cursor-up }
+1783499626.110735 cmdq_get_command: [bind-key/0x58e472511ab0] group 1652
+1783499626.110737 cmdq_append <global>: [bind-key/0x58e472511ab0]
+1783499626.110739 yylex_token: end at WS
+1783499626.110741 yylex_token: bind
+1783499626.110745 yylex_token: end at WS
+1783499626.110746 yylex_token: -Tcopy-mode
+1783499626.110748 yylex_token: end at WS
+1783499626.110749 yylex_token: Down
+1783499626.110750 yylex_token: end at WS
+1783499626.110752 yylex_token: send
+1783499626.110753 yylex_token: end at WS
+1783499626.110754 yylex_token: -X
+1783499626.110756 yylex_token: end at WS
+1783499626.110757 yylex_token: cursor-down
+1783499626.110760 cmd_parse_build_commands 0:0: bind
+1783499626.110761 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.110763 cmd_parse_build_commands 0:2: Down
+1783499626.110764 cmd_parse_build_commands 0:3 0:0: send
+1783499626.110766 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.110767 cmd_parse_build_commands 0:3 0:2: cursor-down
+1783499626.110769 cmd_parse_build_commands 0:0: send
+1783499626.110771 cmd_parse_build_commands 0:1: -X
+1783499626.110772 cmd_parse_build_commands 0:2: cursor-down
+1783499626.110775 args_parse_flags: next -X
+1783499626.110777 args_parse_flags: -X
+1783499626.110778 args_parse_flags: next cursor-down
+1783499626.110780 args_parse: flags end at 2 of 3
+1783499626.110781 args_parse: 2 = cursor-down (type STRING)
+1783499626.110784 cmd_parse_build_commands: send-keys -X cursor-down
+1783499626.110786 args_parse_flags: next -Tcopy-mode
+1783499626.110788 args_parse_flag_argument: -T = copy-mode
+1783499626.110790 args_parse_flags: next Down
+1783499626.110791 args_parse: flags end at 2 of 4
+1783499626.110792 args_parse: 2 = Down (type STRING)
+1783499626.110795 args_parse: 3 = send-keys -X cursor-down (type COMMANDS)
+1783499626.110800 cmd_parse_build_commands: bind-key -T copy-mode Down { send-keys -X cursor-down }
+1783499626.110802 cmdq_get_command: [bind-key/0x58e472511e80] group 1660
+1783499626.110804 cmdq_append <global>: [bind-key/0x58e472511e80]
+1783499626.110807 yylex_token: end at WS
+1783499626.110808 yylex_token: bind
+1783499626.110810 yylex_token: end at WS
+1783499626.110811 yylex_token: -Tcopy-mode
+1783499626.110812 yylex_token: end at WS
+1783499626.110814 yylex_token: Left
+1783499626.110815 yylex_token: end at WS
+1783499626.110816 yylex_token: send
+1783499626.110818 yylex_token: end at WS
+1783499626.110819 yylex_token: -X
+1783499626.110820 yylex_token: end at WS
+1783499626.110822 yylex_token: cursor-left
+1783499626.110824 cmd_parse_build_commands 0:0: bind
+1783499626.110825 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.110827 cmd_parse_build_commands 0:2: Left
+1783499626.110828 cmd_parse_build_commands 0:3 0:0: send
+1783499626.110830 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.110832 cmd_parse_build_commands 0:3 0:2: cursor-left
+1783499626.110833 cmd_parse_build_commands 0:0: send
+1783499626.110835 cmd_parse_build_commands 0:1: -X
+1783499626.110837 cmd_parse_build_commands 0:2: cursor-left
+1783499626.110840 args_parse_flags: next -X
+1783499626.110841 args_parse_flags: -X
+1783499626.110842 args_parse_flags: next cursor-left
+1783499626.110844 args_parse: flags end at 2 of 3
+1783499626.110846 args_parse: 2 = cursor-left (type STRING)
+1783499626.110849 cmd_parse_build_commands: send-keys -X cursor-left
+1783499626.110850 args_parse_flags: next -Tcopy-mode
+1783499626.110852 args_parse_flag_argument: -T = copy-mode
+1783499626.110853 args_parse_flags: next Left
+1783499626.110855 args_parse: flags end at 2 of 4
+1783499626.110856 args_parse: 2 = Left (type STRING)
+1783499626.110859 args_parse: 3 = send-keys -X cursor-left (type COMMANDS)
+1783499626.110863 cmd_parse_build_commands: bind-key -T copy-mode Left { send-keys -X cursor-left }
+1783499626.110866 cmdq_get_command: [bind-key/0x58e472512450] group 1668
+1783499626.110868 cmdq_append <global>: [bind-key/0x58e472512450]
+1783499626.110877 yylex_token: end at WS
+1783499626.110880 yylex_token: bind
+1783499626.110882 yylex_token: end at WS
+1783499626.110884 yylex_token: -Tcopy-mode
+1783499626.110885 yylex_token: end at WS
+1783499626.110886 yylex_token: Right
+1783499626.110888 yylex_token: end at WS
+1783499626.110889 yylex_token: send
+1783499626.110890 yylex_token: end at WS
+1783499626.110891 yylex_token: -X
+1783499626.110893 yylex_token: end at WS
+1783499626.110897 yylex_token: cursor-right
+1783499626.110899 cmd_parse_build_commands 0:0: bind
+1783499626.110901 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.110903 cmd_parse_build_commands 0:2: Right
+1783499626.110904 cmd_parse_build_commands 0:3 0:0: send
+1783499626.110906 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.110908 cmd_parse_build_commands 0:3 0:2: cursor-right
+1783499626.110910 cmd_parse_build_commands 0:0: send
+1783499626.110911 cmd_parse_build_commands 0:1: -X
+1783499626.110913 cmd_parse_build_commands 0:2: cursor-right
+1783499626.110916 args_parse_flags: next -X
+1783499626.110918 args_parse_flags: -X
+1783499626.110919 args_parse_flags: next cursor-right
+1783499626.110920 args_parse: flags end at 2 of 3
+1783499626.110922 args_parse: 2 = cursor-right (type STRING)
+1783499626.110925 cmd_parse_build_commands: send-keys -X cursor-right
+1783499626.110927 args_parse_flags: next -Tcopy-mode
+1783499626.110929 args_parse_flag_argument: -T = copy-mode
+1783499626.110930 args_parse_flags: next Right
+1783499626.110932 args_parse: flags end at 2 of 4
+1783499626.110933 args_parse: 2 = Right (type STRING)
+1783499626.110936 args_parse: 3 = send-keys -X cursor-right (type COMMANDS)
+1783499626.110941 cmd_parse_build_commands: bind-key -T copy-mode Right { send-keys -X cursor-right }
+1783499626.110943 cmdq_get_command: [bind-key/0x58e4725127e0] group 1676
+1783499626.110945 cmdq_append <global>: [bind-key/0x58e4725127e0]
+1783499626.110948 yylex_token: end at WS
+1783499626.110949 yylex_token: bind
+1783499626.110951 yylex_token: end at WS
+1783499626.110952 yylex_token: -Tcopy-mode
+1783499626.110953 yylex_token: end at WS
+1783499626.110955 yylex_token: M-1
+1783499626.110956 yylex_token: end at WS
+1783499626.110958 yylex_token: command-prompt
+1783499626.110960 yylex_token: end at WS
+1783499626.110961 yylex_token: -Np(repeat)
+1783499626.110962 yylex_token: end at WS
+1783499626.110964 yylex_token: -I1
+1783499626.110965 yylex_token: end at WS
+1783499626.110966 yylex_token: send
+1783499626.110968 yylex_token: end at WS
+1783499626.110969 yylex_token: -N
+1783499626.110970 yylex_token: end at WS
+1783499626.110971 yylex_token: %%
+1783499626.110974 cmd_parse_build_commands 0:0: bind
+1783499626.110976 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.110977 cmd_parse_build_commands 0:2: M-1
+1783499626.110979 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.110981 cmd_parse_build_commands 0:3 0:1: -Np(repeat)
+1783499626.110982 cmd_parse_build_commands 0:3 0:2: -I1
+1783499626.110984 cmd_parse_build_commands 0:3 0:3 0:0: send
+1783499626.110986 cmd_parse_build_commands 0:3 0:3 0:1: -N
+1783499626.110987 cmd_parse_build_commands 0:3 0:3 0:2: %%
+1783499626.110989 cmd_parse_build_commands 0:0: command-prompt
+1783499626.110991 cmd_parse_build_commands 0:1: -Np(repeat)
+1783499626.110993 cmd_parse_build_commands 0:2: -I1
+1783499626.110994 cmd_parse_build_commands 0:3 0:0: send
+1783499626.110996 cmd_parse_build_commands 0:3 0:1: -N
+1783499626.110997 cmd_parse_build_commands 0:3 0:2: %%
+1783499626.110999 cmd_parse_build_commands 0:0: send
+1783499626.111001 cmd_parse_build_commands 0:1: -N
+1783499626.111002 cmd_parse_build_commands 0:2: %%
+1783499626.111005 args_parse_flags: next -N
+1783499626.111007 args_parse_flag_argument: -N = %%
+1783499626.111008 args_parse: flags end at 3 of 3
+1783499626.111011 cmd_parse_build_commands: send-keys -N "%%"
+1783499626.111013 args_parse_flags: next -Np(repeat)
+1783499626.111015 args_parse_flags: -N
+1783499626.111016 args_parse_flag_argument: -p = (repeat)
+1783499626.111018 args_parse_flags: next -I1
+1783499626.111020 args_parse_flag_argument: -I = 1
+1783499626.111021 args_parse: flags end at 3 of 4
+1783499626.111024 args_parse: 3 = send-keys -N "%%" (type COMMANDS)
+1783499626.111029 cmd_parse_build_commands: command-prompt -N -I 1 -p (repeat) { send-keys -N "%%" }
+1783499626.111031 args_parse_flags: next -Tcopy-mode
+1783499626.111032 args_parse_flag_argument: -T = copy-mode
+1783499626.111034 args_parse_flags: next M-1
+1783499626.111035 args_parse: flags end at 2 of 4
+1783499626.111037 args_parse: 2 = M-1 (type STRING)
+1783499626.111044 args_parse: 3 = command-prompt -N -I 1 -p (repeat) { send-keys -N "%%" } (type COMMANDS)
+1783499626.111050 cmd_parse_build_commands: bind-key -T copy-mode M-1 { command-prompt -N -I 1 -p (repeat) { send-keys -N "%%" } }
+1783499626.111053 cmdq_get_command: [bind-key/0x58e472513670] group 1684
+1783499626.111055 cmdq_append <global>: [bind-key/0x58e472513670]
+1783499626.111064 yylex_token: end at WS
+1783499626.111067 yylex_token: bind
+1783499626.111069 yylex_token: end at WS
+1783499626.111070 yylex_token: -Tcopy-mode
+1783499626.111072 yylex_token: end at WS
+1783499626.111073 yylex_token: M-2
+1783499626.111074 yylex_token: end at WS
+1783499626.111076 yylex_token: command-prompt
+1783499626.111077 yylex_token: end at WS
+1783499626.111079 yylex_token: -Np(repeat)
+1783499626.111080 yylex_token: end at WS
+1783499626.111081 yylex_token: -I2
+1783499626.111083 yylex_token: end at WS
+1783499626.111084 yylex_token: send
+1783499626.111085 yylex_token: end at WS
+1783499626.111086 yylex_token: -N
+1783499626.111087 yylex_token: end at WS
+1783499626.111089 yylex_token: %%
+1783499626.111092 cmd_parse_build_commands 0:0: bind
+1783499626.111093 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.111095 cmd_parse_build_commands 0:2: M-2
+1783499626.111097 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.111099 cmd_parse_build_commands 0:3 0:1: -Np(repeat)
+1783499626.111100 cmd_parse_build_commands 0:3 0:2: -I2
+1783499626.111102 cmd_parse_build_commands 0:3 0:3 0:0: send
+1783499626.111103 cmd_parse_build_commands 0:3 0:3 0:1: -N
+1783499626.111105 cmd_parse_build_commands 0:3 0:3 0:2: %%
+1783499626.111107 cmd_parse_build_commands 0:0: command-prompt
+1783499626.111109 cmd_parse_build_commands 0:1: -Np(repeat)
+1783499626.111111 cmd_parse_build_commands 0:2: -I2
+1783499626.111112 cmd_parse_build_commands 0:3 0:0: send
+1783499626.111114 cmd_parse_build_commands 0:3 0:1: -N
+1783499626.111115 cmd_parse_build_commands 0:3 0:2: %%
+1783499626.111117 cmd_parse_build_commands 0:0: send
+1783499626.111119 cmd_parse_build_commands 0:1: -N
+1783499626.111120 cmd_parse_build_commands 0:2: %%
+1783499626.111123 args_parse_flags: next -N
+1783499626.111125 args_parse_flag_argument: -N = %%
+1783499626.111127 args_parse: flags end at 3 of 3
+1783499626.111130 cmd_parse_build_commands: send-keys -N "%%"
+1783499626.111132 args_parse_flags: next -Np(repeat)
+1783499626.111133 args_parse_flags: -N
+1783499626.111135 args_parse_flag_argument: -p = (repeat)
+1783499626.111136 args_parse_flags: next -I2
+1783499626.111138 args_parse_flag_argument: -I = 2
+1783499626.111139 args_parse: flags end at 3 of 4
+1783499626.111142 args_parse: 3 = send-keys -N "%%" (type COMMANDS)
+1783499626.111146 cmd_parse_build_commands: command-prompt -N -I 2 -p (repeat) { send-keys -N "%%" }
+1783499626.111148 args_parse_flags: next -Tcopy-mode
+1783499626.111150 args_parse_flag_argument: -T = copy-mode
+1783499626.111151 args_parse_flags: next M-2
+1783499626.111153 args_parse: flags end at 2 of 4
+1783499626.111154 args_parse: 2 = M-2 (type STRING)
+1783499626.111159 args_parse: 3 = command-prompt -N -I 2 -p (repeat) { send-keys -N "%%" } (type COMMANDS)
+1783499626.111165 cmd_parse_build_commands: bind-key -T copy-mode M-2 { command-prompt -N -I 2 -p (repeat) { send-keys -N "%%" } }
+1783499626.111168 cmdq_get_command: [bind-key/0x58e472513f50] group 1696
+1783499626.111169 cmdq_append <global>: [bind-key/0x58e472513f50]
+1783499626.111173 yylex_token: end at WS
+1783499626.111174 yylex_token: bind
+1783499626.111176 yylex_token: end at WS
+1783499626.111177 yylex_token: -Tcopy-mode
+1783499626.111178 yylex_token: end at WS
+1783499626.111179 yylex_token: M-3
+1783499626.111181 yylex_token: end at WS
+1783499626.111183 yylex_token: command-prompt
+1783499626.111184 yylex_token: end at WS
+1783499626.111185 yylex_token: -Np(repeat)
+1783499626.111187 yylex_token: end at WS
+1783499626.111188 yylex_token: -I3
+1783499626.111189 yylex_token: end at WS
+1783499626.111190 yylex_token: send
+1783499626.111192 yylex_token: end at WS
+1783499626.111193 yylex_token: -N
+1783499626.111283 yylex_token: end at WS
+1783499626.111289 yylex_token: %%
+1783499626.111294 cmd_parse_build_commands 0:0: bind
+1783499626.111297 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.111299 cmd_parse_build_commands 0:2: M-3
+1783499626.111301 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.111303 cmd_parse_build_commands 0:3 0:1: -Np(repeat)
+1783499626.111305 cmd_parse_build_commands 0:3 0:2: -I3
+1783499626.111308 cmd_parse_build_commands 0:3 0:3 0:0: send
+1783499626.111310 cmd_parse_build_commands 0:3 0:3 0:1: -N
+1783499626.111312 cmd_parse_build_commands 0:3 0:3 0:2: %%
+1783499626.111316 cmd_parse_build_commands 0:0: command-prompt
+1783499626.111318 cmd_parse_build_commands 0:1: -Np(repeat)
+1783499626.111319 cmd_parse_build_commands 0:2: -I3
+1783499626.111321 cmd_parse_build_commands 0:3 0:0: send
+1783499626.111323 cmd_parse_build_commands 0:3 0:1: -N
+1783499626.111325 cmd_parse_build_commands 0:3 0:2: %%
+1783499626.111328 cmd_parse_build_commands 0:0: send
+1783499626.111329 cmd_parse_build_commands 0:1: -N
+1783499626.111331 cmd_parse_build_commands 0:2: %%
+1783499626.111336 args_parse_flags: next -N
+1783499626.111338 args_parse_flag_argument: -N = %%
+1783499626.111340 args_parse: flags end at 3 of 3
+1783499626.111345 cmd_parse_build_commands: send-keys -N "%%"
+1783499626.111348 args_parse_flags: next -Np(repeat)
+1783499626.111349 args_parse_flags: -N
+1783499626.111351 args_parse_flag_argument: -p = (repeat)
+1783499626.111353 args_parse_flags: next -I3
+1783499626.111355 args_parse_flag_argument: -I = 3
+1783499626.111357 args_parse: flags end at 3 of 4
+1783499626.111360 args_parse: 3 = send-keys -N "%%" (type COMMANDS)
+1783499626.111366 cmd_parse_build_commands: command-prompt -N -I 3 -p (repeat) { send-keys -N "%%" }
+1783499626.111368 args_parse_flags: next -Tcopy-mode
+1783499626.111370 args_parse_flag_argument: -T = copy-mode
+1783499626.111372 args_parse_flags: next M-3
+1783499626.111397 args_parse: flags end at 2 of 4
+1783499626.111401 args_parse: 2 = M-3 (type STRING)
+1783499626.111410 args_parse: 3 = command-prompt -N -I 3 -p (repeat) { send-keys -N "%%" } (type COMMANDS)
+1783499626.111419 cmd_parse_build_commands: bind-key -T copy-mode M-3 { command-prompt -N -I 3 -p (repeat) { send-keys -N "%%" } }
+1783499626.111423 cmdq_get_command: [bind-key/0x58e472514640] group 1708
+1783499626.111425 cmdq_append <global>: [bind-key/0x58e472514640]
+1783499626.111439 yylex_token: end at WS
+1783499626.111443 yylex_token: bind
+1783499626.111445 yylex_token: end at WS
+1783499626.111447 yylex_token: -Tcopy-mode
+1783499626.111449 yylex_token: end at WS
+1783499626.111450 yylex_token: M-4
+1783499626.111452 yylex_token: end at WS
+1783499626.111454 yylex_token: command-prompt
+1783499626.111456 yylex_token: end at WS
+1783499626.111458 yylex_token: -Np(repeat)
+1783499626.111460 yylex_token: end at WS
+1783499626.111461 yylex_token: -I4
+1783499626.111463 yylex_token: end at WS
+1783499626.111464 yylex_token: send
+1783499626.111466 yylex_token: end at WS
+1783499626.111467 yylex_token: -N
+1783499626.111469 yylex_token: end at WS
+1783499626.111470 yylex_token: %%
+1783499626.111474 cmd_parse_build_commands 0:0: bind
+1783499626.111476 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.111478 cmd_parse_build_commands 0:2: M-4
+1783499626.111480 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.111482 cmd_parse_build_commands 0:3 0:1: -Np(repeat)
+1783499626.111484 cmd_parse_build_commands 0:3 0:2: -I4
+1783499626.111486 cmd_parse_build_commands 0:3 0:3 0:0: send
+1783499626.111488 cmd_parse_build_commands 0:3 0:3 0:1: -N
+1783499626.111490 cmd_parse_build_commands 0:3 0:3 0:2: %%
+1783499626.111493 cmd_parse_build_commands 0:0: command-prompt
+1783499626.111495 cmd_parse_build_commands 0:1: -Np(repeat)
+1783499626.111497 cmd_parse_build_commands 0:2: -I4
+1783499626.111499 cmd_parse_build_commands 0:3 0:0: send
+1783499626.111500 cmd_parse_build_commands 0:3 0:1: -N
+1783499626.111502 cmd_parse_build_commands 0:3 0:2: %%
+1783499626.111505 cmd_parse_build_commands 0:0: send
+1783499626.111506 cmd_parse_build_commands 0:1: -N
+1783499626.111514 cmd_parse_build_commands 0:2: %%
+1783499626.111518 args_parse_flags: next -N
+1783499626.111520 args_parse_flag_argument: -N = %%
+1783499626.111522 args_parse: flags end at 3 of 3
+1783499626.111526 cmd_parse_build_commands: send-keys -N "%%"
+1783499626.111528 args_parse_flags: next -Np(repeat)
+1783499626.111530 args_parse_flags: -N
+1783499626.111532 args_parse_flag_argument: -p = (repeat)
+1783499626.111533 args_parse_flags: next -I4
+1783499626.111535 args_parse_flag_argument: -I = 4
+1783499626.111537 args_parse: flags end at 3 of 4
+1783499626.111539 args_parse: 3 = send-keys -N "%%" (type COMMANDS)
+1783499626.111545 cmd_parse_build_commands: command-prompt -N -I 4 -p (repeat) { send-keys -N "%%" }
+1783499626.111547 args_parse_flags: next -Tcopy-mode
+1783499626.111549 args_parse_flag_argument: -T = copy-mode
+1783499626.111550 args_parse_flags: next M-4
+1783499626.111552 args_parse: flags end at 2 of 4
+1783499626.111553 args_parse: 2 = M-4 (type STRING)
+1783499626.111558 args_parse: 3 = command-prompt -N -I 4 -p (repeat) { send-keys -N "%%" } (type COMMANDS)
+1783499626.111565 cmd_parse_build_commands: bind-key -T copy-mode M-4 { command-prompt -N -I 4 -p (repeat) { send-keys -N "%%" } }
+1783499626.111568 cmdq_get_command: [bind-key/0x58e472514dc0] group 1720
+1783499626.111570 cmdq_append <global>: [bind-key/0x58e472514dc0]
+1783499626.111574 yylex_token: end at WS
+1783499626.111576 yylex_token: bind
+1783499626.111578 yylex_token: end at WS
+1783499626.111579 yylex_token: -Tcopy-mode
+1783499626.111581 yylex_token: end at WS
+1783499626.111582 yylex_token: M-5
+1783499626.111584 yylex_token: end at WS
+1783499626.111586 yylex_token: command-prompt
+1783499626.111588 yylex_token: end at WS
+1783499626.111589 yylex_token: -Np(repeat)
+1783499626.111591 yylex_token: end at WS
+1783499626.111592 yylex_token: -I5
+1783499626.111593 yylex_token: end at WS
+1783499626.111595 yylex_token: send
+1783499626.111596 yylex_token: end at WS
+1783499626.111598 yylex_token: -N
+1783499626.111599 yylex_token: end at WS
+1783499626.111600 yylex_token: %%
+1783499626.111604 cmd_parse_build_commands 0:0: bind
+1783499626.111606 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.111607 cmd_parse_build_commands 0:2: M-5
+1783499626.111609 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.111611 cmd_parse_build_commands 0:3 0:1: -Np(repeat)
+1783499626.111613 cmd_parse_build_commands 0:3 0:2: -I5
+1783499626.111615 cmd_parse_build_commands 0:3 0:3 0:0: send
+1783499626.111617 cmd_parse_build_commands 0:3 0:3 0:1: -N
+1783499626.111618 cmd_parse_build_commands 0:3 0:3 0:2: %%
+1783499626.111621 cmd_parse_build_commands 0:0: command-prompt
+1783499626.111622 cmd_parse_build_commands 0:1: -Np(repeat)
+1783499626.111624 cmd_parse_build_commands 0:2: -I5
+1783499626.111626 cmd_parse_build_commands 0:3 0:0: send
+1783499626.111628 cmd_parse_build_commands 0:3 0:1: -N
+1783499626.111629 cmd_parse_build_commands 0:3 0:2: %%
+1783499626.111632 cmd_parse_build_commands 0:0: send
+1783499626.111633 cmd_parse_build_commands 0:1: -N
+1783499626.111635 cmd_parse_build_commands 0:2: %%
+1783499626.111638 args_parse_flags: next -N
+1783499626.111640 args_parse_flag_argument: -N = %%
+1783499626.111642 args_parse: flags end at 3 of 3
+1783499626.111645 cmd_parse_build_commands: send-keys -N "%%"
+1783499626.111647 args_parse_flags: next -Np(repeat)
+1783499626.111648 args_parse_flags: -N
+1783499626.111650 args_parse_flag_argument: -p = (repeat)
+1783499626.111652 args_parse_flags: next -I5
+1783499626.111654 args_parse_flag_argument: -I = 5
+1783499626.111655 args_parse: flags end at 3 of 4
+1783499626.111658 args_parse: 3 = send-keys -N "%%" (type COMMANDS)
+1783499626.111663 cmd_parse_build_commands: command-prompt -N -I 5 -p (repeat) { send-keys -N "%%" }
+1783499626.111665 args_parse_flags: next -Tcopy-mode
+1783499626.111667 args_parse_flag_argument: -T = copy-mode
+1783499626.111668 args_parse_flags: next M-5
+1783499626.111670 args_parse: flags end at 2 of 4
+1783499626.111671 args_parse: 2 = M-5 (type STRING)
+1783499626.111676 args_parse: 3 = command-prompt -N -I 5 -p (repeat) { send-keys -N "%%" } (type COMMANDS)
+1783499626.111687 cmd_parse_build_commands: bind-key -T copy-mode M-5 { command-prompt -N -I 5 -p (repeat) { send-keys -N "%%" } }
+1783499626.111691 cmdq_get_command: [bind-key/0x58e472515490] group 1732
+1783499626.111693 cmdq_append <global>: [bind-key/0x58e472515490]
+1783499626.111704 yylex_token: end at WS
+1783499626.111708 yylex_token: bind
+1783499626.111710 yylex_token: end at WS
+1783499626.111712 yylex_token: -Tcopy-mode
+1783499626.111714 yylex_token: end at WS
+1783499626.111715 yylex_token: M-6
+1783499626.111717 yylex_token: end at WS
+1783499626.111719 yylex_token: command-prompt
+1783499626.111721 yylex_token: end at WS
+1783499626.111722 yylex_token: -Np(repeat)
+1783499626.111724 yylex_token: end at WS
+1783499626.111725 yylex_token: -I6
+1783499626.111727 yylex_token: end at WS
+1783499626.111728 yylex_token: send
+1783499626.111729 yylex_token: end at WS
+1783499626.111730 yylex_token: -N
+1783499626.111732 yylex_token: end at WS
+1783499626.111733 yylex_token: %%
+1783499626.111737 cmd_parse_build_commands 0:0: bind
+1783499626.111738 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.111740 cmd_parse_build_commands 0:2: M-6
+1783499626.111742 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.111744 cmd_parse_build_commands 0:3 0:1: -Np(repeat)
+1783499626.111746 cmd_parse_build_commands 0:3 0:2: -I6
+1783499626.111748 cmd_parse_build_commands 0:3 0:3 0:0: send
+1783499626.111749 cmd_parse_build_commands 0:3 0:3 0:1: -N
+1783499626.111751 cmd_parse_build_commands 0:3 0:3 0:2: %%
+1783499626.111754 cmd_parse_build_commands 0:0: command-prompt
+1783499626.111756 cmd_parse_build_commands 0:1: -Np(repeat)
+1783499626.111757 cmd_parse_build_commands 0:2: -I6
+1783499626.111759 cmd_parse_build_commands 0:3 0:0: send
+1783499626.111761 cmd_parse_build_commands 0:3 0:1: -N
+1783499626.111763 cmd_parse_build_commands 0:3 0:2: %%
+1783499626.111765 cmd_parse_build_commands 0:0: send
+1783499626.111767 cmd_parse_build_commands 0:1: -N
+1783499626.111768 cmd_parse_build_commands 0:2: %%
+1783499626.111772 args_parse_flags: next -N
+1783499626.111774 args_parse_flag_argument: -N = %%
+1783499626.111775 args_parse: flags end at 3 of 3
+1783499626.111779 cmd_parse_build_commands: send-keys -N "%%"
+1783499626.111781 args_parse_flags: next -Np(repeat)
+1783499626.111783 args_parse_flags: -N
+1783499626.111785 args_parse_flag_argument: -p = (repeat)
+1783499626.111786 args_parse_flags: next -I6
+1783499626.111788 args_parse_flag_argument: -I = 6
+1783499626.111789 args_parse: flags end at 3 of 4
+1783499626.111792 args_parse: 3 = send-keys -N "%%" (type COMMANDS)
+1783499626.111797 cmd_parse_build_commands: command-prompt -N -I 6 -p (repeat) { send-keys -N "%%" }
+1783499626.111799 args_parse_flags: next -Tcopy-mode
+1783499626.111801 args_parse_flag_argument: -T = copy-mode
+1783499626.111803 args_parse_flags: next M-6
+1783499626.111804 args_parse: flags end at 2 of 4
+1783499626.111806 args_parse: 2 = M-6 (type STRING)
+1783499626.111810 args_parse: 3 = command-prompt -N -I 6 -p (repeat) { send-keys -N "%%" } (type COMMANDS)
+1783499626.111817 cmd_parse_build_commands: bind-key -T copy-mode M-6 { command-prompt -N -I 6 -p (repeat) { send-keys -N "%%" } }
+1783499626.111820 cmdq_get_command: [bind-key/0x58e472515cb0] group 1744
+1783499626.111822 cmdq_append <global>: [bind-key/0x58e472515cb0]
+1783499626.111826 yylex_token: end at WS
+1783499626.111827 yylex_token: bind
+1783499626.111829 yylex_token: end at WS
+1783499626.111831 yylex_token: -Tcopy-mode
+1783499626.111832 yylex_token: end at WS
+1783499626.111833 yylex_token: M-7
+1783499626.111835 yylex_token: end at WS
+1783499626.111837 yylex_token: command-prompt
+1783499626.111839 yylex_token: end at WS
+1783499626.111840 yylex_token: -Np(repeat)
+1783499626.111842 yylex_token: end at WS
+1783499626.111843 yylex_token: -I7
+1783499626.111845 yylex_token: end at WS
+1783499626.111846 yylex_token: send
+1783499626.111847 yylex_token: end at WS
+1783499626.111849 yylex_token: -N
+1783499626.111850 yylex_token: end at WS
+1783499626.111851 yylex_token: %%
+1783499626.111854 cmd_parse_build_commands 0:0: bind
+1783499626.111860 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.111861 cmd_parse_build_commands 0:2: M-7
+1783499626.111863 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.111865 cmd_parse_build_commands 0:3 0:1: -Np(repeat)
+1783499626.111867 cmd_parse_build_commands 0:3 0:2: -I7
+1783499626.111869 cmd_parse_build_commands 0:3 0:3 0:0: send
+1783499626.111870 cmd_parse_build_commands 0:3 0:3 0:1: -N
+1783499626.111872 cmd_parse_build_commands 0:3 0:3 0:2: %%
+1783499626.111874 cmd_parse_build_commands 0:0: command-prompt
+1783499626.111876 cmd_parse_build_commands 0:1: -Np(repeat)
+1783499626.111878 cmd_parse_build_commands 0:2: -I7
+1783499626.111879 cmd_parse_build_commands 0:3 0:0: send
+1783499626.111881 cmd_parse_build_commands 0:3 0:1: -N
+1783499626.111883 cmd_parse_build_commands 0:3 0:2: %%
+1783499626.111885 cmd_parse_build_commands 0:0: send
+1783499626.111886 cmd_parse_build_commands 0:1: -N
+1783499626.111888 cmd_parse_build_commands 0:2: %%
+1783499626.111891 args_parse_flags: next -N
+1783499626.111893 args_parse_flag_argument: -N = %%
+1783499626.111895 args_parse: flags end at 3 of 3
+1783499626.111898 cmd_parse_build_commands: send-keys -N "%%"
+1783499626.111900 args_parse_flags: next -Np(repeat)
+1783499626.111901 args_parse_flags: -N
+1783499626.111903 args_parse_flag_argument: -p = (repeat)
+1783499626.111905 args_parse_flags: next -I7
+1783499626.111906 args_parse_flag_argument: -I = 7
+1783499626.111908 args_parse: flags end at 3 of 4
+1783499626.111911 args_parse: 3 = send-keys -N "%%" (type COMMANDS)
+1783499626.111916 cmd_parse_build_commands: command-prompt -N -I 7 -p (repeat) { send-keys -N "%%" }
+1783499626.111918 args_parse_flags: next -Tcopy-mode
+1783499626.111919 args_parse_flag_argument: -T = copy-mode
+1783499626.111921 args_parse_flags: next M-7
+1783499626.111923 args_parse: flags end at 2 of 4
+1783499626.111924 args_parse: 2 = M-7 (type STRING)
+1783499626.111929 args_parse: 3 = command-prompt -N -I 7 -p (repeat) { send-keys -N "%%" } (type COMMANDS)
+1783499626.111935 cmd_parse_build_commands: bind-key -T copy-mode M-7 { command-prompt -N -I 7 -p (repeat) { send-keys -N "%%" } }
+1783499626.111938 cmdq_get_command: [bind-key/0x58e4725161b0] group 1756
+1783499626.111940 cmdq_append <global>: [bind-key/0x58e4725161b0]
+1783499626.111944 yylex_token: end at WS
+1783499626.111946 yylex_token: bind
+1783499626.111947 yylex_token: end at WS
+1783499626.111949 yylex_token: -Tcopy-mode
+1783499626.111951 yylex_token: end at WS
+1783499626.111952 yylex_token: M-8
+1783499626.111954 yylex_token: end at WS
+1783499626.111955 yylex_token: command-prompt
+1783499626.111957 yylex_token: end at WS
+1783499626.111958 yylex_token: -Np(repeat)
+1783499626.111960 yylex_token: end at WS
+1783499626.111961 yylex_token: -I8
+1783499626.111963 yylex_token: end at WS
+1783499626.111964 yylex_token: send
+1783499626.111965 yylex_token: end at WS
+1783499626.111966 yylex_token: -N
+1783499626.111968 yylex_token: end at WS
+1783499626.111969 yylex_token: %%
+1783499626.111972 cmd_parse_build_commands 0:0: bind
+1783499626.111974 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.111975 cmd_parse_build_commands 0:2: M-8
+1783499626.111977 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.111979 cmd_parse_build_commands 0:3 0:1: -Np(repeat)
+1783499626.111981 cmd_parse_build_commands 0:3 0:2: -I8
+1783499626.111983 cmd_parse_build_commands 0:3 0:3 0:0: send
+1783499626.111985 cmd_parse_build_commands 0:3 0:3 0:1: -N
+1783499626.111986 cmd_parse_build_commands 0:3 0:3 0:2: %%
+1783499626.111989 cmd_parse_build_commands 0:0: command-prompt
+1783499626.111990 cmd_parse_build_commands 0:1: -Np(repeat)
+1783499626.111992 cmd_parse_build_commands 0:2: -I8
+1783499626.111994 cmd_parse_build_commands 0:3 0:0: send
+1783499626.111995 cmd_parse_build_commands 0:3 0:1: -N
+1783499626.111997 cmd_parse_build_commands 0:3 0:2: %%
+1783499626.111999 cmd_parse_build_commands 0:0: send
+1783499626.112000 cmd_parse_build_commands 0:1: -N
+1783499626.112002 cmd_parse_build_commands 0:2: %%
+1783499626.112005 args_parse_flags: next -N
+1783499626.112010 args_parse_flag_argument: -N = %%
+1783499626.112011 args_parse: flags end at 3 of 3
+1783499626.112014 cmd_parse_build_commands: send-keys -N "%%"
+1783499626.112016 args_parse_flags: next -Np(repeat)
+1783499626.112018 args_parse_flags: -N
+1783499626.112019 args_parse_flag_argument: -p = (repeat)
+1783499626.112021 args_parse_flags: next -I8
+1783499626.112023 args_parse_flag_argument: -I = 8
+1783499626.112024 args_parse: flags end at 3 of 4
+1783499626.112027 args_parse: 3 = send-keys -N "%%" (type COMMANDS)
+1783499626.112032 cmd_parse_build_commands: command-prompt -N -I 8 -p (repeat) { send-keys -N "%%" }
+1783499626.112034 args_parse_flags: next -Tcopy-mode
+1783499626.112036 args_parse_flag_argument: -T = copy-mode
+1783499626.112038 args_parse_flags: next M-8
+1783499626.112039 args_parse: flags end at 2 of 4
+1783499626.112041 args_parse: 2 = M-8 (type STRING)
+1783499626.112046 args_parse: 3 = command-prompt -N -I 8 -p (repeat) { send-keys -N "%%" } (type COMMANDS)
+1783499626.112052 cmd_parse_build_commands: bind-key -T copy-mode M-8 { command-prompt -N -I 8 -p (repeat) { send-keys -N "%%" } }
+1783499626.112055 cmdq_get_command: [bind-key/0x58e4725168a0] group 1768
+1783499626.112057 cmdq_append <global>: [bind-key/0x58e4725168a0]
+1783499626.112073 yylex_token: end at WS
+1783499626.112078 yylex_token: bind
+1783499626.112080 yylex_token: end at WS
+1783499626.112081 yylex_token: -Tcopy-mode
+1783499626.112083 yylex_token: end at WS
+1783499626.112084 yylex_token: M-9
+1783499626.112086 yylex_token: end at WS
+1783499626.112088 yylex_token: command-prompt
+1783499626.112090 yylex_token: end at WS
+1783499626.112091 yylex_token: -Np(repeat)
+1783499626.112093 yylex_token: end at WS
+1783499626.112094 yylex_token: -I9
+1783499626.112096 yylex_token: end at WS
+1783499626.112097 yylex_token: send
+1783499626.112099 yylex_token: end at WS
+1783499626.112100 yylex_token: -N
+1783499626.112102 yylex_token: end at WS
+1783499626.112103 yylex_token: %%
+1783499626.112117 cmd_parse_build_commands 0:0: bind
+1783499626.112119 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.112121 cmd_parse_build_commands 0:2: M-9
+1783499626.112123 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.112125 cmd_parse_build_commands 0:3 0:1: -Np(repeat)
+1783499626.112126 cmd_parse_build_commands 0:3 0:2: -I9
+1783499626.112128 cmd_parse_build_commands 0:3 0:3 0:0: send
+1783499626.112130 cmd_parse_build_commands 0:3 0:3 0:1: -N
+1783499626.112132 cmd_parse_build_commands 0:3 0:3 0:2: %%
+1783499626.112135 cmd_parse_build_commands 0:0: command-prompt
+1783499626.112137 cmd_parse_build_commands 0:1: -Np(repeat)
+1783499626.112138 cmd_parse_build_commands 0:2: -I9
+1783499626.112140 cmd_parse_build_commands 0:3 0:0: send
+1783499626.112142 cmd_parse_build_commands 0:3 0:1: -N
+1783499626.112143 cmd_parse_build_commands 0:3 0:2: %%
+1783499626.112146 cmd_parse_build_commands 0:0: send
+1783499626.112147 cmd_parse_build_commands 0:1: -N
+1783499626.112149 cmd_parse_build_commands 0:2: %%
+1783499626.112152 args_parse_flags: next -N
+1783499626.112154 args_parse_flag_argument: -N = %%
+1783499626.112156 args_parse: flags end at 3 of 3
+1783499626.112160 cmd_parse_build_commands: send-keys -N "%%"
+1783499626.112162 args_parse_flags: next -Np(repeat)
+1783499626.112163 args_parse_flags: -N
+1783499626.112165 args_parse_flag_argument: -p = (repeat)
+1783499626.112166 args_parse_flags: next -I9
+1783499626.112168 args_parse_flag_argument: -I = 9
+1783499626.112170 args_parse: flags end at 3 of 4
+1783499626.112174 args_parse: 3 = send-keys -N "%%" (type COMMANDS)
+1783499626.112179 cmd_parse_build_commands: command-prompt -N -I 9 -p (repeat) { send-keys -N "%%" }
+1783499626.112182 args_parse_flags: next -Tcopy-mode
+1783499626.112183 args_parse_flag_argument: -T = copy-mode
+1783499626.112185 args_parse_flags: next M-9
+1783499626.112186 args_parse: flags end at 2 of 4
+1783499626.112188 args_parse: 2 = M-9 (type STRING)
+1783499626.112193 args_parse: 3 = command-prompt -N -I 9 -p (repeat) { send-keys -N "%%" } (type COMMANDS)
+1783499626.112201 cmd_parse_build_commands: bind-key -T copy-mode M-9 { command-prompt -N -I 9 -p (repeat) { send-keys -N "%%" } }
+1783499626.112209 cmdq_get_command: [bind-key/0x58e4725159b0] group 1780
+1783499626.112212 cmdq_append <global>: [bind-key/0x58e4725159b0]
+1783499626.112214 yylex_token: end at WS
+1783499626.112215 yylex_token: bind
+1783499626.112217 yylex_token: end at WS
+1783499626.112219 yylex_token: -Tcopy-mode
+1783499626.112220 yylex_token: end at WS
+1783499626.112222 yylex_token: M-<
+1783499626.112223 yylex_token: end at WS
+1783499626.112224 yylex_token: send
+1783499626.112226 yylex_token: end at WS
+1783499626.112227 yylex_token: -X
+1783499626.112229 yylex_token: end at WS
+1783499626.112231 yylex_token: history-top
+1783499626.112234 cmd_parse_build_commands 0:0: bind
+1783499626.112235 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.112237 cmd_parse_build_commands 0:2: M-<
+1783499626.112239 cmd_parse_build_commands 0:3 0:0: send
+1783499626.112240 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.112242 cmd_parse_build_commands 0:3 0:2: history-top
+1783499626.112245 cmd_parse_build_commands 0:0: send
+1783499626.112246 cmd_parse_build_commands 0:1: -X
+1783499626.112248 cmd_parse_build_commands 0:2: history-top
+1783499626.112251 args_parse_flags: next -X
+1783499626.112253 args_parse_flags: -X
+1783499626.112255 args_parse_flags: next history-top
+1783499626.112256 args_parse: flags end at 2 of 3
+1783499626.112258 args_parse: 2 = history-top (type STRING)
+1783499626.112262 cmd_parse_build_commands: send-keys -X history-top
+1783499626.112264 args_parse_flags: next -Tcopy-mode
+1783499626.112266 args_parse_flag_argument: -T = copy-mode
+1783499626.112268 args_parse_flags: next M-<
+1783499626.112269 args_parse: flags end at 2 of 4
+1783499626.112271 args_parse: 2 = M-< (type STRING)
+1783499626.112274 args_parse: 3 = send-keys -X history-top (type COMMANDS)
+1783499626.112280 cmd_parse_build_commands: bind-key -T copy-mode M-< { send-keys -X history-top }
+1783499626.112284 cmdq_get_command: [bind-key/0x58e472516c10] group 1792
+1783499626.112286 cmdq_append <global>: [bind-key/0x58e472516c10]
+1783499626.112288 yylex_token: end at WS
+1783499626.112289 yylex_token: bind
+1783499626.112291 yylex_token: end at WS
+1783499626.112292 yylex_token: -Tcopy-mode
+1783499626.112294 yylex_token: end at WS
+1783499626.112295 yylex_token: M->
+1783499626.112297 yylex_token: end at WS
+1783499626.112298 yylex_token: send
+1783499626.112299 yylex_token: end at WS
+1783499626.112300 yylex_token: -X
+1783499626.112302 yylex_token: end at WS
+1783499626.112304 yylex_token: history-bottom
+1783499626.112307 cmd_parse_build_commands 0:0: bind
+1783499626.112309 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.112310 cmd_parse_build_commands 0:2: M->
+1783499626.112312 cmd_parse_build_commands 0:3 0:0: send
+1783499626.112314 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.112316 cmd_parse_build_commands 0:3 0:2: history-bottom
+1783499626.112318 cmd_parse_build_commands 0:0: send
+1783499626.112320 cmd_parse_build_commands 0:1: -X
+1783499626.112322 cmd_parse_build_commands 0:2: history-bottom
+1783499626.112325 args_parse_flags: next -X
+1783499626.112326 args_parse_flags: -X
+1783499626.112328 args_parse_flags: next history-bottom
+1783499626.112329 args_parse: flags end at 2 of 3
+1783499626.112331 args_parse: 2 = history-bottom (type STRING)
+1783499626.112335 cmd_parse_build_commands: send-keys -X history-bottom
+1783499626.112337 args_parse_flags: next -Tcopy-mode
+1783499626.112339 args_parse_flag_argument: -T = copy-mode
+1783499626.112340 args_parse_flags: next M->
+1783499626.112342 args_parse: flags end at 2 of 4
+1783499626.112343 args_parse: 2 = M-> (type STRING)
+1783499626.112347 args_parse: 3 = send-keys -X history-bottom (type COMMANDS)
+1783499626.112352 cmd_parse_build_commands: bind-key -T copy-mode M-> { send-keys -X history-bottom }
+1783499626.112356 cmdq_get_command: [bind-key/0x58e472516f00] group 1800
+1783499626.112358 cmdq_append <global>: [bind-key/0x58e472516f00]
+1783499626.112360 yylex_token: end at WS
+1783499626.112361 yylex_token: bind
+1783499626.112363 yylex_token: end at WS
+1783499626.112367 yylex_token: -Tcopy-mode
+1783499626.112369 yylex_token: end at WS
+1783499626.112370 yylex_token: M-R
+1783499626.112372 yylex_token: end at WS
+1783499626.112373 yylex_token: send
+1783499626.112374 yylex_token: end at WS
+1783499626.112376 yylex_token: -X
+1783499626.112378 yylex_token: end at WS
+1783499626.112379 yylex_token: top-line
+1783499626.112382 cmd_parse_build_commands 0:0: bind
+1783499626.112383 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.112385 cmd_parse_build_commands 0:2: M-R
+1783499626.112387 cmd_parse_build_commands 0:3 0:0: send
+1783499626.112389 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.112390 cmd_parse_build_commands 0:3 0:2: top-line
+1783499626.112393 cmd_parse_build_commands 0:0: send
+1783499626.112394 cmd_parse_build_commands 0:1: -X
+1783499626.112396 cmd_parse_build_commands 0:2: top-line
+1783499626.112399 args_parse_flags: next -X
+1783499626.112401 args_parse_flags: -X
+1783499626.112402 args_parse_flags: next top-line
+1783499626.112404 args_parse: flags end at 2 of 3
+1783499626.112406 args_parse: 2 = top-line (type STRING)
+1783499626.112410 cmd_parse_build_commands: send-keys -X top-line
+1783499626.112412 args_parse_flags: next -Tcopy-mode
+1783499626.112414 args_parse_flag_argument: -T = copy-mode
+1783499626.112415 args_parse_flags: next M-R
+1783499626.112417 args_parse: flags end at 2 of 4
+1783499626.112418 args_parse: 2 = M-R (type STRING)
+1783499626.112421 args_parse: 3 = send-keys -X top-line (type COMMANDS)
+1783499626.112426 cmd_parse_build_commands: bind-key -T copy-mode M-R { send-keys -X top-line }
+1783499626.112430 cmdq_get_command: [bind-key/0x58e4725170a0] group 1808
+1783499626.112432 cmdq_append <global>: [bind-key/0x58e4725170a0]
+1783499626.112434 yylex_token: end at WS
+1783499626.112435 yylex_token: bind
+1783499626.112437 yylex_token: end at WS
+1783499626.112438 yylex_token: -Tcopy-mode
+1783499626.112440 yylex_token: end at WS
+1783499626.112441 yylex_token: M-b
+1783499626.112442 yylex_token: end at WS
+1783499626.112444 yylex_token: send
+1783499626.112445 yylex_token: end at WS
+1783499626.112446 yylex_token: -X
+1783499626.112448 yylex_token: end at WS
+1783499626.112449 yylex_token: previous-word
+1783499626.112452 cmd_parse_build_commands 0:0: bind
+1783499626.112454 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.112456 cmd_parse_build_commands 0:2: M-b
+1783499626.112458 cmd_parse_build_commands 0:3 0:0: send
+1783499626.112459 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.112461 cmd_parse_build_commands 0:3 0:2: previous-word
+1783499626.112463 cmd_parse_build_commands 0:0: send
+1783499626.112465 cmd_parse_build_commands 0:1: -X
+1783499626.112467 cmd_parse_build_commands 0:2: previous-word
+1783499626.112470 args_parse_flags: next -X
+1783499626.112471 args_parse_flags: -X
+1783499626.112473 args_parse_flags: next previous-word
+1783499626.112475 args_parse: flags end at 2 of 3
+1783499626.112476 args_parse: 2 = previous-word (type STRING)
+1783499626.112480 cmd_parse_build_commands: send-keys -X previous-word
+1783499626.112482 args_parse_flags: next -Tcopy-mode
+1783499626.112484 args_parse_flag_argument: -T = copy-mode
+1783499626.112485 args_parse_flags: next M-b
+1783499626.112487 args_parse: flags end at 2 of 4
+1783499626.112488 args_parse: 2 = M-b (type STRING)
+1783499626.112491 args_parse: 3 = send-keys -X previous-word (type COMMANDS)
+1783499626.112497 cmd_parse_build_commands: bind-key -T copy-mode M-b { send-keys -X previous-word }
+1783499626.112500 cmdq_get_command: [bind-key/0x58e472517270] group 1816
+1783499626.112502 cmdq_append <global>: [bind-key/0x58e472517270]
+1783499626.112512 yylex_token: end at WS
+1783499626.112516 yylex_token: bind
+1783499626.112518 yylex_token: end at WS
+1783499626.112520 yylex_token: -Tcopy-mode
+1783499626.112521 yylex_token: end at WS
+1783499626.112523 yylex_token: C-M-b
+1783499626.112524 yylex_token: end at WS
+1783499626.112525 yylex_token: send
+1783499626.112527 yylex_token: end at WS
+1783499626.112528 yylex_token: -X
+1783499626.112531 yylex_token: end at WS
+1783499626.112532 yylex_token: previous-matching-bracket
+1783499626.112539 cmd_parse_build_commands 0:0: bind
+1783499626.112541 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.112542 cmd_parse_build_commands 0:2: C-M-b
+1783499626.112544 cmd_parse_build_commands 0:3 0:0: send
+1783499626.112546 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.112548 cmd_parse_build_commands 0:3 0:2: previous-matching-bracket
+1783499626.112551 cmd_parse_build_commands 0:0: send
+1783499626.112553 cmd_parse_build_commands 0:1: -X
+1783499626.112555 cmd_parse_build_commands 0:2: previous-matching-bracket
+1783499626.112558 args_parse_flags: next -X
+1783499626.112560 args_parse_flags: -X
+1783499626.112562 args_parse_flags: next previous-matching-bracket
+1783499626.112563 args_parse: flags end at 2 of 3
+1783499626.112566 args_parse: 2 = previous-matching-bracket (type STRING)
+1783499626.112570 cmd_parse_build_commands: send-keys -X previous-matching-bracket
+1783499626.112572 args_parse_flags: next -Tcopy-mode
+1783499626.112574 args_parse_flag_argument: -T = copy-mode
+1783499626.112575 args_parse_flags: next C-M-b
+1783499626.112577 args_parse: flags end at 2 of 4
+1783499626.112578 args_parse: 2 = C-M-b (type STRING)
+1783499626.112582 args_parse: 3 = send-keys -X previous-matching-bracket (type COMMANDS)
+1783499626.112589 cmd_parse_build_commands: bind-key -T copy-mode C-M-b { send-keys -X previous-matching-bracket }
+1783499626.112592 cmdq_get_command: [bind-key/0x58e472517b10] group 1824
+1783499626.112595 cmdq_append <global>: [bind-key/0x58e472517b10]
+1783499626.112597 yylex_token: end at WS
+1783499626.112598 yylex_token: bind
+1783499626.112600 yylex_token: end at WS
+1783499626.112601 yylex_token: -Tcopy-mode
+1783499626.112603 yylex_token: end at WS
+1783499626.112604 yylex_token: M-f
+1783499626.112605 yylex_token: end at WS
+1783499626.112607 yylex_token: send
+1783499626.112608 yylex_token: end at WS
+1783499626.112609 yylex_token: -X
+1783499626.112611 yylex_token: end at WS
+1783499626.112613 yylex_token: next-word-end
+1783499626.112615 cmd_parse_build_commands 0:0: bind
+1783499626.112617 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.112619 cmd_parse_build_commands 0:2: M-f
+1783499626.112621 cmd_parse_build_commands 0:3 0:0: send
+1783499626.112622 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.112624 cmd_parse_build_commands 0:3 0:2: next-word-end
+1783499626.112627 cmd_parse_build_commands 0:0: send
+1783499626.112628 cmd_parse_build_commands 0:1: -X
+1783499626.112630 cmd_parse_build_commands 0:2: next-word-end
+1783499626.112633 args_parse_flags: next -X
+1783499626.112635 args_parse_flags: -X
+1783499626.112636 args_parse_flags: next next-word-end
+1783499626.112638 args_parse: flags end at 2 of 3
+1783499626.112640 args_parse: 2 = next-word-end (type STRING)
+1783499626.112643 cmd_parse_build_commands: send-keys -X next-word-end
+1783499626.112645 args_parse_flags: next -Tcopy-mode
+1783499626.112647 args_parse_flag_argument: -T = copy-mode
+1783499626.112648 args_parse_flags: next M-f
+1783499626.112650 args_parse: flags end at 2 of 4
+1783499626.112652 args_parse: 2 = M-f (type STRING)
+1783499626.112654 args_parse: 3 = send-keys -X next-word-end (type COMMANDS)
+1783499626.112660 cmd_parse_build_commands: bind-key -T copy-mode M-f { send-keys -X next-word-end }
+1783499626.112663 cmdq_get_command: [bind-key/0x58e472517700] group 1832
+1783499626.112665 cmdq_append <global>: [bind-key/0x58e472517700]
+1783499626.112668 yylex_token: end at WS
+1783499626.112669 yylex_token: bind
+1783499626.112671 yylex_token: end at WS
+1783499626.112672 yylex_token: -Tcopy-mode
+1783499626.112674 yylex_token: end at WS
+1783499626.112675 yylex_token: C-M-f
+1783499626.112677 yylex_token: end at WS
+1783499626.112678 yylex_token: send
+1783499626.112679 yylex_token: end at WS
+1783499626.112681 yylex_token: -X
+1783499626.112683 yylex_token: end at WS
+1783499626.112684 yylex_token: next-matching-bracket
+1783499626.112687 cmd_parse_build_commands 0:0: bind
+1783499626.112689 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.112690 cmd_parse_build_commands 0:2: C-M-f
+1783499626.112692 cmd_parse_build_commands 0:3 0:0: send
+1783499626.112694 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.112699 cmd_parse_build_commands 0:3 0:2: next-matching-bracket
+1783499626.112702 cmd_parse_build_commands 0:0: send
+1783499626.112703 cmd_parse_build_commands 0:1: -X
+1783499626.112705 cmd_parse_build_commands 0:2: next-matching-bracket
+1783499626.112709 args_parse_flags: next -X
+1783499626.112710 args_parse_flags: -X
+1783499626.112712 args_parse_flags: next next-matching-bracket
+1783499626.112714 args_parse: flags end at 2 of 3
+1783499626.112716 args_parse: 2 = next-matching-bracket (type STRING)
+1783499626.112720 cmd_parse_build_commands: send-keys -X next-matching-bracket
+1783499626.112722 args_parse_flags: next -Tcopy-mode
+1783499626.112724 args_parse_flag_argument: -T = copy-mode
+1783499626.112725 args_parse_flags: next C-M-f
+1783499626.112727 args_parse: flags end at 2 of 4
+1783499626.112729 args_parse: 2 = C-M-f (type STRING)
+1783499626.112732 args_parse: 3 = send-keys -X next-matching-bracket (type COMMANDS)
+1783499626.112738 cmd_parse_build_commands: bind-key -T copy-mode C-M-f { send-keys -X next-matching-bracket }
+1783499626.112741 cmdq_get_command: [bind-key/0x58e4725180f0] group 1840
+1783499626.112743 cmdq_append <global>: [bind-key/0x58e4725180f0]
+1783499626.112752 yylex_token: end at WS
+1783499626.112756 yylex_token: bind
+1783499626.112758 yylex_token: end at WS
+1783499626.112759 yylex_token: -Tcopy-mode
+1783499626.112761 yylex_token: end at WS
+1783499626.112762 yylex_token: M-m
+1783499626.112764 yylex_token: end at WS
+1783499626.112765 yylex_token: send
+1783499626.112766 yylex_token: end at WS
+1783499626.112767 yylex_token: -X
+1783499626.112769 yylex_token: end at WS
+1783499626.112771 yylex_token: back-to-indentation
+1783499626.112774 cmd_parse_build_commands 0:0: bind
+1783499626.112776 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.112778 cmd_parse_build_commands 0:2: M-m
+1783499626.112780 cmd_parse_build_commands 0:3 0:0: send
+1783499626.112781 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.112783 cmd_parse_build_commands 0:3 0:2: back-to-indentation
+1783499626.112786 cmd_parse_build_commands 0:0: send
+1783499626.112788 cmd_parse_build_commands 0:1: -X
+1783499626.112790 cmd_parse_build_commands 0:2: back-to-indentation
+1783499626.112793 args_parse_flags: next -X
+1783499626.112795 args_parse_flags: -X
+1783499626.112797 args_parse_flags: next back-to-indentation
+1783499626.112798 args_parse: flags end at 2 of 3
+1783499626.112801 args_parse: 2 = back-to-indentation (type STRING)
+1783499626.112805 cmd_parse_build_commands: send-keys -X back-to-indentation
+1783499626.112807 args_parse_flags: next -Tcopy-mode
+1783499626.112808 args_parse_flag_argument: -T = copy-mode
+1783499626.112810 args_parse_flags: next M-m
+1783499626.112811 args_parse: flags end at 2 of 4
+1783499626.112813 args_parse: 2 = M-m (type STRING)
+1783499626.112817 args_parse: 3 = send-keys -X back-to-indentation (type COMMANDS)
+1783499626.112822 cmd_parse_build_commands: bind-key -T copy-mode M-m { send-keys -X back-to-indentation }
+1783499626.112826 cmdq_get_command: [bind-key/0x58e472518a40] group 1848
+1783499626.112828 cmdq_append <global>: [bind-key/0x58e472518a40]
+1783499626.112830 yylex_token: end at WS
+1783499626.112831 yylex_token: bind
+1783499626.112833 yylex_token: end at WS
+1783499626.112834 yylex_token: -Tcopy-mode
+1783499626.112836 yylex_token: end at WS
+1783499626.112837 yylex_token: M-r
+1783499626.112839 yylex_token: end at WS
+1783499626.112840 yylex_token: send
+1783499626.112841 yylex_token: end at WS
+1783499626.112843 yylex_token: -X
+1783499626.112844 yylex_token: end at WS
+1783499626.112846 yylex_token: middle-line
+1783499626.112848 cmd_parse_build_commands 0:0: bind
+1783499626.112850 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.112852 cmd_parse_build_commands 0:2: M-r
+1783499626.112854 cmd_parse_build_commands 0:3 0:0: send
+1783499626.112855 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.112857 cmd_parse_build_commands 0:3 0:2: middle-line
+1783499626.112860 cmd_parse_build_commands 0:0: send
+1783499626.112861 cmd_parse_build_commands 0:1: -X
+1783499626.112863 cmd_parse_build_commands 0:2: middle-line
+1783499626.112869 args_parse_flags: next -X
+1783499626.112899 args_parse_flags: -X
+1783499626.112904 args_parse_flags: next middle-line
+1783499626.112906 args_parse: flags end at 2 of 3
+1783499626.112909 args_parse: 2 = middle-line (type STRING)
+1783499626.112915 cmd_parse_build_commands: send-keys -X middle-line
+1783499626.112918 args_parse_flags: next -Tcopy-mode
+1783499626.112920 args_parse_flag_argument: -T = copy-mode
+1783499626.112922 args_parse_flags: next M-r
+1783499626.112924 args_parse: flags end at 2 of 4
+1783499626.112926 args_parse: 2 = M-r (type STRING)
+1783499626.112930 args_parse: 3 = send-keys -X middle-line (type COMMANDS)
+1783499626.112936 cmd_parse_build_commands: bind-key -T copy-mode M-r { send-keys -X middle-line }
+1783499626.112940 cmdq_get_command: [bind-key/0x58e472518bf0] group 1856
+1783499626.112942 cmdq_append <global>: [bind-key/0x58e472518bf0]
+1783499626.112946 yylex_token: end at WS
+1783499626.112947 yylex_token: bind
+1783499626.112949 yylex_token: end at WS
+1783499626.112951 yylex_token: -Tcopy-mode
+1783499626.112953 yylex_token: end at WS
+1783499626.112954 yylex_token: M-v
+1783499626.112956 yylex_token: end at WS
+1783499626.112957 yylex_token: send
+1783499626.112959 yylex_token: end at WS
+1783499626.112960 yylex_token: -X
+1783499626.112962 yylex_token: end at WS
+1783499626.112963 yylex_token: page-up
+1783499626.112967 cmd_parse_build_commands 0:0: bind
+1783499626.112968 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.112970 cmd_parse_build_commands 0:2: M-v
+1783499626.112972 cmd_parse_build_commands 0:3 0:0: send
+1783499626.112974 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.112976 cmd_parse_build_commands 0:3 0:2: page-up
+1783499626.112979 cmd_parse_build_commands 0:0: send
+1783499626.112980 cmd_parse_build_commands 0:1: -X
+1783499626.112982 cmd_parse_build_commands 0:2: page-up
+1783499626.112986 args_parse_flags: next -X
+1783499626.112987 args_parse_flags: -X
+1783499626.112989 args_parse_flags: next page-up
+1783499626.112991 args_parse: flags end at 2 of 3
+1783499626.112992 args_parse: 2 = page-up (type STRING)
+1783499626.112996 cmd_parse_build_commands: send-keys -X page-up
+1783499626.112998 args_parse_flags: next -Tcopy-mode
+1783499626.113000 args_parse_flag_argument: -T = copy-mode
+1783499626.113002 args_parse_flags: next M-v
+1783499626.113003 args_parse: flags end at 2 of 4
+1783499626.113063 args_parse: 2 = M-v (type STRING)
+1783499626.113103 args_parse: 3 = send-keys -X page-up (type COMMANDS)
+1783499626.113127 cmd_parse_build_commands: bind-key -T copy-mode M-v { send-keys -X page-up }
+1783499626.113139 cmdq_get_command: [bind-key/0x58e472519140] group 1864
+1783499626.113146 cmdq_append <global>: [bind-key/0x58e472519140]
+1783499626.113179 yylex_token: end at WS
+1783499626.113215 yylex_token: bind
+1783499626.113223 yylex_token: end at WS
+1783499626.113227 yylex_token: -Tcopy-mode
+1783499626.113232 yylex_token: end at WS
+1783499626.113235 yylex_token: M-w
+1783499626.113241 yylex_token: end at WS
+1783499626.113316 yylex_token: send
+1783499626.113327 yylex_token: end at WS
+1783499626.113330 yylex_token: -X
+1783499626.113334 yylex_token: end at WS
+1783499626.113337 yylex_token: copy-pipe-and-cancel
+1783499626.113345 cmd_parse_build_commands 0:0: bind
+1783499626.113349 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.113352 cmd_parse_build_commands 0:2: M-w
+1783499626.113355 cmd_parse_build_commands 0:3 0:0: send
+1783499626.113358 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.113361 cmd_parse_build_commands 0:3 0:2: copy-pipe-and-cancel
+1783499626.113398 cmd_parse_build_commands 0:0: send
+1783499626.113403 cmd_parse_build_commands 0:1: -X
+1783499626.113406 cmd_parse_build_commands 0:2: copy-pipe-and-cancel
+1783499626.113450 args_parse_flags: next -X
+1783499626.113457 args_parse_flags: -X
+1783499626.113461 args_parse_flags: next copy-pipe-and-cancel
+1783499626.113464 args_parse: flags end at 2 of 3
+1783499626.113468 args_parse: 2 = copy-pipe-and-cancel (type STRING)
+1783499626.113479 cmd_parse_build_commands: send-keys -X copy-pipe-and-cancel
+1783499626.113494 args_parse_flags: next -Tcopy-mode
+1783499626.113497 args_parse_flag_argument: -T = copy-mode
+1783499626.113499 args_parse_flags: next M-w
+1783499626.113501 args_parse: flags end at 2 of 4
+1783499626.113503 args_parse: 2 = M-w (type STRING)
+1783499626.113509 args_parse: 3 = send-keys -X copy-pipe-and-cancel (type COMMANDS)
+1783499626.113519 cmd_parse_build_commands: bind-key -T copy-mode M-w { send-keys -X copy-pipe-and-cancel }
+1783499626.113524 cmdq_get_command: [bind-key/0x58e472519b50] group 1872
+1783499626.113526 cmdq_append <global>: [bind-key/0x58e472519b50]
+1783499626.113531 yylex_token: end at WS
+1783499626.113533 yylex_token: bind
+1783499626.113535 yylex_token: end at WS
+1783499626.113537 yylex_token: -Tcopy-mode
+1783499626.113539 yylex_token: end at WS
+1783499626.113540 yylex_token: M-x
+1783499626.113542 yylex_token: end at WS
+1783499626.113544 yylex_token: send
+1783499626.113546 yylex_token: end at WS
+1783499626.113547 yylex_token: -X
+1783499626.113550 yylex_token: end at WS
+1783499626.113551 yylex_token: jump-to-mark
+1783499626.113556 cmd_parse_build_commands 0:0: bind
+1783499626.113558 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.113560 cmd_parse_build_commands 0:2: M-x
+1783499626.113562 cmd_parse_build_commands 0:3 0:0: send
+1783499626.113564 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.113566 cmd_parse_build_commands 0:3 0:2: jump-to-mark
+1783499626.113570 cmd_parse_build_commands 0:0: send
+1783499626.113572 cmd_parse_build_commands 0:1: -X
+1783499626.113574 cmd_parse_build_commands 0:2: jump-to-mark
+1783499626.113578 args_parse_flags: next -X
+1783499626.113580 args_parse_flags: -X
+1783499626.113582 args_parse_flags: next jump-to-mark
+1783499626.113584 args_parse: flags end at 2 of 3
+1783499626.113587 args_parse: 2 = jump-to-mark (type STRING)
+1783499626.113594 cmd_parse_build_commands: send-keys -X jump-to-mark
+1783499626.113598 args_parse_flags: next -Tcopy-mode
+1783499626.113601 args_parse_flag_argument: -T = copy-mode
+1783499626.113604 args_parse_flags: next M-x
+1783499626.113606 args_parse: flags end at 2 of 4
+1783499626.113609 args_parse: 2 = M-x (type STRING)
+1783499626.113614 args_parse: 3 = send-keys -X jump-to-mark (type COMMANDS)
+1783499626.113625 cmd_parse_build_commands: bind-key -T copy-mode M-x { send-keys -X jump-to-mark }
+1783499626.113630 cmdq_get_command: [bind-key/0x58e4725198c0] group 1880
+1783499626.113633 cmdq_append <global>: [bind-key/0x58e4725198c0]
+1783499626.113637 yylex_token: end at WS
+1783499626.113640 yylex_token: bind
+1783499626.113672 yylex_token: end at WS
+1783499626.113677 yylex_token: -Tcopy-mode
+1783499626.113681 yylex_token: end at WS
+1783499626.113684 yylex_token: M-{
+1783499626.113687 yylex_token: end at WS
+1783499626.113690 yylex_token: send
+1783499626.113692 yylex_token: end at WS
+1783499626.113695 yylex_token: -X
+1783499626.113698 yylex_token: end at WS
+1783499626.113700 yylex_token: previous-paragraph
+1783499626.113707 cmd_parse_build_commands 0:0: bind
+1783499626.113710 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.113712 cmd_parse_build_commands 0:2: M-{
+1783499626.113715 cmd_parse_build_commands 0:3 0:0: send
+1783499626.113718 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.113722 cmd_parse_build_commands 0:3 0:2: previous-paragraph
+1783499626.113727 cmd_parse_build_commands 0:0: send
+1783499626.113730 cmd_parse_build_commands 0:1: -X
+1783499626.113733 cmd_parse_build_commands 0:2: previous-paragraph
+1783499626.113771 args_parse_flags: next -X
+1783499626.113776 args_parse_flags: -X
+1783499626.113781 args_parse_flags: next previous-paragraph
+1783499626.113784 args_parse: flags end at 2 of 3
+1783499626.113788 args_parse: 2 = previous-paragraph (type STRING)
+1783499626.113797 cmd_parse_build_commands: send-keys -X previous-paragraph
+1783499626.113800 args_parse_flags: next -Tcopy-mode
+1783499626.113804 args_parse_flag_argument: -T = copy-mode
+1783499626.113807 args_parse_flags: next M-{
+1783499626.113810 args_parse: flags end at 2 of 4
+1783499626.113813 args_parse: 2 = M-{ (type STRING)
+1783499626.113820 args_parse: 3 = send-keys -X previous-paragraph (type COMMANDS)
+1783499626.113874 cmd_parse_build_commands: bind-key -T copy-mode "M-{" { send-keys -X previous-paragraph }
+1783499626.113883 cmdq_get_command: [bind-key/0x58e472519f50] group 1888
+1783499626.113887 cmdq_append <global>: [bind-key/0x58e472519f50]
+1783499626.113893 yylex_token: end at WS
+1783499626.113896 yylex_token: bind
+1783499626.113900 yylex_token: end at WS
+1783499626.113903 yylex_token: -Tcopy-mode
+1783499626.113907 yylex_token: end at WS
+1783499626.113909 yylex_token: M-}
+1783499626.113913 yylex_token: end at WS
+1783499626.113915 yylex_token: send
+1783499626.113918 yylex_token: end at WS
+1783499626.113920 yylex_token: -X
+1783499626.113924 yylex_token: end at WS
+1783499626.113927 yylex_token: next-paragraph
+1783499626.113932 cmd_parse_build_commands 0:0: bind
+1783499626.113936 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.113938 cmd_parse_build_commands 0:2: M-}
+1783499626.113942 cmd_parse_build_commands 0:3 0:0: send
+1783499626.113944 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.113948 cmd_parse_build_commands 0:3 0:2: next-paragraph
+1783499626.113953 cmd_parse_build_commands 0:0: send
+1783499626.113955 cmd_parse_build_commands 0:1: -X
+1783499626.113958 cmd_parse_build_commands 0:2: next-paragraph
+1783499626.113964 args_parse_flags: next -X
+1783499626.113967 args_parse_flags: -X
+1783499626.113969 args_parse_flags: next next-paragraph
+1783499626.113972 args_parse: flags end at 2 of 3
+1783499626.113975 args_parse: 2 = next-paragraph (type STRING)
+1783499626.113982 cmd_parse_build_commands: send-keys -X next-paragraph
+1783499626.113986 args_parse_flags: next -Tcopy-mode
+1783499626.113989 args_parse_flag_argument: -T = copy-mode
+1783499626.113992 args_parse_flags: next M-}
+1783499626.114051 args_parse: flags end at 2 of 4
+1783499626.114057 args_parse: 2 = M-} (type STRING)
+1783499626.114066 args_parse: 3 = send-keys -X next-paragraph (type COMMANDS)
+1783499626.114120 cmd_parse_build_commands: bind-key -T copy-mode "M-}" { send-keys -X next-paragraph }
+1783499626.114141 cmdq_get_command: [bind-key/0x58e47251a4a0] group 1896
+1783499626.114147 cmdq_append <global>: [bind-key/0x58e47251a4a0]
+1783499626.114160 yylex_token: end at WS
+1783499626.114163 yylex_token: bind
+1783499626.114167 yylex_token: end at WS
+1783499626.114169 yylex_token: -Tcopy-mode
+1783499626.114172 yylex_token: end at WS
+1783499626.114175 yylex_token: M-Up
+1783499626.114178 yylex_token: end at WS
+1783499626.114180 yylex_token: send
+1783499626.114183 yylex_token: end at WS
+1783499626.114185 yylex_token: -X
+1783499626.114188 yylex_token: end at WS
+1783499626.114191 yylex_token: halfpage-up
+1783499626.114198 cmd_parse_build_commands 0:0: bind
+1783499626.114201 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.114203 cmd_parse_build_commands 0:2: M-Up
+1783499626.114206 cmd_parse_build_commands 0:3 0:0: send
+1783499626.114209 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.114212 cmd_parse_build_commands 0:3 0:2: halfpage-up
+1783499626.114218 cmd_parse_build_commands 0:0: send
+1783499626.114221 cmd_parse_build_commands 0:1: -X
+1783499626.114223 cmd_parse_build_commands 0:2: halfpage-up
+1783499626.114230 args_parse_flags: next -X
+1783499626.114233 args_parse_flags: -X
+1783499626.114235 args_parse_flags: next halfpage-up
+1783499626.114238 args_parse: flags end at 2 of 3
+1783499626.114242 args_parse: 2 = halfpage-up (type STRING)
+1783499626.114252 cmd_parse_build_commands: send-keys -X halfpage-up
+1783499626.114257 args_parse_flags: next -Tcopy-mode
+1783499626.114260 args_parse_flag_argument: -T = copy-mode
+1783499626.114263 args_parse_flags: next M-Up
+1783499626.114265 args_parse: flags end at 2 of 4
+1783499626.114268 args_parse: 2 = M-Up (type STRING)
+1783499626.114274 args_parse: 3 = send-keys -X halfpage-up (type COMMANDS)
+1783499626.114286 cmd_parse_build_commands: bind-key -T copy-mode M-Up { send-keys -X halfpage-up }
+1783499626.114293 cmdq_get_command: [bind-key/0x58e47251aa10] group 1904
+1783499626.114297 cmdq_append <global>: [bind-key/0x58e47251aa10]
+1783499626.114301 yylex_token: end at WS
+1783499626.114312 yylex_token: bind
+1783499626.114315 yylex_token: end at WS
+1783499626.114317 yylex_token: -Tcopy-mode
+1783499626.114320 yylex_token: end at WS
+1783499626.114322 yylex_token: M-Down
+1783499626.114324 yylex_token: end at WS
+1783499626.114326 yylex_token: send
+1783499626.114329 yylex_token: end at WS
+1783499626.114331 yylex_token: -X
+1783499626.114334 yylex_token: end at WS
+1783499626.114336 yylex_token: halfpage-down
+1783499626.114342 cmd_parse_build_commands 0:0: bind
+1783499626.114345 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.114348 cmd_parse_build_commands 0:2: M-Down
+1783499626.114351 cmd_parse_build_commands 0:3 0:0: send
+1783499626.114353 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.114356 cmd_parse_build_commands 0:3 0:2: halfpage-down
+1783499626.114361 cmd_parse_build_commands 0:0: send
+1783499626.114363 cmd_parse_build_commands 0:1: -X
+1783499626.114366 cmd_parse_build_commands 0:2: halfpage-down
+1783499626.114372 args_parse_flags: next -X
+1783499626.114374 args_parse_flags: -X
+1783499626.114377 args_parse_flags: next halfpage-down
+1783499626.114379 args_parse: flags end at 2 of 3
+1783499626.114382 args_parse: 2 = halfpage-down (type STRING)
+1783499626.114389 cmd_parse_build_commands: send-keys -X halfpage-down
+1783499626.114392 args_parse_flags: next -Tcopy-mode
+1783499626.114395 args_parse_flag_argument: -T = copy-mode
+1783499626.114398 args_parse_flags: next M-Down
+1783499626.114400 args_parse: flags end at 2 of 4
+1783499626.114403 args_parse: 2 = M-Down (type STRING)
+1783499626.114408 args_parse: 3 = send-keys -X halfpage-down (type COMMANDS)
+1783499626.114419 cmd_parse_build_commands: bind-key -T copy-mode M-Down { send-keys -X halfpage-down }
+1783499626.114424 cmdq_get_command: [bind-key/0x58e47251a330] group 1912
+1783499626.114427 cmdq_append <global>: [bind-key/0x58e47251a330]
+1783499626.114432 yylex_token: end at WS
+1783499626.114434 yylex_token: bind
+1783499626.114437 yylex_token: end at WS
+1783499626.114439 yylex_token: -Tcopy-mode
+1783499626.114442 yylex_token: end at WS
+1783499626.114444 yylex_token: C-Up
+1783499626.114447 yylex_token: end at WS
+1783499626.114449 yylex_token: send
+1783499626.114451 yylex_token: end at WS
+1783499626.114453 yylex_token: -X
+1783499626.114456 yylex_token: end at WS
+1783499626.114459 yylex_token: scroll-up
+1783499626.114464 cmd_parse_build_commands 0:0: bind
+1783499626.114467 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.114470 cmd_parse_build_commands 0:2: C-Up
+1783499626.114473 cmd_parse_build_commands 0:3 0:0: send
+1783499626.114475 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.114478 cmd_parse_build_commands 0:3 0:2: scroll-up
+1783499626.114482 cmd_parse_build_commands 0:0: send
+1783499626.114484 cmd_parse_build_commands 0:1: -X
+1783499626.114486 cmd_parse_build_commands 0:2: scroll-up
+1783499626.114493 args_parse_flags: next -X
+1783499626.114495 args_parse_flags: -X
+1783499626.114497 args_parse_flags: next scroll-up
+1783499626.114499 args_parse: flags end at 2 of 3
+1783499626.114502 args_parse: 2 = scroll-up (type STRING)
+1783499626.114509 cmd_parse_build_commands: send-keys -X scroll-up
+1783499626.114512 args_parse_flags: next -Tcopy-mode
+1783499626.114515 args_parse_flag_argument: -T = copy-mode
+1783499626.114518 args_parse_flags: next C-Up
+1783499626.114520 args_parse: flags end at 2 of 4
+1783499626.114524 args_parse: 2 = C-Up (type STRING)
+1783499626.114529 args_parse: 3 = send-keys -X scroll-up (type COMMANDS)
+1783499626.114538 cmd_parse_build_commands: bind-key -T copy-mode C-Up { send-keys -X scroll-up }
+1783499626.114543 cmdq_get_command: [bind-key/0x58e47251b210] group 1920
+1783499626.114546 cmdq_append <global>: [bind-key/0x58e47251b210]
+1783499626.114554 yylex_token: end at WS
+1783499626.114557 yylex_token: bind
+1783499626.114560 yylex_token: end at WS
+1783499626.114562 yylex_token: -Tcopy-mode
+1783499626.114565 yylex_token: end at WS
+1783499626.114567 yylex_token: C-Down
+1783499626.114569 yylex_token: end at WS
+1783499626.114571 yylex_token: send
+1783499626.114573 yylex_token: end at WS
+1783499626.114576 yylex_token: -X
+1783499626.114582 yylex_token: end at WS
+1783499626.114585 yylex_token: scroll-down
+1783499626.114589 cmd_parse_build_commands 0:0: bind
+1783499626.114592 cmd_parse_build_commands 0:1: -Tcopy-mode
+1783499626.114594 cmd_parse_build_commands 0:2: C-Down
+1783499626.114597 cmd_parse_build_commands 0:3 0:0: send
+1783499626.114600 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.114603 cmd_parse_build_commands 0:3 0:2: scroll-down
+1783499626.114607 cmd_parse_build_commands 0:0: send
+1783499626.114609 cmd_parse_build_commands 0:1: -X
+1783499626.114611 cmd_parse_build_commands 0:2: scroll-down
+1783499626.114617 args_parse_flags: next -X
+1783499626.114619 args_parse_flags: -X
+1783499626.114622 args_parse_flags: next scroll-down
+1783499626.114624 args_parse: flags end at 2 of 3
+1783499626.114627 args_parse: 2 = scroll-down (type STRING)
+1783499626.114633 cmd_parse_build_commands: send-keys -X scroll-down
+1783499626.114636 args_parse_flags: next -Tcopy-mode
+1783499626.114639 args_parse_flag_argument: -T = copy-mode
+1783499626.114641 args_parse_flags: next C-Down
+1783499626.114644 args_parse: flags end at 2 of 4
+1783499626.114647 args_parse: 2 = C-Down (type STRING)
+1783499626.114652 args_parse: 3 = send-keys -X scroll-down (type COMMANDS)
+1783499626.114661 cmd_parse_build_commands: bind-key -T copy-mode C-Down { send-keys -X scroll-down }
+1783499626.114668 cmdq_get_command: [bind-key/0x58e47251b7f0] group 1928
+1783499626.114671 cmdq_append <global>: [bind-key/0x58e47251b7f0]
+1783499626.114674 yylex_token: end at WS
+1783499626.114676 yylex_token: bind
+1783499626.114679 yylex_token: end at WS
+1783499626.114681 yylex_token: -Tcopy-mode-vi
+1783499626.114684 yylex_token: end at WS
+1783499626.114686 yylex_token: #
+1783499626.114689 yylex_token: end at WS
+1783499626.114692 yylex_token: send
+1783499626.114695 yylex_token: end at WS
+1783499626.114697 yylex_token: -FX
+1783499626.114701 yylex_token: end at WS
+1783499626.114703 yylex_token: search-backward
+1783499626.114707 yylex_token: end at WS
+1783499626.114709 yylex_token: #{copy_cursor_word}
+1783499626.114715 cmd_parse_build_commands 0:0: bind
+1783499626.114718 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.114721 cmd_parse_build_commands 0:2: #
+1783499626.114724 cmd_parse_build_commands 0:3 0:0: send
+1783499626.114727 cmd_parse_build_commands 0:3 0:1: -FX
+1783499626.114730 cmd_parse_build_commands 0:3 0:2: search-backward
+1783499626.114733 cmd_parse_build_commands 0:3 0:3: #{copy_cursor_word}
+1783499626.114738 cmd_parse_build_commands 0:0: send
+1783499626.114740 cmd_parse_build_commands 0:1: -FX
+1783499626.114744 cmd_parse_build_commands 0:2: search-backward
+1783499626.114748 cmd_parse_build_commands 0:3: #{copy_cursor_word}
+1783499626.114755 args_parse_flags: next -FX
+1783499626.114758 args_parse_flags: -F
+1783499626.114760 args_parse_flags: -X
+1783499626.114764 args_parse_flags: next search-backward
+1783499626.114767 args_parse: flags end at 2 of 4
+1783499626.114770 args_parse: 2 = search-backward (type STRING)
+1783499626.114774 args_parse: 3 = #{copy_cursor_word} (type STRING)
+1783499626.114784 cmd_parse_build_commands: send-keys -FX search-backward "#{copy_cursor_word}"
+1783499626.114787 args_parse_flags: next -Tcopy-mode-vi
+1783499626.114790 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.114792 args_parse_flags: next #
+1783499626.114795 args_parse: flags end at 2 of 4
+1783499626.114798 args_parse: 2 = # (type STRING)
+1783499626.114806 args_parse: 3 = send-keys -FX search-backward "#{copy_cursor_word}" (type COMMANDS)
+1783499626.114821 cmd_parse_build_commands: bind-key -T copy-mode-vi \\# { send-keys -FX search-backward "#{copy_cursor_word}" }
+1783499626.114828 cmdq_get_command: [bind-key/0x58e47251c000] group 1936
+1783499626.114832 cmdq_append <global>: [bind-key/0x58e47251c000]
+1783499626.114835 yylex_token: end at WS
+1783499626.114838 yylex_token: bind
+1783499626.114841 yylex_token: end at WS
+1783499626.114843 yylex_token: -Tcopy-mode-vi
+1783499626.114846 yylex_token: end at WS
+1783499626.114849 yylex_token: *
+1783499626.114852 yylex_token: end at WS
+1783499626.114858 yylex_token: send
+1783499626.114861 yylex_token: end at WS
+1783499626.114863 yylex_token: -FX
+1783499626.114867 yylex_token: end at WS
+1783499626.114869 yylex_token: search-forward
+1783499626.114873 yylex_token: end at WS
+1783499626.114875 yylex_token: #{copy_cursor_word}
+1783499626.114882 cmd_parse_build_commands 0:0: bind
+1783499626.114884 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.114887 cmd_parse_build_commands 0:2: *
+1783499626.114890 cmd_parse_build_commands 0:3 0:0: send
+1783499626.114894 cmd_parse_build_commands 0:3 0:1: -FX
+1783499626.114898 cmd_parse_build_commands 0:3 0:2: search-forward
+1783499626.114901 cmd_parse_build_commands 0:3 0:3: #{copy_cursor_word}
+1783499626.114905 cmd_parse_build_commands 0:0: send
+1783499626.114908 cmd_parse_build_commands 0:1: -FX
+1783499626.114910 cmd_parse_build_commands 0:2: search-forward
+1783499626.114913 cmd_parse_build_commands 0:3: #{copy_cursor_word}
+1783499626.114919 args_parse_flags: next -FX
+1783499626.114922 args_parse_flags: -F
+1783499626.114924 args_parse_flags: -X
+1783499626.114926 args_parse_flags: next search-forward
+1783499626.114929 args_parse: flags end at 2 of 4
+1783499626.114931 args_parse: 2 = search-forward (type STRING)
+1783499626.114936 args_parse: 3 = #{copy_cursor_word} (type STRING)
+1783499626.114945 cmd_parse_build_commands: send-keys -FX search-forward "#{copy_cursor_word}"
+1783499626.114948 args_parse_flags: next -Tcopy-mode-vi
+1783499626.114951 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.114954 args_parse_flags: next *
+1783499626.114956 args_parse: flags end at 2 of 4
+1783499626.114959 args_parse: 2 = * (type STRING)
+1783499626.114967 args_parse: 3 = send-keys -FX search-forward "#{copy_cursor_word}" (type COMMANDS)
+1783499626.114980 cmd_parse_build_commands: bind-key -T copy-mode-vi * { send-keys -FX search-forward "#{copy_cursor_word}" }
+1783499626.114985 cmdq_get_command: [bind-key/0x58e47251c5c0] group 1944
+1783499626.114989 cmdq_append <global>: [bind-key/0x58e47251c5c0]
+1783499626.114997 yylex_token: end at WS
+1783499626.114999 yylex_token: bind
+1783499626.115002 yylex_token: end at WS
+1783499626.115005 yylex_token: -Tcopy-mode-vi
+1783499626.115007 yylex_token: end at WS
+1783499626.115010 yylex_token: C-c
+1783499626.115013 yylex_token: end at WS
+1783499626.115015 yylex_token: send
+1783499626.115018 yylex_token: end at WS
+1783499626.115020 yylex_token: -X
+1783499626.115023 yylex_token: end at WS
+1783499626.115025 yylex_token: cancel
+1783499626.115030 cmd_parse_build_commands 0:0: bind
+1783499626.115032 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.115035 cmd_parse_build_commands 0:2: C-c
+1783499626.115038 cmd_parse_build_commands 0:3 0:0: send
+1783499626.115042 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.115045 cmd_parse_build_commands 0:3 0:2: cancel
+1783499626.115049 cmd_parse_build_commands 0:0: send
+1783499626.115052 cmd_parse_build_commands 0:1: -X
+1783499626.115054 cmd_parse_build_commands 0:2: cancel
+1783499626.115060 args_parse_flags: next -X
+1783499626.115062 args_parse_flags: -X
+1783499626.115065 args_parse_flags: next cancel
+1783499626.115068 args_parse: flags end at 2 of 3
+1783499626.115070 args_parse: 2 = cancel (type STRING)
+1783499626.115075 cmd_parse_build_commands: send-keys -X cancel
+1783499626.115078 args_parse_flags: next -Tcopy-mode-vi
+1783499626.115081 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.115083 args_parse_flags: next C-c
+1783499626.115086 args_parse: flags end at 2 of 4
+1783499626.115088 args_parse: 2 = C-c (type STRING)
+1783499626.115094 args_parse: 3 = send-keys -X cancel (type COMMANDS)
+1783499626.115104 cmd_parse_build_commands: bind-key -T copy-mode-vi C-c { send-keys -X cancel }
+1783499626.115109 cmdq_get_command: [bind-key/0x58e47251ccf0] group 1952
+1783499626.115150 cmdq_append <global>: [bind-key/0x58e47251ccf0]
+1783499626.115155 yylex_token: end at WS
+1783499626.115158 yylex_token: bind
+1783499626.115162 yylex_token: end at WS
+1783499626.115164 yylex_token: -Tcopy-mode-vi
+1783499626.115167 yylex_token: end at WS
+1783499626.115170 yylex_token: C-d
+1783499626.115179 yylex_token: end at WS
+1783499626.115181 yylex_token: send
+1783499626.115184 yylex_token: end at WS
+1783499626.115186 yylex_token: -X
+1783499626.115189 yylex_token: end at WS
+1783499626.115191 yylex_token: halfpage-down
+1783499626.115198 cmd_parse_build_commands 0:0: bind
+1783499626.115201 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.115203 cmd_parse_build_commands 0:2: C-d
+1783499626.115206 cmd_parse_build_commands 0:3 0:0: send
+1783499626.115209 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.115212 cmd_parse_build_commands 0:3 0:2: halfpage-down
+1783499626.115218 cmd_parse_build_commands 0:0: send
+1783499626.115220 cmd_parse_build_commands 0:1: -X
+1783499626.115223 cmd_parse_build_commands 0:2: halfpage-down
+1783499626.115229 args_parse_flags: next -X
+1783499626.115232 args_parse_flags: -X
+1783499626.115234 args_parse_flags: next halfpage-down
+1783499626.115237 args_parse: flags end at 2 of 3
+1783499626.115240 args_parse: 2 = halfpage-down (type STRING)
+1783499626.115249 cmd_parse_build_commands: send-keys -X halfpage-down
+1783499626.115253 args_parse_flags: next -Tcopy-mode-vi
+1783499626.115255 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.115258 args_parse_flags: next C-d
+1783499626.115260 args_parse: flags end at 2 of 4
+1783499626.115263 args_parse: 2 = C-d (type STRING)
+1783499626.115269 args_parse: 3 = send-keys -X halfpage-down (type COMMANDS)
+1783499626.115282 cmd_parse_build_commands: bind-key -T copy-mode-vi C-d { send-keys -X halfpage-down }
+1783499626.115288 cmdq_get_command: [bind-key/0x58e47251d010] group 1960
+1783499626.115291 cmdq_append <global>: [bind-key/0x58e47251d010]
+1783499626.115295 yylex_token: end at WS
+1783499626.115297 yylex_token: bind
+1783499626.115300 yylex_token: end at WS
+1783499626.115303 yylex_token: -Tcopy-mode-vi
+1783499626.115305 yylex_token: end at WS
+1783499626.115308 yylex_token: C-e
+1783499626.115310 yylex_token: end at WS
+1783499626.115312 yylex_token: send
+1783499626.115315 yylex_token: end at WS
+1783499626.115317 yylex_token: -X
+1783499626.115320 yylex_token: end at WS
+1783499626.115322 yylex_token: scroll-down
+1783499626.115327 cmd_parse_build_commands 0:0: bind
+1783499626.115330 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.115333 cmd_parse_build_commands 0:2: C-e
+1783499626.115337 cmd_parse_build_commands 0:3 0:0: send
+1783499626.115340 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.115342 cmd_parse_build_commands 0:3 0:2: scroll-down
+1783499626.115346 cmd_parse_build_commands 0:0: send
+1783499626.115349 cmd_parse_build_commands 0:1: -X
+1783499626.115352 cmd_parse_build_commands 0:2: scroll-down
+1783499626.115358 args_parse_flags: next -X
+1783499626.115360 args_parse_flags: -X
+1783499626.115363 args_parse_flags: next scroll-down
+1783499626.115365 args_parse: flags end at 2 of 3
+1783499626.115368 args_parse: 2 = scroll-down (type STRING)
+1783499626.115375 cmd_parse_build_commands: send-keys -X scroll-down
+1783499626.115379 args_parse_flags: next -Tcopy-mode-vi
+1783499626.115382 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.115384 args_parse_flags: next C-e
+1783499626.115387 args_parse: flags end at 2 of 4
+1783499626.115390 args_parse: 2 = C-e (type STRING)
+1783499626.115397 args_parse: 3 = send-keys -X scroll-down (type COMMANDS)
+1783499626.115406 cmd_parse_build_commands: bind-key -T copy-mode-vi C-e { send-keys -X scroll-down }
+1783499626.115413 cmdq_get_command: [bind-key/0x58e47251d400] group 1968
+1783499626.115416 cmdq_append <global>: [bind-key/0x58e47251d400]
+1783499626.115425 yylex_token: end at WS
+1783499626.115427 yylex_token: bind
+1783499626.115430 yylex_token: end at WS
+1783499626.115433 yylex_token: -Tcopy-mode-vi
+1783499626.115436 yylex_token: end at WS
+1783499626.115438 yylex_token: C-b
+1783499626.115441 yylex_token: end at WS
+1783499626.115443 yylex_token: send
+1783499626.115445 yylex_token: end at WS
+1783499626.115447 yylex_token: -X
+1783499626.115450 yylex_token: end at WS
+1783499626.115452 yylex_token: page-up
+1783499626.115458 cmd_parse_build_commands 0:0: bind
+1783499626.115460 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.115468 cmd_parse_build_commands 0:2: C-b
+1783499626.115471 cmd_parse_build_commands 0:3 0:0: send
+1783499626.115474 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.115476 cmd_parse_build_commands 0:3 0:2: page-up
+1783499626.115480 cmd_parse_build_commands 0:0: send
+1783499626.115482 cmd_parse_build_commands 0:1: -X
+1783499626.115484 cmd_parse_build_commands 0:2: page-up
+1783499626.115489 args_parse_flags: next -X
+1783499626.115491 args_parse_flags: -X
+1783499626.115494 args_parse_flags: next page-up
+1783499626.115496 args_parse: flags end at 2 of 3
+1783499626.115499 args_parse: 2 = page-up (type STRING)
+1783499626.115507 cmd_parse_build_commands: send-keys -X page-up
+1783499626.115510 args_parse_flags: next -Tcopy-mode-vi
+1783499626.115513 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.115516 args_parse_flags: next C-b
+1783499626.115518 args_parse: flags end at 2 of 4
+1783499626.115521 args_parse: 2 = C-b (type STRING)
+1783499626.115526 args_parse: 3 = send-keys -X page-up (type COMMANDS)
+1783499626.115534 cmd_parse_build_commands: bind-key -T copy-mode-vi C-b { send-keys -X page-up }
+1783499626.115539 cmdq_get_command: [bind-key/0x58e47251d730] group 1976
+1783499626.115542 cmdq_append <global>: [bind-key/0x58e47251d730]
+1783499626.115546 yylex_token: end at WS
+1783499626.115548 yylex_token: bind
+1783499626.115552 yylex_token: end at WS
+1783499626.115554 yylex_token: -Tcopy-mode-vi
+1783499626.115556 yylex_token: end at WS
+1783499626.115559 yylex_token: C-f
+1783499626.115561 yylex_token: end at WS
+1783499626.115563 yylex_token: send
+1783499626.115566 yylex_token: end at WS
+1783499626.115568 yylex_token: -X
+1783499626.115571 yylex_token: end at WS
+1783499626.115573 yylex_token: page-down
+1783499626.115578 cmd_parse_build_commands 0:0: bind
+1783499626.115581 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.115583 cmd_parse_build_commands 0:2: C-f
+1783499626.115586 cmd_parse_build_commands 0:3 0:0: send
+1783499626.115589 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.115592 cmd_parse_build_commands 0:3 0:2: page-down
+1783499626.115596 cmd_parse_build_commands 0:0: send
+1783499626.115599 cmd_parse_build_commands 0:1: -X
+1783499626.115601 cmd_parse_build_commands 0:2: page-down
+1783499626.115607 args_parse_flags: next -X
+1783499626.115609 args_parse_flags: -X
+1783499626.115612 args_parse_flags: next page-down
+1783499626.115614 args_parse: flags end at 2 of 3
+1783499626.115617 args_parse: 2 = page-down (type STRING)
+1783499626.115623 cmd_parse_build_commands: send-keys -X page-down
+1783499626.115627 args_parse_flags: next -Tcopy-mode-vi
+1783499626.115629 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.115632 args_parse_flags: next C-f
+1783499626.115634 args_parse: flags end at 2 of 4
+1783499626.115637 args_parse: 2 = C-f (type STRING)
+1783499626.115709 args_parse: 3 = send-keys -X page-down (type COMMANDS)
+1783499626.115727 cmd_parse_build_commands: bind-key -T copy-mode-vi C-f { send-keys -X page-down }
+1783499626.115735 cmdq_get_command: [bind-key/0x58e47251de10] group 1984
+1783499626.115739 cmdq_append <global>: [bind-key/0x58e47251de10]
+1783499626.115743 yylex_token: end at WS
+1783499626.115746 yylex_token: bind
+1783499626.115749 yylex_token: end at WS
+1783499626.115752 yylex_token: -Tcopy-mode-vi
+1783499626.115755 yylex_token: end at WS
+1783499626.115758 yylex_token: C-h
+1783499626.115761 yylex_token: end at WS
+1783499626.115763 yylex_token: send
+1783499626.115766 yylex_token: end at WS
+1783499626.115768 yylex_token: -X
+1783499626.115771 yylex_token: end at WS
+1783499626.115774 yylex_token: cursor-left
+1783499626.115780 cmd_parse_build_commands 0:0: bind
+1783499626.115783 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.115786 cmd_parse_build_commands 0:2: C-h
+1783499626.115789 cmd_parse_build_commands 0:3 0:0: send
+1783499626.115792 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.115794 cmd_parse_build_commands 0:3 0:2: cursor-left
+1783499626.115799 cmd_parse_build_commands 0:0: send
+1783499626.115802 cmd_parse_build_commands 0:1: -X
+1783499626.115815 cmd_parse_build_commands 0:2: cursor-left
+1783499626.115823 args_parse_flags: next -X
+1783499626.115825 args_parse_flags: -X
+1783499626.115828 args_parse_flags: next cursor-left
+1783499626.115831 args_parse: flags end at 2 of 3
+1783499626.115834 args_parse: 2 = cursor-left (type STRING)
+1783499626.115842 cmd_parse_build_commands: send-keys -X cursor-left
+1783499626.115846 args_parse_flags: next -Tcopy-mode-vi
+1783499626.115849 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.115852 args_parse_flags: next C-h
+1783499626.115855 args_parse: flags end at 2 of 4
+1783499626.115858 args_parse: 2 = C-h (type STRING)
+1783499626.115864 args_parse: 3 = send-keys -X cursor-left (type COMMANDS)
+1783499626.115875 cmd_parse_build_commands: bind-key -T copy-mode-vi C-h { send-keys -X cursor-left }
+1783499626.115882 cmdq_get_command: [bind-key/0x58e47251e260] group 1992
+1783499626.115885 cmdq_append <global>: [bind-key/0x58e47251e260]
+1783499626.115896 yylex_token: end at WS
+1783499626.115899 yylex_token: bind
+1783499626.115902 yylex_token: end at WS
+1783499626.115905 yylex_token: -Tcopy-mode-vi
+1783499626.115908 yylex_token: end at WS
+1783499626.115910 yylex_token: C-j
+1783499626.115912 yylex_token: end at WS
+1783499626.115915 yylex_token: send
+1783499626.115917 yylex_token: end at WS
+1783499626.115919 yylex_token: -X
+1783499626.115923 yylex_token: end at WS
+1783499626.115925 yylex_token: copy-pipe-and-cancel
+1783499626.115930 cmd_parse_build_commands 0:0: bind
+1783499626.115933 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.115936 cmd_parse_build_commands 0:2: C-j
+1783499626.115939 cmd_parse_build_commands 0:3 0:0: send
+1783499626.115942 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.115945 cmd_parse_build_commands 0:3 0:2: copy-pipe-and-cancel
+1783499626.115949 cmd_parse_build_commands 0:0: send
+1783499626.115952 cmd_parse_build_commands 0:1: -X
+1783499626.115955 cmd_parse_build_commands 0:2: copy-pipe-and-cancel
+1783499626.115960 args_parse_flags: next -X
+1783499626.115962 args_parse_flags: -X
+1783499626.115965 args_parse_flags: next copy-pipe-and-cancel
+1783499626.115967 args_parse: flags end at 2 of 3
+1783499626.115971 args_parse: 2 = copy-pipe-and-cancel (type STRING)
+1783499626.115978 cmd_parse_build_commands: send-keys -X copy-pipe-and-cancel
+1783499626.115981 args_parse_flags: next -Tcopy-mode-vi
+1783499626.115984 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.115987 args_parse_flags: next C-j
+1783499626.115989 args_parse: flags end at 2 of 4
+1783499626.115992 args_parse: 2 = C-j (type STRING)
+1783499626.115999 args_parse: 3 = send-keys -X copy-pipe-and-cancel (type COMMANDS)
+1783499626.116010 cmd_parse_build_commands: bind-key -T copy-mode-vi C-j { send-keys -X copy-pipe-and-cancel }
+1783499626.116015 cmdq_get_command: [bind-key/0x58e47251eba0] group 2000
+1783499626.116018 cmdq_append <global>: [bind-key/0x58e47251eba0]
+1783499626.116023 yylex_token: end at WS
+1783499626.116025 yylex_token: bind
+1783499626.116028 yylex_token: end at WS
+1783499626.116031 yylex_token: -Tcopy-mode-vi
+1783499626.116034 yylex_token: end at WS
+1783499626.116036 yylex_token: Enter
+1783499626.116039 yylex_token: end at WS
+1783499626.116041 yylex_token: send
+1783499626.116043 yylex_token: end at WS
+1783499626.116046 yylex_token: -X
+1783499626.116049 yylex_token: end at WS
+1783499626.116051 yylex_token: copy-pipe-and-cancel
+1783499626.116057 cmd_parse_build_commands 0:0: bind
+1783499626.116060 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.116091 cmd_parse_build_commands 0:2: Enter
+1783499626.116105 cmd_parse_build_commands 0:3 0:0: send
+1783499626.116108 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.116110 cmd_parse_build_commands 0:3 0:2: copy-pipe-and-cancel
+1783499626.116116 cmd_parse_build_commands 0:0: send
+1783499626.116117 cmd_parse_build_commands 0:1: -X
+1783499626.116119 cmd_parse_build_commands 0:2: copy-pipe-and-cancel
+1783499626.116123 args_parse_flags: next -X
+1783499626.116124 args_parse_flags: -X
+1783499626.116126 args_parse_flags: next copy-pipe-and-cancel
+1783499626.116127 args_parse: flags end at 2 of 3
+1783499626.116223 args_parse: 2 = copy-pipe-and-cancel (type STRING)
+1783499626.116235 cmd_parse_build_commands: send-keys -X copy-pipe-and-cancel
+1783499626.116238 args_parse_flags: next -Tcopy-mode-vi
+1783499626.116240 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.116242 args_parse_flags: next Enter
+1783499626.116244 args_parse: flags end at 2 of 4
+1783499626.116245 args_parse: 2 = Enter (type STRING)
+1783499626.116249 args_parse: 3 = send-keys -X copy-pipe-and-cancel (type COMMANDS)
+1783499626.116256 cmd_parse_build_commands: bind-key -T copy-mode-vi Enter { send-keys -X copy-pipe-and-cancel }
+1783499626.116260 cmdq_get_command: [bind-key/0x58e47251edb0] group 2008
+1783499626.116262 cmdq_append <global>: [bind-key/0x58e47251edb0]
+1783499626.116266 yylex_token: end at WS
+1783499626.116268 yylex_token: bind
+1783499626.116270 yylex_token: end at WS
+1783499626.116271 yylex_token: -Tcopy-mode-vi
+1783499626.116273 yylex_token: end at WS
+1783499626.116274 yylex_token: C-u
+1783499626.116275 yylex_token: end at WS
+1783499626.116276 yylex_token: send
+1783499626.116278 yylex_token: end at WS
+1783499626.116279 yylex_token: -X
+1783499626.116280 yylex_token: end at WS
+1783499626.116281 yylex_token: halfpage-up
+1783499626.116285 cmd_parse_build_commands 0:0: bind
+1783499626.116286 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.116288 cmd_parse_build_commands 0:2: C-u
+1783499626.116289 cmd_parse_build_commands 0:3 0:0: send
+1783499626.116291 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.116292 cmd_parse_build_commands 0:3 0:2: halfpage-up
+1783499626.116295 cmd_parse_build_commands 0:0: send
+1783499626.116296 cmd_parse_build_commands 0:1: -X
+1783499626.116297 cmd_parse_build_commands 0:2: halfpage-up
+1783499626.116301 args_parse_flags: next -X
+1783499626.116302 args_parse_flags: -X
+1783499626.116304 args_parse_flags: next halfpage-up
+1783499626.116305 args_parse: flags end at 2 of 3
+1783499626.116307 args_parse: 2 = halfpage-up (type STRING)
+1783499626.116311 cmd_parse_build_commands: send-keys -X halfpage-up
+1783499626.116312 args_parse_flags: next -Tcopy-mode-vi
+1783499626.116314 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.116315 args_parse_flags: next C-u
+1783499626.116316 args_parse: flags end at 2 of 4
+1783499626.116317 args_parse: 2 = C-u (type STRING)
+1783499626.116380 args_parse: 3 = send-keys -X halfpage-up (type COMMANDS)
+1783499626.116389 cmd_parse_build_commands: bind-key -T copy-mode-vi C-u { send-keys -X halfpage-up }
+1783499626.116394 cmdq_get_command: [bind-key/0x58e47251f000] group 2016
+1783499626.116396 cmdq_append <global>: [bind-key/0x58e47251f000]
+1783499626.116471 yylex_token: end at WS
+1783499626.116479 yylex_token: bind
+1783499626.116482 yylex_token: end at WS
+1783499626.116484 yylex_token: -Tcopy-mode-vi
+1783499626.116486 yylex_token: end at WS
+1783499626.116487 yylex_token: C-v
+1783499626.116489 yylex_token: end at WS
+1783499626.116490 yylex_token: send
+1783499626.116491 yylex_token: end at WS
+1783499626.116493 yylex_token: -X
+1783499626.116494 yylex_token: end at WS
+1783499626.116496 yylex_token: rectangle-toggle
+1783499626.116500 cmd_parse_build_commands 0:0: bind
+1783499626.116502 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.116503 cmd_parse_build_commands 0:2: C-v
+1783499626.116505 cmd_parse_build_commands 0:3 0:0: send
+1783499626.116506 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.116508 cmd_parse_build_commands 0:3 0:2: rectangle-toggle
+1783499626.116512 cmd_parse_build_commands 0:0: send
+1783499626.116513 cmd_parse_build_commands 0:1: -X
+1783499626.116514 cmd_parse_build_commands 0:2: rectangle-toggle
+1783499626.116518 args_parse_flags: next -X
+1783499626.116520 args_parse_flags: -X
+1783499626.116521 args_parse_flags: next rectangle-toggle
+1783499626.116523 args_parse: flags end at 2 of 3
+1783499626.116525 args_parse: 2 = rectangle-toggle (type STRING)
+1783499626.116530 cmd_parse_build_commands: send-keys -X rectangle-toggle
+1783499626.116531 args_parse_flags: next -Tcopy-mode-vi
+1783499626.116533 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.116541 args_parse_flags: next C-v
+1783499626.116543 args_parse: flags end at 2 of 4
+1783499626.116544 args_parse: 2 = C-v (type STRING)
+1783499626.116548 args_parse: 3 = send-keys -X rectangle-toggle (type COMMANDS)
+1783499626.116554 cmd_parse_build_commands: bind-key -T copy-mode-vi C-v { send-keys -X rectangle-toggle }
+1783499626.116558 cmdq_get_command: [bind-key/0x58e47251f620] group 2024
+1783499626.116560 cmdq_append <global>: [bind-key/0x58e47251f620]
+1783499626.116562 yylex_token: end at WS
+1783499626.116563 yylex_token: bind
+1783499626.116565 yylex_token: end at WS
+1783499626.116566 yylex_token: -Tcopy-mode-vi
+1783499626.116567 yylex_token: end at WS
+1783499626.116568 yylex_token: C-y
+1783499626.116570 yylex_token: end at WS
+1783499626.116571 yylex_token: send
+1783499626.116572 yylex_token: end at WS
+1783499626.116573 yylex_token: -X
+1783499626.116575 yylex_token: end at WS
+1783499626.116576 yylex_token: scroll-up
+1783499626.116579 cmd_parse_build_commands 0:0: bind
+1783499626.116580 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.116581 cmd_parse_build_commands 0:2: C-y
+1783499626.116583 cmd_parse_build_commands 0:3 0:0: send
+1783499626.116584 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.116586 cmd_parse_build_commands 0:3 0:2: scroll-up
+1783499626.116587 cmd_parse_build_commands 0:0: send
+1783499626.116589 cmd_parse_build_commands 0:1: -X
+1783499626.116590 cmd_parse_build_commands 0:2: scroll-up
+1783499626.116593 args_parse_flags: next -X
+1783499626.116594 args_parse_flags: -X
+1783499626.116595 args_parse_flags: next scroll-up
+1783499626.116597 args_parse: flags end at 2 of 3
+1783499626.116598 args_parse: 2 = scroll-up (type STRING)
+1783499626.116601 cmd_parse_build_commands: send-keys -X scroll-up
+1783499626.116603 args_parse_flags: next -Tcopy-mode-vi
+1783499626.116605 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.116606 args_parse_flags: next C-y
+1783499626.116607 args_parse: flags end at 2 of 4
+1783499626.116608 args_parse: 2 = C-y (type STRING)
+1783499626.116611 args_parse: 3 = send-keys -X scroll-up (type COMMANDS)
+1783499626.116616 cmd_parse_build_commands: bind-key -T copy-mode-vi C-y { send-keys -X scroll-up }
+1783499626.116619 cmdq_get_command: [bind-key/0x58e47251f8b0] group 2032
+1783499626.116621 cmdq_append <global>: [bind-key/0x58e47251f8b0]
+1783499626.116622 yylex_token: end at WS
+1783499626.116623 yylex_token: bind
+1783499626.116625 yylex_token: end at WS
+1783499626.116626 yylex_token: -Tcopy-mode-vi
+1783499626.116627 yylex_token: end at WS
+1783499626.116628 yylex_token: Escape
+1783499626.116630 yylex_token: end at WS
+1783499626.116631 yylex_token: send
+1783499626.116632 yylex_token: end at WS
+1783499626.116633 yylex_token: -X
+1783499626.116635 yylex_token: end at WS
+1783499626.116636 yylex_token: clear-selection
+1783499626.116638 cmd_parse_build_commands 0:0: bind
+1783499626.116640 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.116641 cmd_parse_build_commands 0:2: Escape
+1783499626.116642 cmd_parse_build_commands 0:3 0:0: send
+1783499626.116644 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.116645 cmd_parse_build_commands 0:3 0:2: clear-selection
+1783499626.116647 cmd_parse_build_commands 0:0: send
+1783499626.116649 cmd_parse_build_commands 0:1: -X
+1783499626.116650 cmd_parse_build_commands 0:2: clear-selection
+1783499626.116653 args_parse_flags: next -X
+1783499626.116654 args_parse_flags: -X
+1783499626.116656 args_parse_flags: next clear-selection
+1783499626.116657 args_parse: flags end at 2 of 3
+1783499626.116658 args_parse: 2 = clear-selection (type STRING)
+1783499626.116661 cmd_parse_build_commands: send-keys -X clear-selection
+1783499626.116663 args_parse_flags: next -Tcopy-mode-vi
+1783499626.116664 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.116665 args_parse_flags: next Escape
+1783499626.116667 args_parse: flags end at 2 of 4
+1783499626.116668 args_parse: 2 = Escape (type STRING)
+1783499626.116671 args_parse: 3 = send-keys -X clear-selection (type COMMANDS)
+1783499626.116676 cmd_parse_build_commands: bind-key -T copy-mode-vi Escape { send-keys -X clear-selection }
+1783499626.116682 cmdq_get_command: [bind-key/0x58e472520420] group 2040
+1783499626.116684 cmdq_append <global>: [bind-key/0x58e472520420]
+1783499626.116766 yylex_token: end at WS
+1783499626.116778 yylex_token: bind
+1783499626.116783 yylex_token: end at WS
+1783499626.116785 yylex_token: -Tcopy-mode-vi
+1783499626.116789 yylex_token: end at WS
+1783499626.116791 yylex_token: Space
+1783499626.116794 yylex_token: end at WS
+1783499626.116796 yylex_token: send
+1783499626.116799 yylex_token: end at WS
+1783499626.116801 yylex_token: -X
+1783499626.116804 yylex_token: end at WS
+1783499626.116807 yylex_token: begin-selection
+1783499626.116814 cmd_parse_build_commands 0:0: bind
+1783499626.116818 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.116820 cmd_parse_build_commands 0:2: Space
+1783499626.116824 cmd_parse_build_commands 0:3 0:0: send
+1783499626.116826 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.116829 cmd_parse_build_commands 0:3 0:2: begin-selection
+1783499626.116851 cmd_parse_build_commands 0:0: send
+1783499626.116855 cmd_parse_build_commands 0:1: -X
+1783499626.116857 cmd_parse_build_commands 0:2: begin-selection
+1783499626.116864 args_parse_flags: next -X
+1783499626.116866 args_parse_flags: -X
+1783499626.116869 args_parse_flags: next begin-selection
+1783499626.116872 args_parse: flags end at 2 of 3
+1783499626.116875 args_parse: 2 = begin-selection (type STRING)
+1783499626.116884 cmd_parse_build_commands: send-keys -X begin-selection
+1783499626.116887 args_parse_flags: next -Tcopy-mode-vi
+1783499626.116890 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.116892 args_parse_flags: next Space
+1783499626.116894 args_parse: flags end at 2 of 4
+1783499626.116897 args_parse: 2 = Space (type STRING)
+1783499626.116904 args_parse: 3 = send-keys -X begin-selection (type COMMANDS)
+1783499626.116916 cmd_parse_build_commands: bind-key -T copy-mode-vi Space { send-keys -X begin-selection }
+1783499626.116922 cmdq_get_command: [bind-key/0x58e47251fb00] group 2048
+1783499626.116925 cmdq_append <global>: [bind-key/0x58e47251fb00]
+1783499626.116930 yylex_token: end at WS
+1783499626.116932 yylex_token: bind
+1783499626.116936 yylex_token: end at WS
+1783499626.116975 yylex_token: -Tcopy-mode-vi
+1783499626.116987 yylex_token: end at WS
+1783499626.116990 yylex_token: $
+1783499626.116993 yylex_token: end at WS
+1783499626.116995 yylex_token: send
+1783499626.116998 yylex_token: end at WS
+1783499626.117000 yylex_token: -X
+1783499626.117003 yylex_token: end at WS
+1783499626.117006 yylex_token: end-of-line
+1783499626.117013 cmd_parse_build_commands 0:0: bind
+1783499626.117016 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.117018 cmd_parse_build_commands 0:2: $
+1783499626.117021 cmd_parse_build_commands 0:3 0:0: send
+1783499626.117024 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.117027 cmd_parse_build_commands 0:3 0:2: end-of-line
+1783499626.117032 cmd_parse_build_commands 0:0: send
+1783499626.117034 cmd_parse_build_commands 0:1: -X
+1783499626.117037 cmd_parse_build_commands 0:2: end-of-line
+1783499626.117043 args_parse_flags: next -X
+1783499626.117045 args_parse_flags: -X
+1783499626.117048 args_parse_flags: next end-of-line
+1783499626.117051 args_parse: flags end at 2 of 3
+1783499626.117054 args_parse: 2 = end-of-line (type STRING)
+1783499626.117063 cmd_parse_build_commands: send-keys -X end-of-line
+1783499626.117067 args_parse_flags: next -Tcopy-mode-vi
+1783499626.117070 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.117072 args_parse_flags: next $
+1783499626.117075 args_parse: flags end at 2 of 4
+1783499626.117077 args_parse: 2 = $ (type STRING)
+1783499626.117083 args_parse: 3 = send-keys -X end-of-line (type COMMANDS)
+1783499626.117093 cmd_parse_build_commands: bind-key -T copy-mode-vi \\$ { send-keys -X end-of-line }
+1783499626.117098 cmdq_get_command: [bind-key/0x58e472520760] group 2056
+1783499626.117103 cmdq_append <global>: [bind-key/0x58e472520760]
+1783499626.117107 yylex_token: end at WS
+1783499626.117109 yylex_token: bind
+1783499626.117112 yylex_token: end at WS
+1783499626.117114 yylex_token: -Tcopy-mode-vi
+1783499626.117127 yylex_token: end at WS
+1783499626.117129 yylex_token: ,
+1783499626.117132 yylex_token: end at WS
+1783499626.117134 yylex_token: send
+1783499626.117136 yylex_token: end at WS
+1783499626.117138 yylex_token: -X
+1783499626.117141 yylex_token: end at WS
+1783499626.117143 yylex_token: jump-reverse
+1783499626.117148 cmd_parse_build_commands 0:0: bind
+1783499626.117151 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.117154 cmd_parse_build_commands 0:2: ,
+1783499626.117157 cmd_parse_build_commands 0:3 0:0: send
+1783499626.117159 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.117163 cmd_parse_build_commands 0:3 0:2: jump-reverse
+1783499626.117167 cmd_parse_build_commands 0:0: send
+1783499626.117169 cmd_parse_build_commands 0:1: -X
+1783499626.117172 cmd_parse_build_commands 0:2: jump-reverse
+1783499626.117178 args_parse_flags: next -X
+1783499626.117180 args_parse_flags: -X
+1783499626.117186 args_parse_flags: next jump-reverse
+1783499626.117230 args_parse: flags end at 2 of 3
+1783499626.117233 args_parse: 2 = jump-reverse (type STRING)
+1783499626.117240 cmd_parse_build_commands: send-keys -X jump-reverse
+1783499626.117243 args_parse_flags: next -Tcopy-mode-vi
+1783499626.117246 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.117248 args_parse_flags: next ,
+1783499626.117250 args_parse: flags end at 2 of 4
+1783499626.117253 args_parse: 2 = , (type STRING)
+1783499626.117258 args_parse: 3 = send-keys -X jump-reverse (type COMMANDS)
+1783499626.117269 cmd_parse_build_commands: bind-key -T copy-mode-vi , { send-keys -X jump-reverse }
+1783499626.117275 cmdq_get_command: [bind-key/0x58e472520ec0] group 2064
+1783499626.117278 cmdq_append <global>: [bind-key/0x58e472520ec0]
+1783499626.117281 yylex_token: end at WS
+1783499626.117283 yylex_token: bind
+1783499626.117286 yylex_token: end at WS
+1783499626.117288 yylex_token: -Tcopy-mode-vi
+1783499626.117290 yylex_token: end at WS
+1783499626.117293 yylex_token: /
+1783499626.117296 yylex_token: end at WS
+1783499626.117298 yylex_token: command-prompt
+1783499626.117300 yylex_token: end at WS
+1783499626.117302 yylex_token: -T
+1783499626.117305 yylex_token: end at WS
+1783499626.117307 yylex_token: search
+1783499626.117311 yylex_token: end at WS
+1783499626.117314 yylex_token: -p(search down)
+1783499626.117316 yylex_token: end at WS
+1783499626.117318 yylex_token: send
+1783499626.117320 yylex_token: end at WS
+1783499626.117322 yylex_token: -X
+1783499626.117324 yylex_token: end at WS
+1783499626.117326 yylex_token: search-forward
+1783499626.117329 yylex_token: end at WS
+1783499626.117331 yylex_token: %%
+1783499626.117337 cmd_parse_build_commands 0:0: bind
+1783499626.117339 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.117342 cmd_parse_build_commands 0:2: /
+1783499626.117345 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.117347 cmd_parse_build_commands 0:3 0:1: -T
+1783499626.117350 cmd_parse_build_commands 0:3 0:2: search
+1783499626.117353 cmd_parse_build_commands 0:3 0:3: -p(search down)
+1783499626.117356 cmd_parse_build_commands 0:3 0:4 0:0: send
+1783499626.117359 cmd_parse_build_commands 0:3 0:4 0:1: -X
+1783499626.117362 cmd_parse_build_commands 0:3 0:4 0:2: search-forward
+1783499626.117364 cmd_parse_build_commands 0:3 0:4 0:3: %%
+1783499626.117369 cmd_parse_build_commands 0:0: command-prompt
+1783499626.117371 cmd_parse_build_commands 0:1: -T
+1783499626.117374 cmd_parse_build_commands 0:2: search
+1783499626.117376 cmd_parse_build_commands 0:3: -p(search down)
+1783499626.117379 cmd_parse_build_commands 0:4 0:0: send
+1783499626.117382 cmd_parse_build_commands 0:4 0:1: -X
+1783499626.117385 cmd_parse_build_commands 0:4 0:2: search-forward
+1783499626.117387 cmd_parse_build_commands 0:4 0:3: %%
+1783499626.117391 cmd_parse_build_commands 0:0: send
+1783499626.117394 cmd_parse_build_commands 0:1: -X
+1783499626.117397 cmd_parse_build_commands 0:2: search-forward
+1783499626.117399 cmd_parse_build_commands 0:3: %%
+1783499626.117405 args_parse_flags: next -X
+1783499626.117407 args_parse_flags: -X
+1783499626.117410 args_parse_flags: next search-forward
+1783499626.117420 args_parse: flags end at 2 of 4
+1783499626.117428 args_parse: 2 = search-forward (type STRING)
+1783499626.117431 args_parse: 3 = %% (type STRING)
+1783499626.117439 cmd_parse_build_commands: send-keys -X search-forward "%%"
+1783499626.117443 args_parse_flags: next -T
+1783499626.117446 args_parse_flag_argument: -T = search
+1783499626.117448 args_parse_flags: next -p(search down)
+1783499626.117451 args_parse_flag_argument: -p = (search down)
+1783499626.117454 args_parse: flags end at 4 of 5
+1783499626.117462 args_parse: 4 = send-keys -X search-forward "%%" (type COMMANDS)
+1783499626.117475 cmd_parse_build_commands: command-prompt -T search -p "(search down)" { send-keys -X search-forward "%%" }
+1783499626.117478 args_parse_flags: next -Tcopy-mode-vi
+1783499626.117481 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.117483 args_parse_flags: next /
+1783499626.117486 args_parse: flags end at 2 of 4
+1783499626.117489 args_parse: 2 = / (type STRING)
+1783499626.117499 args_parse: 3 = command-prompt -T search -p "(search down)" { send-keys -X search-forward "%%" } (type COMMANDS)
+1783499626.117514 cmd_parse_build_commands: bind-key -T copy-mode-vi / { command-prompt -T search -p "(search down)" { send-keys -X search-forward "%%" } }
+1783499626.117520 cmdq_get_command: [bind-key/0x58e472522000] group 2072
+1783499626.117523 cmdq_append <global>: [bind-key/0x58e472522000]
+1783499626.117532 yylex_token: end at WS
+1783499626.117534 yylex_token: bind
+1783499626.117538 yylex_token: end at WS
+1783499626.117540 yylex_token: -Tcopy-mode-vi
+1783499626.117542 yylex_token: end at WS
+1783499626.117545 yylex_token: 0
+1783499626.117547 yylex_token: end at WS
+1783499626.117550 yylex_token: send
+1783499626.117552 yylex_token: end at WS
+1783499626.117554 yylex_token: -X
+1783499626.117557 yylex_token: end at WS
+1783499626.117560 yylex_token: start-of-line
+1783499626.117565 cmd_parse_build_commands 0:0: bind
+1783499626.117568 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.117570 cmd_parse_build_commands 0:2: 0
+1783499626.117573 cmd_parse_build_commands 0:3 0:0: send
+1783499626.117576 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.117579 cmd_parse_build_commands 0:3 0:2: start-of-line
+1783499626.117582 cmd_parse_build_commands 0:0: send
+1783499626.117585 cmd_parse_build_commands 0:1: -X
+1783499626.117588 cmd_parse_build_commands 0:2: start-of-line
+1783499626.117593 args_parse_flags: next -X
+1783499626.117595 args_parse_flags: -X
+1783499626.117598 args_parse_flags: next start-of-line
+1783499626.117600 args_parse: flags end at 2 of 3
+1783499626.117603 args_parse: 2 = start-of-line (type STRING)
+1783499626.117608 cmd_parse_build_commands: send-keys -X start-of-line
+1783499626.117611 args_parse_flags: next -Tcopy-mode-vi
+1783499626.117614 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.117616 args_parse_flags: next 0
+1783499626.117618 args_parse: flags end at 2 of 4
+1783499626.117621 args_parse: 2 = 0 (type STRING)
+1783499626.117626 args_parse: 3 = send-keys -X start-of-line (type COMMANDS)
+1783499626.117635 cmd_parse_build_commands: bind-key -T copy-mode-vi 0 { send-keys -X start-of-line }
+1783499626.117641 cmdq_get_command: [bind-key/0x58e472521b30] group 2084
+1783499626.117645 cmdq_append <global>: [bind-key/0x58e472521b30]
+1783499626.117648 yylex_token: end at WS
+1783499626.117650 yylex_token: bind
+1783499626.117653 yylex_token: end at WS
+1783499626.117655 yylex_token: -Tcopy-mode-vi
+1783499626.117658 yylex_token: end at WS
+1783499626.117660 yylex_token: 1
+1783499626.117663 yylex_token: end at WS
+1783499626.117666 yylex_token: command-prompt
+1783499626.117669 yylex_token: end at WS
+1783499626.117671 yylex_token: -Np(repeat)
+1783499626.117674 yylex_token: end at WS
+1783499626.117676 yylex_token: -I1
+1783499626.117678 yylex_token: end at WS
+1783499626.117680 yylex_token: send
+1783499626.117682 yylex_token: end at WS
+1783499626.117684 yylex_token: -N
+1783499626.117687 yylex_token: end at WS
+1783499626.117689 yylex_token: %%
+1783499626.117694 cmd_parse_build_commands 0:0: bind
+1783499626.117697 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.117703 cmd_parse_build_commands 0:2: 1
+1783499626.117707 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.117710 cmd_parse_build_commands 0:3 0:1: -Np(repeat)
+1783499626.117712 cmd_parse_build_commands 0:3 0:2: -I1
+1783499626.117716 cmd_parse_build_commands 0:3 0:3 0:0: send
+1783499626.117718 cmd_parse_build_commands 0:3 0:3 0:1: -N
+1783499626.117721 cmd_parse_build_commands 0:3 0:3 0:2: %%
+1783499626.117725 cmd_parse_build_commands 0:0: command-prompt
+1783499626.117727 cmd_parse_build_commands 0:1: -Np(repeat)
+1783499626.117730 cmd_parse_build_commands 0:2: -I1
+1783499626.117732 cmd_parse_build_commands 0:3 0:0: send
+1783499626.117735 cmd_parse_build_commands 0:3 0:1: -N
+1783499626.117737 cmd_parse_build_commands 0:3 0:2: %%
+1783499626.117741 cmd_parse_build_commands 0:0: send
+1783499626.117743 cmd_parse_build_commands 0:1: -N
+1783499626.117745 cmd_parse_build_commands 0:2: %%
+1783499626.117750 args_parse_flags: next -N
+1783499626.117753 args_parse_flag_argument: -N = %%
+1783499626.117756 args_parse: flags end at 3 of 3
+1783499626.117761 cmd_parse_build_commands: send-keys -N "%%"
+1783499626.117764 args_parse_flags: next -Np(repeat)
+1783499626.117766 args_parse_flags: -N
+1783499626.117769 args_parse_flag_argument: -p = (repeat)
+1783499626.117771 args_parse_flags: next -I1
+1783499626.117868 args_parse_flag_argument: -I = 1
+1783499626.117875 args_parse: flags end at 3 of 4
+1783499626.117884 args_parse: 3 = send-keys -N "%%" (type COMMANDS)
+1783499626.117897 cmd_parse_build_commands: command-prompt -N -I 1 -p (repeat) { send-keys -N "%%" }
+1783499626.117900 args_parse_flags: next -Tcopy-mode-vi
+1783499626.117903 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.117906 args_parse_flags: next 1
+1783499626.117908 args_parse: flags end at 2 of 4
+1783499626.117910 args_parse: 2 = 1 (type STRING)
+1783499626.117920 args_parse: 3 = command-prompt -N -I 1 -p (repeat) { send-keys -N "%%" } (type COMMANDS)
+1783499626.117933 cmd_parse_build_commands: bind-key -T copy-mode-vi 1 { command-prompt -N -I 1 -p (repeat) { send-keys -N "%%" } }
+1783499626.117938 cmdq_get_command: [bind-key/0x58e472522b80] group 2092
+1783499626.117942 cmdq_append <global>: [bind-key/0x58e472522b80]
+1783499626.117948 yylex_token: end at WS
+1783499626.117950 yylex_token: bind
+1783499626.117953 yylex_token: end at WS
+1783499626.117955 yylex_token: -Tcopy-mode-vi
+1783499626.117958 yylex_token: end at WS
+1783499626.117960 yylex_token: 2
+1783499626.117964 yylex_token: end at WS
+1783499626.117966 yylex_token: command-prompt
+1783499626.117969 yylex_token: end at WS
+1783499626.117971 yylex_token: -Np(repeat)
+1783499626.117973 yylex_token: end at WS
+1783499626.117975 yylex_token: -I2
+1783499626.117978 yylex_token: end at WS
+1783499626.117980 yylex_token: send
+1783499626.117982 yylex_token: end at WS
+1783499626.117984 yylex_token: -N
+1783499626.117987 yylex_token: end at WS
+1783499626.117989 yylex_token: %%
+1783499626.117995 cmd_parse_build_commands 0:0: bind
+1783499626.117998 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.118001 cmd_parse_build_commands 0:2: 2
+1783499626.118004 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.118007 cmd_parse_build_commands 0:3 0:1: -Np(repeat)
+1783499626.118009 cmd_parse_build_commands 0:3 0:2: -I2
+1783499626.118012 cmd_parse_build_commands 0:3 0:3 0:0: send
+1783499626.118015 cmd_parse_build_commands 0:3 0:3 0:1: -N
+1783499626.118017 cmd_parse_build_commands 0:3 0:3 0:2: %%
+1783499626.118022 cmd_parse_build_commands 0:0: command-prompt
+1783499626.118025 cmd_parse_build_commands 0:1: -Np(repeat)
+1783499626.118028 cmd_parse_build_commands 0:2: -I2
+1783499626.118031 cmd_parse_build_commands 0:3 0:0: send
+1783499626.118034 cmd_parse_build_commands 0:3 0:1: -N
+1783499626.118036 cmd_parse_build_commands 0:3 0:2: %%
+1783499626.118041 cmd_parse_build_commands 0:0: send
+1783499626.118043 cmd_parse_build_commands 0:1: -N
+1783499626.118046 cmd_parse_build_commands 0:2: %%
+1783499626.118051 args_parse_flags: next -N
+1783499626.118054 args_parse_flag_argument: -N = %%
+1783499626.118064 args_parse: flags end at 3 of 3
+1783499626.118070 cmd_parse_build_commands: send-keys -N "%%"
+1783499626.118073 args_parse_flags: next -Np(repeat)
+1783499626.118075 args_parse_flags: -N
+1783499626.118078 args_parse_flag_argument: -p = (repeat)
+1783499626.118081 args_parse_flags: next -I2
+1783499626.118083 args_parse_flag_argument: -I = 2
+1783499626.118085 args_parse: flags end at 3 of 4
+1783499626.118092 args_parse: 3 = send-keys -N "%%" (type COMMANDS)
+1783499626.118101 cmd_parse_build_commands: command-prompt -N -I 2 -p (repeat) { send-keys -N "%%" }
+1783499626.118104 args_parse_flags: next -Tcopy-mode-vi
+1783499626.118107 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.118109 args_parse_flags: next 2
+1783499626.118111 args_parse: flags end at 2 of 4
+1783499626.118114 args_parse: 2 = 2 (type STRING)
+1783499626.118121 args_parse: 3 = command-prompt -N -I 2 -p (repeat) { send-keys -N "%%" } (type COMMANDS)
+1783499626.118133 cmd_parse_build_commands: bind-key -T copy-mode-vi 2 { command-prompt -N -I 2 -p (repeat) { send-keys -N "%%" } }
+1783499626.118139 cmdq_get_command: [bind-key/0x58e472521d10] group 2104
+1783499626.118142 cmdq_append <global>: [bind-key/0x58e472521d10]
+1783499626.118152 yylex_token: end at WS
+1783499626.118155 yylex_token: bind
+1783499626.118158 yylex_token: end at WS
+1783499626.118258 yylex_token: -Tcopy-mode-vi
+1783499626.118267 yylex_token: end at WS
+1783499626.118270 yylex_token: 3
+1783499626.118273 yylex_token: end at WS
+1783499626.118276 yylex_token: command-prompt
+1783499626.118279 yylex_token: end at WS
+1783499626.118281 yylex_token: -Np(repeat)
+1783499626.118284 yylex_token: end at WS
+1783499626.118286 yylex_token: -I3
+1783499626.118473 yylex_token: end at WS
+1783499626.118485 yylex_token: send
+1783499626.118489 yylex_token: end at WS
+1783499626.118491 yylex_token: -N
+1783499626.118494 yylex_token: end at WS
+1783499626.118496 yylex_token: %%
+1783499626.118505 cmd_parse_build_commands 0:0: bind
+1783499626.118507 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.118510 cmd_parse_build_commands 0:2: 3
+1783499626.118514 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.118517 cmd_parse_build_commands 0:3 0:1: -Np(repeat)
+1783499626.118519 cmd_parse_build_commands 0:3 0:2: -I3
+1783499626.118522 cmd_parse_build_commands 0:3 0:3 0:0: send
+1783499626.118525 cmd_parse_build_commands 0:3 0:3 0:1: -N
+1783499626.118527 cmd_parse_build_commands 0:3 0:3 0:2: %%
+1783499626.118533 cmd_parse_build_commands 0:0: command-prompt
+1783499626.118536 cmd_parse_build_commands 0:1: -Np(repeat)
+1783499626.118538 cmd_parse_build_commands 0:2: -I3
+1783499626.118541 cmd_parse_build_commands 0:3 0:0: send
+1783499626.118543 cmd_parse_build_commands 0:3 0:1: -N
+1783499626.118545 cmd_parse_build_commands 0:3 0:2: %%
+1783499626.118549 cmd_parse_build_commands 0:0: send
+1783499626.118552 cmd_parse_build_commands 0:1: -N
+1783499626.118554 cmd_parse_build_commands 0:2: %%
+1783499626.118560 args_parse_flags: next -N
+1783499626.118563 args_parse_flag_argument: -N = %%
+1783499626.118565 args_parse: flags end at 3 of 3
+1783499626.118573 cmd_parse_build_commands: send-keys -N "%%"
+1783499626.118576 args_parse_flags: next -Np(repeat)
+1783499626.118578 args_parse_flags: -N
+1783499626.118581 args_parse_flag_argument: -p = (repeat)
+1783499626.118583 args_parse_flags: next -I3
+1783499626.118586 args_parse_flag_argument: -I = 3
+1783499626.118588 args_parse: flags end at 3 of 4
+1783499626.118594 args_parse: 3 = send-keys -N "%%" (type COMMANDS)
+1783499626.118603 cmd_parse_build_commands: command-prompt -N -I 3 -p (repeat) { send-keys -N "%%" }
+1783499626.118606 args_parse_flags: next -Tcopy-mode-vi
+1783499626.118608 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.118611 args_parse_flags: next 3
+1783499626.118613 args_parse: flags end at 2 of 4
+1783499626.118615 args_parse: 2 = 3 (type STRING)
+1783499626.118623 args_parse: 3 = command-prompt -N -I 3 -p (repeat) { send-keys -N "%%" } (type COMMANDS)
+1783499626.118635 cmd_parse_build_commands: bind-key -T copy-mode-vi 3 { command-prompt -N -I 3 -p (repeat) { send-keys -N "%%" } }
+1783499626.118729 cmdq_get_command: [bind-key/0x58e472523bc0] group 2116
+1783499626.118734 cmdq_append <global>: [bind-key/0x58e472523bc0]
+1783499626.118741 yylex_token: end at WS
+1783499626.118744 yylex_token: bind
+1783499626.118747 yylex_token: end at WS
+1783499626.118749 yylex_token: -Tcopy-mode-vi
+1783499626.118752 yylex_token: end at WS
+1783499626.118754 yylex_token: 4
+1783499626.118757 yylex_token: end at WS
+1783499626.118760 yylex_token: command-prompt
+1783499626.118763 yylex_token: end at WS
+1783499626.118766 yylex_token: -Np(repeat)
+1783499626.118768 yylex_token: end at WS
+1783499626.118771 yylex_token: -I4
+1783499626.118773 yylex_token: end at WS
+1783499626.118776 yylex_token: send
+1783499626.118778 yylex_token: end at WS
+1783499626.118780 yylex_token: -N
+1783499626.118783 yylex_token: end at WS
+1783499626.118785 yylex_token: %%
+1783499626.118792 cmd_parse_build_commands 0:0: bind
+1783499626.118795 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.118798 cmd_parse_build_commands 0:2: 4
+1783499626.118828 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.118833 cmd_parse_build_commands 0:3 0:1: -Np(repeat)
+1783499626.118837 cmd_parse_build_commands 0:3 0:2: -I4
+1783499626.118841 cmd_parse_build_commands 0:3 0:3 0:0: send
+1783499626.118844 cmd_parse_build_commands 0:3 0:3 0:1: -N
+1783499626.118847 cmd_parse_build_commands 0:3 0:3 0:2: %%
+1783499626.118853 cmd_parse_build_commands 0:0: command-prompt
+1783499626.118855 cmd_parse_build_commands 0:1: -Np(repeat)
+1783499626.118858 cmd_parse_build_commands 0:2: -I4
+1783499626.118861 cmd_parse_build_commands 0:3 0:0: send
+1783499626.118863 cmd_parse_build_commands 0:3 0:1: -N
+1783499626.118866 cmd_parse_build_commands 0:3 0:2: %%
+1783499626.118869 cmd_parse_build_commands 0:0: send
+1783499626.118872 cmd_parse_build_commands 0:1: -N
+1783499626.118874 cmd_parse_build_commands 0:2: %%
+1783499626.118880 args_parse_flags: next -N
+1783499626.118883 args_parse_flag_argument: -N = %%
+1783499626.118886 args_parse: flags end at 3 of 3
+1783499626.118893 cmd_parse_build_commands: send-keys -N "%%"
+1783499626.118896 args_parse_flags: next -Np(repeat)
+1783499626.118899 args_parse_flags: -N
+1783499626.118902 args_parse_flag_argument: -p = (repeat)
+1783499626.118904 args_parse_flags: next -I4
+1783499626.118907 args_parse_flag_argument: -I = 4
+1783499626.118910 args_parse: flags end at 3 of 4
+1783499626.118916 args_parse: 3 = send-keys -N "%%" (type COMMANDS)
+1783499626.118927 cmd_parse_build_commands: command-prompt -N -I 4 -p (repeat) { send-keys -N "%%" }
+1783499626.118930 args_parse_flags: next -Tcopy-mode-vi
+1783499626.118933 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.118935 args_parse_flags: next 4
+1783499626.118937 args_parse: flags end at 2 of 4
+1783499626.118940 args_parse: 2 = 4 (type STRING)
+1783499626.118949 args_parse: 3 = command-prompt -N -I 4 -p (repeat) { send-keys -N "%%" } (type COMMANDS)
+1783499626.118960 cmd_parse_build_commands: bind-key -T copy-mode-vi 4 { command-prompt -N -I 4 -p (repeat) { send-keys -N "%%" } }
+1783499626.118966 cmdq_get_command: [bind-key/0x58e472523d20] group 2128
+1783499626.118969 cmdq_append <global>: [bind-key/0x58e472523d20]
+1783499626.118981 yylex_token: end at WS
+1783499626.118984 yylex_token: bind
+1783499626.118987 yylex_token: end at WS
+1783499626.118989 yylex_token: -Tcopy-mode-vi
+1783499626.118992 yylex_token: end at WS
+1783499626.118994 yylex_token: 5
+1783499626.118997 yylex_token: end at WS
+1783499626.118999 yylex_token: command-prompt
+1783499626.119002 yylex_token: end at WS
+1783499626.119005 yylex_token: -Np(repeat)
+1783499626.119007 yylex_token: end at WS
+1783499626.119009 yylex_token: -I5
+1783499626.119012 yylex_token: end at WS
+1783499626.119014 yylex_token: send
+1783499626.119017 yylex_token: end at WS
+1783499626.119019 yylex_token: -N
+1783499626.119022 yylex_token: end at WS
+1783499626.119024 yylex_token: %%
+1783499626.119030 cmd_parse_build_commands 0:0: bind
+1783499626.119032 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.119035 cmd_parse_build_commands 0:2: 5
+1783499626.119043 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.119046 cmd_parse_build_commands 0:3 0:1: -Np(repeat)
+1783499626.119049 cmd_parse_build_commands 0:3 0:2: -I5
+1783499626.119052 cmd_parse_build_commands 0:3 0:3 0:0: send
+1783499626.119055 cmd_parse_build_commands 0:3 0:3 0:1: -N
+1783499626.119057 cmd_parse_build_commands 0:3 0:3 0:2: %%
+1783499626.119061 cmd_parse_build_commands 0:0: command-prompt
+1783499626.119064 cmd_parse_build_commands 0:1: -Np(repeat)
+1783499626.119066 cmd_parse_build_commands 0:2: -I5
+1783499626.119069 cmd_parse_build_commands 0:3 0:0: send
+1783499626.119072 cmd_parse_build_commands 0:3 0:1: -N
+1783499626.119074 cmd_parse_build_commands 0:3 0:2: %%
+1783499626.119078 cmd_parse_build_commands 0:0: send
+1783499626.119080 cmd_parse_build_commands 0:1: -N
+1783499626.119083 cmd_parse_build_commands 0:2: %%
+1783499626.119088 args_parse_flags: next -N
+1783499626.119090 args_parse_flag_argument: -N = %%
+1783499626.119093 args_parse: flags end at 3 of 3
+1783499626.119098 cmd_parse_build_commands: send-keys -N "%%"
+1783499626.119101 args_parse_flags: next -Np(repeat)
+1783499626.119103 args_parse_flags: -N
+1783499626.119106 args_parse_flag_argument: -p = (repeat)
+1783499626.119108 args_parse_flags: next -I5
+1783499626.119110 args_parse_flag_argument: -I = 5
+1783499626.119113 args_parse: flags end at 3 of 4
+1783499626.119119 args_parse: 3 = send-keys -N "%%" (type COMMANDS)
+1783499626.119128 cmd_parse_build_commands: command-prompt -N -I 5 -p (repeat) { send-keys -N "%%" }
+1783499626.119131 args_parse_flags: next -Tcopy-mode-vi
+1783499626.119134 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.119136 args_parse_flags: next 5
+1783499626.119138 args_parse: flags end at 2 of 4
+1783499626.119141 args_parse: 2 = 5 (type STRING)
+1783499626.119149 args_parse: 3 = command-prompt -N -I 5 -p (repeat) { send-keys -N "%%" } (type COMMANDS)
+1783499626.119160 cmd_parse_build_commands: bind-key -T copy-mode-vi 5 { command-prompt -N -I 5 -p (repeat) { send-keys -N "%%" } }
+1783499626.119165 cmdq_get_command: [bind-key/0x58e472523e90] group 2140
+1783499626.119168 cmdq_append <global>: [bind-key/0x58e472523e90]
+1783499626.119173 yylex_token: end at WS
+1783499626.119176 yylex_token: bind
+1783499626.119179 yylex_token: end at WS
+1783499626.119181 yylex_token: -Tcopy-mode-vi
+1783499626.119183 yylex_token: end at WS
+1783499626.119185 yylex_token: 6
+1783499626.119189 yylex_token: end at WS
+1783499626.119191 yylex_token: command-prompt
+1783499626.119194 yylex_token: end at WS
+1783499626.119196 yylex_token: -Np(repeat)
+1783499626.119199 yylex_token: end at WS
+1783499626.119201 yylex_token: -I6
+1783499626.119203 yylex_token: end at WS
+1783499626.119205 yylex_token: send
+1783499626.119208 yylex_token: end at WS
+1783499626.119210 yylex_token: -N
+1783499626.119212 yylex_token: end at WS
+1783499626.119214 yylex_token: %%
+1783499626.119220 cmd_parse_build_commands 0:0: bind
+1783499626.119223 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.119225 cmd_parse_build_commands 0:2: 6
+1783499626.119228 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.119231 cmd_parse_build_commands 0:3 0:1: -Np(repeat)
+1783499626.119233 cmd_parse_build_commands 0:3 0:2: -I6
+1783499626.119236 cmd_parse_build_commands 0:3 0:3 0:0: send
+1783499626.119239 cmd_parse_build_commands 0:3 0:3 0:1: -N
+1783499626.119241 cmd_parse_build_commands 0:3 0:3 0:2: %%
+1783499626.119245 cmd_parse_build_commands 0:0: command-prompt
+1783499626.119247 cmd_parse_build_commands 0:1: -Np(repeat)
+1783499626.119250 cmd_parse_build_commands 0:2: -I6
+1783499626.119253 cmd_parse_build_commands 0:3 0:0: send
+1783499626.119255 cmd_parse_build_commands 0:3 0:1: -N
+1783499626.119257 cmd_parse_build_commands 0:3 0:2: %%
+1783499626.119261 cmd_parse_build_commands 0:0: send
+1783499626.119263 cmd_parse_build_commands 0:1: -N
+1783499626.119265 cmd_parse_build_commands 0:2: %%
+1783499626.119271 args_parse_flags: next -N
+1783499626.119274 args_parse_flag_argument: -N = %%
+1783499626.119276 args_parse: flags end at 3 of 3
+1783499626.119281 cmd_parse_build_commands: send-keys -N "%%"
+1783499626.119287 args_parse_flags: next -Np(repeat)
+1783499626.119289 args_parse_flags: -N
+1783499626.119292 args_parse_flag_argument: -p = (repeat)
+1783499626.119294 args_parse_flags: next -I6
+1783499626.119297 args_parse_flag_argument: -I = 6
+1783499626.119299 args_parse: flags end at 3 of 4
+1783499626.119304 args_parse: 3 = send-keys -N "%%" (type COMMANDS)
+1783499626.119313 cmd_parse_build_commands: command-prompt -N -I 6 -p (repeat) { send-keys -N "%%" }
+1783499626.119315 args_parse_flags: next -Tcopy-mode-vi
+1783499626.119318 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.119320 args_parse_flags: next 6
+1783499626.119323 args_parse: flags end at 2 of 4
+1783499626.119325 args_parse: 2 = 6 (type STRING)
+1783499626.119333 args_parse: 3 = command-prompt -N -I 6 -p (repeat) { send-keys -N "%%" } (type COMMANDS)
+1783499626.119343 cmd_parse_build_commands: bind-key -T copy-mode-vi 6 { command-prompt -N -I 6 -p (repeat) { send-keys -N "%%" } }
+1783499626.119348 cmdq_get_command: [bind-key/0x58e472525470] group 2152
+1783499626.119351 cmdq_append <global>: [bind-key/0x58e472525470]
+1783499626.119358 yylex_token: end at WS
+1783499626.119360 yylex_token: bind
+1783499626.119363 yylex_token: end at WS
+1783499626.119366 yylex_token: -Tcopy-mode-vi
+1783499626.119368 yylex_token: end at WS
+1783499626.119370 yylex_token: 7
+1783499626.119373 yylex_token: end at WS
+1783499626.119375 yylex_token: command-prompt
+1783499626.119378 yylex_token: end at WS
+1783499626.119380 yylex_token: -Np(repeat)
+1783499626.119383 yylex_token: end at WS
+1783499626.119385 yylex_token: -I7
+1783499626.119388 yylex_token: end at WS
+1783499626.119390 yylex_token: send
+1783499626.119392 yylex_token: end at WS
+1783499626.119394 yylex_token: -N
+1783499626.119397 yylex_token: end at WS
+1783499626.119399 yylex_token: %%
+1783499626.119404 cmd_parse_build_commands 0:0: bind
+1783499626.119407 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.119409 cmd_parse_build_commands 0:2: 7
+1783499626.119413 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.119415 cmd_parse_build_commands 0:3 0:1: -Np(repeat)
+1783499626.119418 cmd_parse_build_commands 0:3 0:2: -I7
+1783499626.119421 cmd_parse_build_commands 0:3 0:3 0:0: send
+1783499626.119423 cmd_parse_build_commands 0:3 0:3 0:1: -N
+1783499626.119426 cmd_parse_build_commands 0:3 0:3 0:2: %%
+1783499626.119430 cmd_parse_build_commands 0:0: command-prompt
+1783499626.119433 cmd_parse_build_commands 0:1: -Np(repeat)
+1783499626.119435 cmd_parse_build_commands 0:2: -I7
+1783499626.119438 cmd_parse_build_commands 0:3 0:0: send
+1783499626.119440 cmd_parse_build_commands 0:3 0:1: -N
+1783499626.119443 cmd_parse_build_commands 0:3 0:2: %%
+1783499626.119446 cmd_parse_build_commands 0:0: send
+1783499626.119448 cmd_parse_build_commands 0:1: -N
+1783499626.119451 cmd_parse_build_commands 0:2: %%
+1783499626.119455 args_parse_flags: next -N
+1783499626.119458 args_parse_flag_argument: -N = %%
+1783499626.119460 args_parse: flags end at 3 of 3
+1783499626.119465 cmd_parse_build_commands: send-keys -N "%%"
+1783499626.119468 args_parse_flags: next -Np(repeat)
+1783499626.119470 args_parse_flags: -N
+1783499626.119473 args_parse_flag_argument: -p = (repeat)
+1783499626.119475 args_parse_flags: next -I7
+1783499626.119477 args_parse_flag_argument: -I = 7
+1783499626.119480 args_parse: flags end at 3 of 4
+1783499626.119485 args_parse: 3 = send-keys -N "%%" (type COMMANDS)
+1783499626.119493 cmd_parse_build_commands: command-prompt -N -I 7 -p (repeat) { send-keys -N "%%" }
+1783499626.119496 args_parse_flags: next -Tcopy-mode-vi
+1783499626.119498 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.119501 args_parse_flags: next 7
+1783499626.119503 args_parse: flags end at 2 of 4
+1783499626.119505 args_parse: 2 = 7 (type STRING)
+1783499626.119513 args_parse: 3 = command-prompt -N -I 7 -p (repeat) { send-keys -N "%%" } (type COMMANDS)
+1783499626.119523 cmd_parse_build_commands: bind-key -T copy-mode-vi 7 { command-prompt -N -I 7 -p (repeat) { send-keys -N "%%" } }
+1783499626.119528 cmdq_get_command: [bind-key/0x58e472525c10] group 2164
+1783499626.119540 cmdq_append <global>: [bind-key/0x58e472525c10]
+1783499626.119545 yylex_token: end at WS
+1783499626.119548 yylex_token: bind
+1783499626.119551 yylex_token: end at WS
+1783499626.119553 yylex_token: -Tcopy-mode-vi
+1783499626.119555 yylex_token: end at WS
+1783499626.119557 yylex_token: 8
+1783499626.119561 yylex_token: end at WS
+1783499626.119563 yylex_token: command-prompt
+1783499626.119566 yylex_token: end at WS
+1783499626.119568 yylex_token: -Np(repeat)
+1783499626.119570 yylex_token: end at WS
+1783499626.119572 yylex_token: -I8
+1783499626.119575 yylex_token: end at WS
+1783499626.119577 yylex_token: send
+1783499626.119580 yylex_token: end at WS
+1783499626.119582 yylex_token: -N
+1783499626.119584 yylex_token: end at WS
+1783499626.119586 yylex_token: %%
+1783499626.119591 cmd_parse_build_commands 0:0: bind
+1783499626.119594 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.119596 cmd_parse_build_commands 0:2: 8
+1783499626.119599 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.119602 cmd_parse_build_commands 0:3 0:1: -Np(repeat)
+1783499626.119604 cmd_parse_build_commands 0:3 0:2: -I8
+1783499626.119607 cmd_parse_build_commands 0:3 0:3 0:0: send
+1783499626.119610 cmd_parse_build_commands 0:3 0:3 0:1: -N
+1783499626.119612 cmd_parse_build_commands 0:3 0:3 0:2: %%
+1783499626.119616 cmd_parse_build_commands 0:0: command-prompt
+1783499626.119618 cmd_parse_build_commands 0:1: -Np(repeat)
+1783499626.119621 cmd_parse_build_commands 0:2: -I8
+1783499626.119623 cmd_parse_build_commands 0:3 0:0: send
+1783499626.119626 cmd_parse_build_commands 0:3 0:1: -N
+1783499626.119629 cmd_parse_build_commands 0:3 0:2: %%
+1783499626.119632 cmd_parse_build_commands 0:0: send
+1783499626.119634 cmd_parse_build_commands 0:1: -N
+1783499626.119637 cmd_parse_build_commands 0:2: %%
+1783499626.119642 args_parse_flags: next -N
+1783499626.119645 args_parse_flag_argument: -N = %%
+1783499626.119647 args_parse: flags end at 3 of 3
+1783499626.119652 cmd_parse_build_commands: send-keys -N "%%"
+1783499626.119655 args_parse_flags: next -Np(repeat)
+1783499626.119657 args_parse_flags: -N
+1783499626.119659 args_parse_flag_argument: -p = (repeat)
+1783499626.119662 args_parse_flags: next -I8
+1783499626.119664 args_parse_flag_argument: -I = 8
+1783499626.119667 args_parse: flags end at 3 of 4
+1783499626.119672 args_parse: 3 = send-keys -N "%%" (type COMMANDS)
+1783499626.119680 cmd_parse_build_commands: command-prompt -N -I 8 -p (repeat) { send-keys -N "%%" }
+1783499626.119683 args_parse_flags: next -Tcopy-mode-vi
+1783499626.119686 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.119689 args_parse_flags: next 8
+1783499626.119691 args_parse: flags end at 2 of 4
+1783499626.119694 args_parse: 2 = 8 (type STRING)
+1783499626.119701 args_parse: 3 = command-prompt -N -I 8 -p (repeat) { send-keys -N "%%" } (type COMMANDS)
+1783499626.119712 cmd_parse_build_commands: bind-key -T copy-mode-vi 8 { command-prompt -N -I 8 -p (repeat) { send-keys -N "%%" } }
+1783499626.119717 cmdq_get_command: [bind-key/0x58e472525220] group 2176
+1783499626.119719 cmdq_append <global>: [bind-key/0x58e472525220]
+1783499626.119727 yylex_token: end at WS
+1783499626.119729 yylex_token: bind
+1783499626.119732 yylex_token: end at WS
+1783499626.119735 yylex_token: -Tcopy-mode-vi
+1783499626.119737 yylex_token: end at WS
+1783499626.119793 yylex_token: 9
+1783499626.119799 yylex_token: end at WS
+1783499626.119801 yylex_token: command-prompt
+1783499626.119803 yylex_token: end at WS
+1783499626.119804 yylex_token: -Np(repeat)
+1783499626.119806 yylex_token: end at WS
+1783499626.119807 yylex_token: -I9
+1783499626.119808 yylex_token: end at WS
+1783499626.119809 yylex_token: send
+1783499626.119811 yylex_token: end at WS
+1783499626.119812 yylex_token: -N
+1783499626.119813 yylex_token: end at WS
+1783499626.119814 yylex_token: %%
+1783499626.119819 cmd_parse_build_commands 0:0: bind
+1783499626.119821 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.119823 cmd_parse_build_commands 0:2: 9
+1783499626.119824 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.119835 cmd_parse_build_commands 0:3 0:1: -Np(repeat)
+1783499626.119837 cmd_parse_build_commands 0:3 0:2: -I9
+1783499626.119838 cmd_parse_build_commands 0:3 0:3 0:0: send
+1783499626.119840 cmd_parse_build_commands 0:3 0:3 0:1: -N
+1783499626.119841 cmd_parse_build_commands 0:3 0:3 0:2: %%
+1783499626.119845 cmd_parse_build_commands 0:0: command-prompt
+1783499626.119847 cmd_parse_build_commands 0:1: -Np(repeat)
+1783499626.119848 cmd_parse_build_commands 0:2: -I9
+1783499626.119849 cmd_parse_build_commands 0:3 0:0: send
+1783499626.119851 cmd_parse_build_commands 0:3 0:1: -N
+1783499626.119852 cmd_parse_build_commands 0:3 0:2: %%
+1783499626.119854 cmd_parse_build_commands 0:0: send
+1783499626.119856 cmd_parse_build_commands 0:1: -N
+1783499626.119857 cmd_parse_build_commands 0:2: %%
+1783499626.119860 args_parse_flags: next -N
+1783499626.119862 args_parse_flag_argument: -N = %%
+1783499626.119864 args_parse: flags end at 3 of 3
+1783499626.119868 cmd_parse_build_commands: send-keys -N "%%"
+1783499626.119871 args_parse_flags: next -Np(repeat)
+1783499626.119872 args_parse_flags: -N
+1783499626.119873 args_parse_flag_argument: -p = (repeat)
+1783499626.119874 args_parse_flags: next -I9
+1783499626.119876 args_parse_flag_argument: -I = 9
+1783499626.119877 args_parse: flags end at 3 of 4
+1783499626.119881 args_parse: 3 = send-keys -N "%%" (type COMMANDS)
+1783499626.119887 cmd_parse_build_commands: command-prompt -N -I 9 -p (repeat) { send-keys -N "%%" }
+1783499626.119889 args_parse_flags: next -Tcopy-mode-vi
+1783499626.119890 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.119892 args_parse_flags: next 9
+1783499626.119893 args_parse: flags end at 2 of 4
+1783499626.119894 args_parse: 2 = 9 (type STRING)
+1783499626.119899 args_parse: 3 = command-prompt -N -I 9 -p (repeat) { send-keys -N "%%" } (type COMMANDS)
+1783499626.119905 cmd_parse_build_commands: bind-key -T copy-mode-vi 9 { command-prompt -N -I 9 -p (repeat) { send-keys -N "%%" } }
+1783499626.119909 cmdq_get_command: [bind-key/0x58e472525eb0] group 2188
+1783499626.119911 cmdq_append <global>: [bind-key/0x58e472525eb0]
+1783499626.119915 yylex_token: end at WS
+1783499626.119916 yylex_token: bind
+1783499626.119917 yylex_token: end at WS
+1783499626.119919 yylex_token: -Tcopy-mode-vi
+1783499626.119920 yylex_token: end at WS
+1783499626.119921 yylex_token: :
+1783499626.119922 yylex_token: end at WS
+1783499626.119923 yylex_token: command-prompt
+1783499626.119925 yylex_token: end at WS
+1783499626.119926 yylex_token: -p(goto line)
+1783499626.119927 yylex_token: end at WS
+1783499626.119928 yylex_token: send
+1783499626.119930 yylex_token: end at WS
+1783499626.119931 yylex_token: -X
+1783499626.119932 yylex_token: end at WS
+1783499626.119933 yylex_token: goto-line
+1783499626.119934 yylex_token: end at WS
+1783499626.119935 yylex_token: %%
+1783499626.119939 cmd_parse_build_commands 0:0: bind
+1783499626.119940 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.119941 cmd_parse_build_commands 0:2: :
+1783499626.119943 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.119944 cmd_parse_build_commands 0:3 0:1: -p(goto line)
+1783499626.119946 cmd_parse_build_commands 0:3 0:2 0:0: send
+1783499626.119947 cmd_parse_build_commands 0:3 0:2 0:1: -X
+1783499626.119948 cmd_parse_build_commands 0:3 0:2 0:2: goto-line
+1783499626.119950 cmd_parse_build_commands 0:3 0:2 0:3: %%
+1783499626.119952 cmd_parse_build_commands 0:0: command-prompt
+1783499626.119953 cmd_parse_build_commands 0:1: -p(goto line)
+1783499626.119954 cmd_parse_build_commands 0:2 0:0: send
+1783499626.119956 cmd_parse_build_commands 0:2 0:1: -X
+1783499626.119957 cmd_parse_build_commands 0:2 0:2: goto-line
+1783499626.119958 cmd_parse_build_commands 0:2 0:3: %%
+1783499626.120036 cmd_parse_build_commands 0:0: send
+1783499626.120046 cmd_parse_build_commands 0:1: -X
+1783499626.120049 cmd_parse_build_commands 0:2: goto-line
+1783499626.120050 cmd_parse_build_commands 0:3: %%
+1783499626.120056 args_parse_flags: next -X
+1783499626.120058 args_parse_flags: -X
+1783499626.120059 args_parse_flags: next goto-line
+1783499626.120061 args_parse: flags end at 2 of 4
+1783499626.120146 args_parse: 2 = goto-line (type STRING)
+1783499626.120156 args_parse: 3 = %% (type STRING)
+1783499626.120203 cmd_parse_build_commands: send-keys -X goto-line "%%"
+1783499626.120216 args_parse_flags: next -p(goto line)
+1783499626.120219 args_parse_flag_argument: -p = (goto line)
+1783499626.120222 args_parse: flags end at 2 of 3
+1783499626.120231 args_parse: 2 = send-keys -X goto-line "%%" (type COMMANDS)
+1783499626.120241 cmd_parse_build_commands: command-prompt -p "(goto line)" { send-keys -X goto-line "%%" }
+1783499626.120244 args_parse_flags: next -Tcopy-mode-vi
+1783499626.120246 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.120249 args_parse_flags: next :
+1783499626.120251 args_parse: flags end at 2 of 4
+1783499626.120254 args_parse: 2 = : (type STRING)
+1783499626.120261 args_parse: 3 = command-prompt -p "(goto line)" { send-keys -X goto-line "%%" } (type COMMANDS)
+1783499626.120273 cmd_parse_build_commands: bind-key -T copy-mode-vi : { command-prompt -p "(goto line)" { send-keys -X goto-line "%%" } }
+1783499626.120279 cmdq_get_command: [bind-key/0x58e472526510] group 2200
+1783499626.120282 cmdq_append <global>: [bind-key/0x58e472526510]
+1783499626.120289 yylex_token: end at WS
+1783499626.120291 yylex_token: bind
+1783499626.120294 yylex_token: end at WS
+1783499626.120297 yylex_token: -Tcopy-mode-vi
+1783499626.120299 yylex_token: end at WS
+1783499626.120301 yylex_token: ;
+1783499626.120303 yylex_token: end at WS
+1783499626.120305 yylex_token: send
+1783499626.120308 yylex_token: end at WS
+1783499626.120310 yylex_token: -X
+1783499626.120313 yylex_token: end at WS
+1783499626.120315 yylex_token: jump-again
+1783499626.120320 cmd_parse_build_commands 0:0: bind
+1783499626.120323 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.120325 cmd_parse_build_commands 0:2: ;
+1783499626.120328 cmd_parse_build_commands 0:3 0:0: send
+1783499626.120330 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.120332 cmd_parse_build_commands 0:3 0:2: jump-again
+1783499626.120337 cmd_parse_build_commands 0:0: send
+1783499626.120339 cmd_parse_build_commands 0:1: -X
+1783499626.120342 cmd_parse_build_commands 0:2: jump-again
+1783499626.120347 args_parse_flags: next -X
+1783499626.120349 args_parse_flags: -X
+1783499626.120351 args_parse_flags: next jump-again
+1783499626.120354 args_parse: flags end at 2 of 3
+1783499626.120357 args_parse: 2 = jump-again (type STRING)
+1783499626.120363 cmd_parse_build_commands: send-keys -X jump-again
+1783499626.120366 args_parse_flags: next -Tcopy-mode-vi
+1783499626.120369 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.120371 args_parse_flags: next ;
+1783499626.120373 args_parse: flags end at 2 of 4
+1783499626.120376 args_parse: 2 = ; (type STRING)
+1783499626.120381 args_parse: 3 = send-keys -X jump-again (type COMMANDS)
+1783499626.120390 cmd_parse_build_commands: bind-key -T copy-mode-vi \\; { send-keys -X jump-again }
+1783499626.120394 cmdq_get_command: [bind-key/0x58e472526d60] group 2212
+1783499626.120397 cmdq_append <global>: [bind-key/0x58e472526d60]
+1783499626.120401 yylex_token: end at WS
+1783499626.120403 yylex_token: bind
+1783499626.120406 yylex_token: end at WS
+1783499626.120408 yylex_token: -Tcopy-mode-vi
+1783499626.120411 yylex_token: end at WS
+1783499626.120413 yylex_token: ?
+1783499626.120416 yylex_token: end at WS
+1783499626.120418 yylex_token: command-prompt
+1783499626.120420 yylex_token: end at WS
+1783499626.120422 yylex_token: -T
+1783499626.120424 yylex_token: end at WS
+1783499626.120426 yylex_token: search
+1783499626.120430 yylex_token: end at WS
+1783499626.120432 yylex_token: -p(search up)
+1783499626.120435 yylex_token: end at WS
+1783499626.120437 yylex_token: send
+1783499626.120439 yylex_token: end at WS
+1783499626.120441 yylex_token: -X
+1783499626.120444 yylex_token: end at WS
+1783499626.120446 yylex_token: search-backward
+1783499626.120449 yylex_token: end at WS
+1783499626.120451 yylex_token: %%
+1783499626.120456 cmd_parse_build_commands 0:0: bind
+1783499626.120458 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.120461 cmd_parse_build_commands 0:2: ?
+1783499626.120473 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.120476 cmd_parse_build_commands 0:3 0:1: -T
+1783499626.120479 cmd_parse_build_commands 0:3 0:2: search
+1783499626.120481 cmd_parse_build_commands 0:3 0:3: -p(search up)
+1783499626.120485 cmd_parse_build_commands 0:3 0:4 0:0: send
+1783499626.120487 cmd_parse_build_commands 0:3 0:4 0:1: -X
+1783499626.120490 cmd_parse_build_commands 0:3 0:4 0:2: search-backward
+1783499626.120492 cmd_parse_build_commands 0:3 0:4 0:3: %%
+1783499626.120497 cmd_parse_build_commands 0:0: command-prompt
+1783499626.120499 cmd_parse_build_commands 0:1: -T
+1783499626.120502 cmd_parse_build_commands 0:2: search
+1783499626.120504 cmd_parse_build_commands 0:3: -p(search up)
+1783499626.120507 cmd_parse_build_commands 0:4 0:0: send
+1783499626.120509 cmd_parse_build_commands 0:4 0:1: -X
+1783499626.120512 cmd_parse_build_commands 0:4 0:2: search-backward
+1783499626.120514 cmd_parse_build_commands 0:4 0:3: %%
+1783499626.120518 cmd_parse_build_commands 0:0: send
+1783499626.120521 cmd_parse_build_commands 0:1: -X
+1783499626.120524 cmd_parse_build_commands 0:2: search-backward
+1783499626.120526 cmd_parse_build_commands 0:3: %%
+1783499626.120531 args_parse_flags: next -X
+1783499626.120533 args_parse_flags: -X
+1783499626.120536 args_parse_flags: next search-backward
+1783499626.120538 args_parse: flags end at 2 of 4
+1783499626.120541 args_parse: 2 = search-backward (type STRING)
+1783499626.120544 args_parse: 3 = %% (type STRING)
+1783499626.120555 cmd_parse_build_commands: send-keys -X search-backward "%%"
+1783499626.120559 args_parse_flags: next -T
+1783499626.120562 args_parse_flag_argument: -T = search
+1783499626.120564 args_parse_flags: next -p(search up)
+1783499626.120567 args_parse_flag_argument: -p = (search up)
+1783499626.120569 args_parse: flags end at 4 of 5
+1783499626.120575 args_parse: 4 = send-keys -X search-backward "%%" (type COMMANDS)
+1783499626.120586 cmd_parse_build_commands: command-prompt -T search -p "(search up)" { send-keys -X search-backward "%%" }
+1783499626.120588 args_parse_flags: next -Tcopy-mode-vi
+1783499626.120591 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.120593 args_parse_flags: next ?
+1783499626.120595 args_parse: flags end at 2 of 4
+1783499626.120597 args_parse: 2 = ? (type STRING)
+1783499626.120606 args_parse: 3 = command-prompt -T search -p "(search up)" { send-keys -X search-backward "%%" } (type COMMANDS)
+1783499626.120618 cmd_parse_build_commands: bind-key -T copy-mode-vi ? { command-prompt -T search -p "(search up)" { send-keys -X search-backward "%%" } }
+1783499626.120622 cmdq_get_command: [bind-key/0x58e4725288d0] group 2220
+1783499626.120624 cmdq_append <global>: [bind-key/0x58e4725288d0]
+1783499626.120635 yylex_token: end at WS
+1783499626.120637 yylex_token: bind
+1783499626.120640 yylex_token: end at WS
+1783499626.120642 yylex_token: -Tcopy-mode-vi
+1783499626.120644 yylex_token: end at WS
+1783499626.120646 yylex_token: A
+1783499626.120649 yylex_token: end at WS
+1783499626.120651 yylex_token: send
+1783499626.120653 yylex_token: end at WS
+1783499626.120655 yylex_token: -X
+1783499626.120659 yylex_token: end at WS
+1783499626.120661 yylex_token: append-selection-and-cancel
+1783499626.120665 cmd_parse_build_commands 0:0: bind
+1783499626.120667 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.120670 cmd_parse_build_commands 0:2: A
+1783499626.120672 cmd_parse_build_commands 0:3 0:0: send
+1783499626.120675 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.120678 cmd_parse_build_commands 0:3 0:2: append-selection-and-cancel
+1783499626.120682 cmd_parse_build_commands 0:0: send
+1783499626.120684 cmd_parse_build_commands 0:1: -X
+1783499626.120687 cmd_parse_build_commands 0:2: append-selection-and-cancel
+1783499626.120692 args_parse_flags: next -X
+1783499626.120695 args_parse_flags: -X
+1783499626.120697 args_parse_flags: next append-selection-and-cancel
+1783499626.120700 args_parse: flags end at 2 of 3
+1783499626.120702 args_parse: 2 = append-selection-and-cancel (type STRING)
+1783499626.120709 cmd_parse_build_commands: send-keys -X append-selection-and-cancel
+1783499626.120716 args_parse_flags: next -Tcopy-mode-vi
+1783499626.120719 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.120721 args_parse_flags: next A
+1783499626.120724 args_parse: flags end at 2 of 4
+1783499626.120726 args_parse: 2 = A (type STRING)
+1783499626.120732 args_parse: 3 = send-keys -X append-selection-and-cancel (type COMMANDS)
+1783499626.120740 cmd_parse_build_commands: bind-key -T copy-mode-vi A { send-keys -X append-selection-and-cancel }
+1783499626.120744 cmdq_get_command: [bind-key/0x58e472526fe0] group 2232
+1783499626.120747 cmdq_append <global>: [bind-key/0x58e472526fe0]
+1783499626.120752 yylex_token: end at WS
+1783499626.120754 yylex_token: bind
+1783499626.120757 yylex_token: end at WS
+1783499626.120760 yylex_token: -Tcopy-mode-vi
+1783499626.120762 yylex_token: end at WS
+1783499626.120764 yylex_token: B
+1783499626.120767 yylex_token: end at WS
+1783499626.120769 yylex_token: send
+1783499626.120771 yylex_token: end at WS
+1783499626.120773 yylex_token: -X
+1783499626.120776 yylex_token: end at WS
+1783499626.120779 yylex_token: previous-space
+1783499626.120782 cmd_parse_build_commands 0:0: bind
+1783499626.120784 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.120786 cmd_parse_build_commands 0:2: B
+1783499626.120789 cmd_parse_build_commands 0:3 0:0: send
+1783499626.120792 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.120794 cmd_parse_build_commands 0:3 0:2: previous-space
+1783499626.120798 cmd_parse_build_commands 0:0: send
+1783499626.120801 cmd_parse_build_commands 0:1: -X
+1783499626.120804 cmd_parse_build_commands 0:2: previous-space
+1783499626.120809 args_parse_flags: next -X
+1783499626.120811 args_parse_flags: -X
+1783499626.120814 args_parse_flags: next previous-space
+1783499626.120817 args_parse: flags end at 2 of 3
+1783499626.120819 args_parse: 2 = previous-space (type STRING)
+1783499626.120825 cmd_parse_build_commands: send-keys -X previous-space
+1783499626.120828 args_parse_flags: next -Tcopy-mode-vi
+1783499626.120831 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.120833 args_parse_flags: next B
+1783499626.120835 args_parse: flags end at 2 of 4
+1783499626.120838 args_parse: 2 = B (type STRING)
+1783499626.120843 args_parse: 3 = send-keys -X previous-space (type COMMANDS)
+1783499626.120851 cmd_parse_build_commands: bind-key -T copy-mode-vi B { send-keys -X previous-space }
+1783499626.120856 cmdq_get_command: [bind-key/0x58e472527540] group 2240
+1783499626.120859 cmdq_append <global>: [bind-key/0x58e472527540]
+1783499626.120864 yylex_token: end at WS
+1783499626.120866 yylex_token: bind
+1783499626.120870 yylex_token: end at WS
+1783499626.120872 yylex_token: -Tcopy-mode-vi
+1783499626.120875 yylex_token: end at WS
+1783499626.120877 yylex_token: D
+1783499626.120879 yylex_token: end at WS
+1783499626.120881 yylex_token: send
+1783499626.120883 yylex_token: end at WS
+1783499626.120886 yylex_token: -X
+1783499626.120889 yylex_token: end at WS
+1783499626.120891 yylex_token: copy-pipe-end-of-line-and-cancel
+1783499626.120896 cmd_parse_build_commands 0:0: bind
+1783499626.120898 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.120901 cmd_parse_build_commands 0:2: D
+1783499626.120904 cmd_parse_build_commands 0:3 0:0: send
+1783499626.120906 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.120909 cmd_parse_build_commands 0:3 0:2: copy-pipe-end-of-line-and-cancel
+1783499626.120913 cmd_parse_build_commands 0:0: send
+1783499626.120915 cmd_parse_build_commands 0:1: -X
+1783499626.120918 cmd_parse_build_commands 0:2: copy-pipe-end-of-line-and-cancel
+1783499626.120922 args_parse_flags: next -X
+1783499626.120925 args_parse_flags: -X
+1783499626.120927 args_parse_flags: next copy-pipe-end-of-line-and-cancel
+1783499626.120930 args_parse: flags end at 2 of 3
+1783499626.120933 args_parse: 2 = copy-pipe-end-of-line-and-cancel (type STRING)
+1783499626.120940 cmd_parse_build_commands: send-keys -X copy-pipe-end-of-line-and-cancel
+1783499626.120942 args_parse_flags: next -Tcopy-mode-vi
+1783499626.120945 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.120953 args_parse_flags: next D
+1783499626.120955 args_parse: flags end at 2 of 4
+1783499626.120957 args_parse: 2 = D (type STRING)
+1783499626.120964 args_parse: 3 = send-keys -X copy-pipe-end-of-line-and-cancel (type COMMANDS)
+1783499626.120973 cmd_parse_build_commands: bind-key -T copy-mode-vi D { send-keys -X copy-pipe-end-of-line-and-cancel }
+1783499626.120977 cmdq_get_command: [bind-key/0x58e472528aa0] group 2248
+1783499626.120980 cmdq_append <global>: [bind-key/0x58e472528aa0]
+1783499626.120985 yylex_token: end at WS
+1783499626.120987 yylex_token: bind
+1783499626.120990 yylex_token: end at WS
+1783499626.120992 yylex_token: -Tcopy-mode-vi
+1783499626.120994 yylex_token: end at WS
+1783499626.120996 yylex_token: E
+1783499626.120999 yylex_token: end at WS
+1783499626.121001 yylex_token: send
+1783499626.121003 yylex_token: end at WS
+1783499626.121005 yylex_token: -X
+1783499626.121008 yylex_token: end at WS
+1783499626.121010 yylex_token: next-space-end
+1783499626.121014 cmd_parse_build_commands 0:0: bind
+1783499626.121017 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.121019 cmd_parse_build_commands 0:2: E
+1783499626.121022 cmd_parse_build_commands 0:3 0:0: send
+1783499626.121024 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.121027 cmd_parse_build_commands 0:3 0:2: next-space-end
+1783499626.121030 cmd_parse_build_commands 0:0: send
+1783499626.121033 cmd_parse_build_commands 0:1: -X
+1783499626.121035 cmd_parse_build_commands 0:2: next-space-end
+1783499626.121040 args_parse_flags: next -X
+1783499626.121042 args_parse_flags: -X
+1783499626.121045 args_parse_flags: next next-space-end
+1783499626.121047 args_parse: flags end at 2 of 3
+1783499626.121050 args_parse: 2 = next-space-end (type STRING)
+1783499626.121055 cmd_parse_build_commands: send-keys -X next-space-end
+1783499626.121058 args_parse_flags: next -Tcopy-mode-vi
+1783499626.121060 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.121062 args_parse_flags: next E
+1783499626.121065 args_parse: flags end at 2 of 4
+1783499626.121067 args_parse: 2 = E (type STRING)
+1783499626.121071 args_parse: 3 = send-keys -X next-space-end (type COMMANDS)
+1783499626.121078 cmd_parse_build_commands: bind-key -T copy-mode-vi E { send-keys -X next-space-end }
+1783499626.121081 cmdq_get_command: [bind-key/0x58e472529100] group 2256
+1783499626.121084 cmdq_append <global>: [bind-key/0x58e472529100]
+1783499626.121088 yylex_token: end at WS
+1783499626.121090 yylex_token: bind
+1783499626.121093 yylex_token: end at WS
+1783499626.121095 yylex_token: -Tcopy-mode-vi
+1783499626.121097 yylex_token: end at WS
+1783499626.121099 yylex_token: F
+1783499626.121102 yylex_token: end at WS
+1783499626.121103 yylex_token: command-prompt
+1783499626.121106 yylex_token: end at WS
+1783499626.121108 yylex_token: -1p(jump backward)
+1783499626.121110 yylex_token: end at WS
+1783499626.121112 yylex_token: send
+1783499626.121114 yylex_token: end at WS
+1783499626.121116 yylex_token: -X
+1783499626.121119 yylex_token: end at WS
+1783499626.121121 yylex_token: jump-backward
+1783499626.121124 yylex_token: end at WS
+1783499626.121126 yylex_token: %%
+1783499626.121130 cmd_parse_build_commands 0:0: bind
+1783499626.121133 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.121135 cmd_parse_build_commands 0:2: F
+1783499626.121138 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.121142 cmd_parse_build_commands 0:3 0:1: -1p(jump backward)
+1783499626.121145 cmd_parse_build_commands 0:3 0:2 0:0: send
+1783499626.121147 cmd_parse_build_commands 0:3 0:2 0:1: -X
+1783499626.121149 cmd_parse_build_commands 0:3 0:2 0:2: jump-backward
+1783499626.121151 cmd_parse_build_commands 0:3 0:2 0:3: %%
+1783499626.121154 cmd_parse_build_commands 0:0: command-prompt
+1783499626.121156 cmd_parse_build_commands 0:1: -1p(jump backward)
+1783499626.121159 cmd_parse_build_commands 0:2 0:0: send
+1783499626.121160 cmd_parse_build_commands 0:2 0:1: -X
+1783499626.121162 cmd_parse_build_commands 0:2 0:2: jump-backward
+1783499626.121164 cmd_parse_build_commands 0:2 0:3: %%
+1783499626.121166 cmd_parse_build_commands 0:0: send
+1783499626.121172 cmd_parse_build_commands 0:1: -X
+1783499626.121174 cmd_parse_build_commands 0:2: jump-backward
+1783499626.121176 cmd_parse_build_commands 0:3: %%
+1783499626.121179 args_parse_flags: next -X
+1783499626.121181 args_parse_flags: -X
+1783499626.121206 args_parse_flags: next jump-backward
+1783499626.121210 args_parse: flags end at 2 of 4
+1783499626.121212 args_parse: 2 = jump-backward (type STRING)
+1783499626.121215 args_parse: 3 = %% (type STRING)
+1783499626.121223 cmd_parse_build_commands: send-keys -X jump-backward "%%"
+1783499626.121226 args_parse_flags: next -1p(jump backward)
+1783499626.121228 args_parse_flags: -1
+1783499626.121231 args_parse_flag_argument: -p = (jump backward)
+1783499626.121233 args_parse: flags end at 2 of 3
+1783499626.121239 args_parse: 2 = send-keys -X jump-backward "%%" (type COMMANDS)
+1783499626.121260 cmd_parse_build_commands: command-prompt -1 -p "(jump backward)" { send-keys -X jump-backward "%%" }
+1783499626.121263 args_parse_flags: next -Tcopy-mode-vi
+1783499626.121265 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.121268 args_parse_flags: next F
+1783499626.121270 args_parse: flags end at 2 of 4
+1783499626.121272 args_parse: 2 = F (type STRING)
+1783499626.121287 args_parse: 3 = command-prompt -1 -p "(jump backward)" { send-keys -X jump-backward "%%" } (type COMMANDS)
+1783499626.121300 cmd_parse_build_commands: bind-key -T copy-mode-vi F { command-prompt -1 -p "(jump backward)" { send-keys -X jump-backward "%%" } }
+1783499626.121306 cmdq_get_command: [bind-key/0x58e47252a340] group 2264
+1783499626.121309 cmdq_append <global>: [bind-key/0x58e47252a340]
+1783499626.121320 yylex_token: end at WS
+1783499626.121322 yylex_token: bind
+1783499626.121326 yylex_token: end at WS
+1783499626.121328 yylex_token: -Tcopy-mode-vi
+1783499626.121331 yylex_token: end at WS
+1783499626.121333 yylex_token: G
+1783499626.121335 yylex_token: end at WS
+1783499626.121337 yylex_token: send
+1783499626.121340 yylex_token: end at WS
+1783499626.121342 yylex_token: -X
+1783499626.121345 yylex_token: end at WS
+1783499626.121347 yylex_token: history-bottom
+1783499626.121351 cmd_parse_build_commands 0:0: bind
+1783499626.121354 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.121357 cmd_parse_build_commands 0:2: G
+1783499626.121359 cmd_parse_build_commands 0:3 0:0: send
+1783499626.121362 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.121365 cmd_parse_build_commands 0:3 0:2: history-bottom
+1783499626.121369 cmd_parse_build_commands 0:0: send
+1783499626.121372 cmd_parse_build_commands 0:1: -X
+1783499626.121375 cmd_parse_build_commands 0:2: history-bottom
+1783499626.121381 args_parse_flags: next -X
+1783499626.121383 args_parse_flags: -X
+1783499626.121385 args_parse_flags: next history-bottom
+1783499626.121388 args_parse: flags end at 2 of 3
+1783499626.121391 args_parse: 2 = history-bottom (type STRING)
+1783499626.121397 cmd_parse_build_commands: send-keys -X history-bottom
+1783499626.121400 args_parse_flags: next -Tcopy-mode-vi
+1783499626.121403 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.121405 args_parse_flags: next G
+1783499626.121408 args_parse: flags end at 2 of 4
+1783499626.121411 args_parse: 2 = G (type STRING)
+1783499626.121416 args_parse: 3 = send-keys -X history-bottom (type COMMANDS)
+1783499626.121424 cmd_parse_build_commands: bind-key -T copy-mode-vi G { send-keys -X history-bottom }
+1783499626.121429 cmdq_get_command: [bind-key/0x58e472529410] group 2276
+1783499626.121432 cmdq_append <global>: [bind-key/0x58e472529410]
+1783499626.121437 yylex_token: end at WS
+1783499626.121439 yylex_token: bind
+1783499626.121443 yylex_token: end at WS
+1783499626.121445 yylex_token: -Tcopy-mode-vi
+1783499626.121447 yylex_token: end at WS
+1783499626.121449 yylex_token: H
+1783499626.121452 yylex_token: end at WS
+1783499626.121454 yylex_token: send
+1783499626.121457 yylex_token: end at WS
+1783499626.121459 yylex_token: -X
+1783499626.121462 yylex_token: end at WS
+1783499626.121464 yylex_token: top-line
+1783499626.121468 cmd_parse_build_commands 0:0: bind
+1783499626.121471 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.121479 cmd_parse_build_commands 0:2: H
+1783499626.121482 cmd_parse_build_commands 0:3 0:0: send
+1783499626.121484 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.121487 cmd_parse_build_commands 0:3 0:2: top-line
+1783499626.121491 cmd_parse_build_commands 0:0: send
+1783499626.121494 cmd_parse_build_commands 0:1: -X
+1783499626.121496 cmd_parse_build_commands 0:2: top-line
+1783499626.121502 args_parse_flags: next -X
+1783499626.121504 args_parse_flags: -X
+1783499626.121506 args_parse_flags: next top-line
+1783499626.121509 args_parse: flags end at 2 of 3
+1783499626.121512 args_parse: 2 = top-line (type STRING)
+1783499626.121517 cmd_parse_build_commands: send-keys -X top-line
+1783499626.121521 args_parse_flags: next -Tcopy-mode-vi
+1783499626.121523 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.121526 args_parse_flags: next H
+1783499626.121528 args_parse: flags end at 2 of 4
+1783499626.121531 args_parse: 2 = H (type STRING)
+1783499626.121536 args_parse: 3 = send-keys -X top-line (type COMMANDS)
+1783499626.121544 cmd_parse_build_commands: bind-key -T copy-mode-vi H { send-keys -X top-line }
+1783499626.121548 cmdq_get_command: [bind-key/0x58e47252a620] group 2284
+1783499626.121551 cmdq_append <global>: [bind-key/0x58e47252a620]
+1783499626.121556 yylex_token: end at WS
+1783499626.121559 yylex_token: bind
+1783499626.121562 yylex_token: end at WS
+1783499626.121564 yylex_token: -Tcopy-mode-vi
+1783499626.121567 yylex_token: end at WS
+1783499626.121569 yylex_token: J
+1783499626.121572 yylex_token: end at WS
+1783499626.121574 yylex_token: send
+1783499626.121576 yylex_token: end at WS
+1783499626.121578 yylex_token: -X
+1783499626.121582 yylex_token: end at WS
+1783499626.121584 yylex_token: scroll-down
+1783499626.121588 cmd_parse_build_commands 0:0: bind
+1783499626.121591 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.121593 cmd_parse_build_commands 0:2: J
+1783499626.121596 cmd_parse_build_commands 0:3 0:0: send
+1783499626.121598 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.121600 cmd_parse_build_commands 0:3 0:2: scroll-down
+1783499626.121603 cmd_parse_build_commands 0:0: send
+1783499626.121606 cmd_parse_build_commands 0:1: -X
+1783499626.121608 cmd_parse_build_commands 0:2: scroll-down
+1783499626.121614 args_parse_flags: next -X
+1783499626.121617 args_parse_flags: -X
+1783499626.121620 args_parse_flags: next scroll-down
+1783499626.121623 args_parse: flags end at 2 of 3
+1783499626.121625 args_parse: 2 = scroll-down (type STRING)
+1783499626.121631 cmd_parse_build_commands: send-keys -X scroll-down
+1783499626.121634 args_parse_flags: next -Tcopy-mode-vi
+1783499626.121637 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.121639 args_parse_flags: next J
+1783499626.121642 args_parse: flags end at 2 of 4
+1783499626.121644 args_parse: 2 = J (type STRING)
+1783499626.121649 args_parse: 3 = send-keys -X scroll-down (type COMMANDS)
+1783499626.121657 cmd_parse_build_commands: bind-key -T copy-mode-vi J { send-keys -X scroll-down }
+1783499626.121661 cmdq_get_command: [bind-key/0x58e47252acd0] group 2292
+1783499626.121664 cmdq_append <global>: [bind-key/0x58e47252acd0]
+1783499626.121669 yylex_token: end at WS
+1783499626.121672 yylex_token: bind
+1783499626.121675 yylex_token: end at WS
+1783499626.121677 yylex_token: -Tcopy-mode-vi
+1783499626.121680 yylex_token: end at WS
+1783499626.121682 yylex_token: K
+1783499626.121684 yylex_token: end at WS
+1783499626.121687 yylex_token: send
+1783499626.121689 yylex_token: end at WS
+1783499626.121691 yylex_token: -X
+1783499626.121694 yylex_token: end at WS
+1783499626.121697 yylex_token: scroll-up
+1783499626.121701 cmd_parse_build_commands 0:0: bind
+1783499626.121704 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.121706 cmd_parse_build_commands 0:2: K
+1783499626.121709 cmd_parse_build_commands 0:3 0:0: send
+1783499626.121712 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.121714 cmd_parse_build_commands 0:3 0:2: scroll-up
+1783499626.121718 cmd_parse_build_commands 0:0: send
+1783499626.121721 cmd_parse_build_commands 0:1: -X
+1783499626.121723 cmd_parse_build_commands 0:2: scroll-up
+1783499626.121732 args_parse_flags: next -X
+1783499626.121735 args_parse_flags: -X
+1783499626.121737 args_parse_flags: next scroll-up
+1783499626.121740 args_parse: flags end at 2 of 3
+1783499626.121743 args_parse: 2 = scroll-up (type STRING)
+1783499626.121748 cmd_parse_build_commands: send-keys -X scroll-up
+1783499626.121750 args_parse_flags: next -Tcopy-mode-vi
+1783499626.121753 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.121755 args_parse_flags: next K
+1783499626.121758 args_parse: flags end at 2 of 4
+1783499626.121761 args_parse: 2 = K (type STRING)
+1783499626.121765 args_parse: 3 = send-keys -X scroll-up (type COMMANDS)
+1783499626.121774 cmd_parse_build_commands: bind-key -T copy-mode-vi K { send-keys -X scroll-up }
+1783499626.121778 cmdq_get_command: [bind-key/0x58e47252b290] group 2300
+1783499626.121780 cmdq_append <global>: [bind-key/0x58e47252b290]
+1783499626.121825 yylex_token: end at WS
+1783499626.121830 yylex_token: bind
+1783499626.121834 yylex_token: end at WS
+1783499626.121836 yylex_token: -Tcopy-mode-vi
+1783499626.121839 yylex_token: end at WS
+1783499626.121841 yylex_token: L
+1783499626.121845 yylex_token: end at WS
+1783499626.121847 yylex_token: send
+1783499626.121850 yylex_token: end at WS
+1783499626.121852 yylex_token: -X
+1783499626.121855 yylex_token: end at WS
+1783499626.121858 yylex_token: bottom-line
+1783499626.121863 cmd_parse_build_commands 0:0: bind
+1783499626.121866 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.121868 cmd_parse_build_commands 0:2: L
+1783499626.121871 cmd_parse_build_commands 0:3 0:0: send
+1783499626.121874 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.121877 cmd_parse_build_commands 0:3 0:2: bottom-line
+1783499626.121882 cmd_parse_build_commands 0:0: send
+1783499626.121885 cmd_parse_build_commands 0:1: -X
+1783499626.121888 cmd_parse_build_commands 0:2: bottom-line
+1783499626.121895 args_parse_flags: next -X
+1783499626.121897 args_parse_flags: -X
+1783499626.121900 args_parse_flags: next bottom-line
+1783499626.121903 args_parse: flags end at 2 of 3
+1783499626.121906 args_parse: 2 = bottom-line (type STRING)
+1783499626.121913 cmd_parse_build_commands: send-keys -X bottom-line
+1783499626.121917 args_parse_flags: next -Tcopy-mode-vi
+1783499626.121919 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.121922 args_parse_flags: next L
+1783499626.121924 args_parse: flags end at 2 of 4
+1783499626.121927 args_parse: 2 = L (type STRING)
+1783499626.121932 args_parse: 3 = send-keys -X bottom-line (type COMMANDS)
+1783499626.121942 cmd_parse_build_commands: bind-key -T copy-mode-vi L { send-keys -X bottom-line }
+1783499626.121946 cmdq_get_command: [bind-key/0x58e47252b800] group 2308
+1783499626.121949 cmdq_append <global>: [bind-key/0x58e47252b800]
+1783499626.121954 yylex_token: end at WS
+1783499626.121956 yylex_token: bind
+1783499626.121959 yylex_token: end at WS
+1783499626.121961 yylex_token: -Tcopy-mode-vi
+1783499626.121964 yylex_token: end at WS
+1783499626.121966 yylex_token: M
+1783499626.121969 yylex_token: end at WS
+1783499626.121971 yylex_token: send
+1783499626.121973 yylex_token: end at WS
+1783499626.121975 yylex_token: -X
+1783499626.121979 yylex_token: end at WS
+1783499626.121981 yylex_token: middle-line
+1783499626.121985 cmd_parse_build_commands 0:0: bind
+1783499626.121988 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.121990 cmd_parse_build_commands 0:2: M
+1783499626.121993 cmd_parse_build_commands 0:3 0:0: send
+1783499626.121995 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.121998 cmd_parse_build_commands 0:3 0:2: middle-line
+1783499626.122002 cmd_parse_build_commands 0:0: send
+1783499626.122005 cmd_parse_build_commands 0:1: -X
+1783499626.122008 cmd_parse_build_commands 0:2: middle-line
+1783499626.122013 args_parse_flags: next -X
+1783499626.122015 args_parse_flags: -X
+1783499626.122018 args_parse_flags: next middle-line
+1783499626.122020 args_parse: flags end at 2 of 3
+1783499626.122023 args_parse: 2 = middle-line (type STRING)
+1783499626.122029 cmd_parse_build_commands: send-keys -X middle-line
+1783499626.122032 args_parse_flags: next -Tcopy-mode-vi
+1783499626.122040 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.122043 args_parse_flags: next M
+1783499626.122045 args_parse: flags end at 2 of 4
+1783499626.122048 args_parse: 2 = M (type STRING)
+1783499626.122053 args_parse: 3 = send-keys -X middle-line (type COMMANDS)
+1783499626.122061 cmd_parse_build_commands: bind-key -T copy-mode-vi M { send-keys -X middle-line }
+1783499626.122066 cmdq_get_command: [bind-key/0x58e47252bdb0] group 2316
+1783499626.122069 cmdq_append <global>: [bind-key/0x58e47252bdb0]
+1783499626.122075 yylex_token: end at WS
+1783499626.122077 yylex_token: bind
+1783499626.122081 yylex_token: end at WS
+1783499626.122083 yylex_token: -Tcopy-mode-vi
+1783499626.122086 yylex_token: end at WS
+1783499626.122088 yylex_token: N
+1783499626.122091 yylex_token: end at WS
+1783499626.122093 yylex_token: send
+1783499626.122096 yylex_token: end at WS
+1783499626.122098 yylex_token: -X
+1783499626.122101 yylex_token: end at WS
+1783499626.122104 yylex_token: search-reverse
+1783499626.122108 cmd_parse_build_commands 0:0: bind
+1783499626.122110 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.122113 cmd_parse_build_commands 0:2: N
+1783499626.122116 cmd_parse_build_commands 0:3 0:0: send
+1783499626.122118 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.122121 cmd_parse_build_commands 0:3 0:2: search-reverse
+1783499626.122125 cmd_parse_build_commands 0:0: send
+1783499626.122128 cmd_parse_build_commands 0:1: -X
+1783499626.122130 cmd_parse_build_commands 0:2: search-reverse
+1783499626.122135 args_parse_flags: next -X
+1783499626.122137 args_parse_flags: -X
+1783499626.122140 args_parse_flags: next search-reverse
+1783499626.122143 args_parse: flags end at 2 of 3
+1783499626.122146 args_parse: 2 = search-reverse (type STRING)
+1783499626.122152 cmd_parse_build_commands: send-keys -X search-reverse
+1783499626.122154 args_parse_flags: next -Tcopy-mode-vi
+1783499626.122157 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.122159 args_parse_flags: next N
+1783499626.122161 args_parse: flags end at 2 of 4
+1783499626.122164 args_parse: 2 = N (type STRING)
+1783499626.122169 args_parse: 3 = send-keys -X search-reverse (type COMMANDS)
+1783499626.122177 cmd_parse_build_commands: bind-key -T copy-mode-vi N { send-keys -X search-reverse }
+1783499626.122182 cmdq_get_command: [bind-key/0x58e47252c390] group 2324
+1783499626.122184 cmdq_append <global>: [bind-key/0x58e47252c390]
+1783499626.122194 yylex_token: end at WS
+1783499626.122197 yylex_token: bind
+1783499626.122200 yylex_token: end at WS
+1783499626.122202 yylex_token: -Tcopy-mode-vi
+1783499626.122204 yylex_token: end at WS
+1783499626.122207 yylex_token: P
+1783499626.122209 yylex_token: end at WS
+1783499626.122211 yylex_token: send
+1783499626.122214 yylex_token: end at WS
+1783499626.122216 yylex_token: -X
+1783499626.122220 yylex_token: end at WS
+1783499626.122222 yylex_token: toggle-position
+1783499626.122226 cmd_parse_build_commands 0:0: bind
+1783499626.122229 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.122231 cmd_parse_build_commands 0:2: P
+1783499626.122234 cmd_parse_build_commands 0:3 0:0: send
+1783499626.122237 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.122240 cmd_parse_build_commands 0:3 0:2: toggle-position
+1783499626.122244 cmd_parse_build_commands 0:0: send
+1783499626.122246 cmd_parse_build_commands 0:1: -X
+1783499626.122249 cmd_parse_build_commands 0:2: toggle-position
+1783499626.122254 args_parse_flags: next -X
+1783499626.122256 args_parse_flags: -X
+1783499626.122259 args_parse_flags: next toggle-position
+1783499626.122262 args_parse: flags end at 2 of 3
+1783499626.122265 args_parse: 2 = toggle-position (type STRING)
+1783499626.122270 cmd_parse_build_commands: send-keys -X toggle-position
+1783499626.122273 args_parse_flags: next -Tcopy-mode-vi
+1783499626.122275 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.122278 args_parse_flags: next P
+1783499626.122280 args_parse: flags end at 2 of 4
+1783499626.122283 args_parse: 2 = P (type STRING)
+1783499626.122288 args_parse: 3 = send-keys -X toggle-position (type COMMANDS)
+1783499626.122395 cmd_parse_build_commands: bind-key -T copy-mode-vi P { send-keys -X toggle-position }
+1783499626.122403 cmdq_get_command: [bind-key/0x58e47252c970] group 2332
+1783499626.122406 cmdq_append <global>: [bind-key/0x58e47252c970]
+1783499626.122412 yylex_token: end at WS
+1783499626.122415 yylex_token: bind
+1783499626.122419 yylex_token: end at WS
+1783499626.122421 yylex_token: -Tcopy-mode-vi
+1783499626.122424 yylex_token: end at WS
+1783499626.122426 yylex_token: T
+1783499626.122430 yylex_token: end at WS
+1783499626.122432 yylex_token: command-prompt
+1783499626.122436 yylex_token: end at WS
+1783499626.122438 yylex_token: -1p(jump to backward)
+1783499626.122441 yylex_token: end at WS
+1783499626.122444 yylex_token: send
+1783499626.122446 yylex_token: end at WS
+1783499626.122448 yylex_token: -X
+1783499626.122452 yylex_token: end at WS
+1783499626.122454 yylex_token: jump-to-backward
+1783499626.122457 yylex_token: end at WS
+1783499626.122459 yylex_token: %%
+1783499626.122464 cmd_parse_build_commands 0:0: bind
+1783499626.122467 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.122469 cmd_parse_build_commands 0:2: T
+1783499626.122473 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.122476 cmd_parse_build_commands 0:3 0:1: -1p(jump to backward)
+1783499626.122479 cmd_parse_build_commands 0:3 0:2 0:0: send
+1783499626.122482 cmd_parse_build_commands 0:3 0:2 0:1: -X
+1783499626.122485 cmd_parse_build_commands 0:3 0:2 0:2: jump-to-backward
+1783499626.122488 cmd_parse_build_commands 0:3 0:2 0:3: %%
+1783499626.122493 cmd_parse_build_commands 0:0: command-prompt
+1783499626.122496 cmd_parse_build_commands 0:1: -1p(jump to backward)
+1783499626.122499 cmd_parse_build_commands 0:2 0:0: send
+1783499626.122502 cmd_parse_build_commands 0:2 0:1: -X
+1783499626.122505 cmd_parse_build_commands 0:2 0:2: jump-to-backward
+1783499626.122507 cmd_parse_build_commands 0:2 0:3: %%
+1783499626.122511 cmd_parse_build_commands 0:0: send
+1783499626.122514 cmd_parse_build_commands 0:1: -X
+1783499626.122517 cmd_parse_build_commands 0:2: jump-to-backward
+1783499626.122519 cmd_parse_build_commands 0:3: %%
+1783499626.122524 args_parse_flags: next -X
+1783499626.122527 args_parse_flags: -X
+1783499626.122529 args_parse_flags: next jump-to-backward
+1783499626.122532 args_parse: flags end at 2 of 4
+1783499626.122535 args_parse: 2 = jump-to-backward (type STRING)
+1783499626.122538 args_parse: 3 = %% (type STRING)
+1783499626.122545 cmd_parse_build_commands: send-keys -X jump-to-backward "%%"
+1783499626.122548 args_parse_flags: next -1p(jump to backward)
+1783499626.122551 args_parse_flags: -1
+1783499626.122554 args_parse_flag_argument: -p = (jump to backward)
+1783499626.122557 args_parse: flags end at 2 of 3
+1783499626.122563 args_parse: 2 = send-keys -X jump-to-backward "%%" (type COMMANDS)
+1783499626.122574 cmd_parse_build_commands: command-prompt -1 -p "(jump to backward)" { send-keys -X jump-to-backward "%%" }
+1783499626.122577 args_parse_flags: next -Tcopy-mode-vi
+1783499626.122580 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.122582 args_parse_flags: next T
+1783499626.122585 args_parse: flags end at 2 of 4
+1783499626.122587 args_parse: 2 = T (type STRING)
+1783499626.122597 args_parse: 3 = command-prompt -1 -p "(jump to backward)" { send-keys -X jump-to-backward "%%" } (type COMMANDS)
+1783499626.122611 cmd_parse_build_commands: bind-key -T copy-mode-vi T { command-prompt -1 -p "(jump to backward)" { send-keys -X jump-to-backward "%%" } }
+1783499626.122617 cmdq_get_command: [bind-key/0x58e47252d8c0] group 2340
+1783499626.122620 cmdq_append <global>: [bind-key/0x58e47252d8c0]
+1783499626.122631 yylex_token: end at WS
+1783499626.122633 yylex_token: bind
+1783499626.122637 yylex_token: end at WS
+1783499626.122639 yylex_token: -Tcopy-mode-vi
+1783499626.122642 yylex_token: end at WS
+1783499626.122644 yylex_token: V
+1783499626.122647 yylex_token: end at WS
+1783499626.122649 yylex_token: send
+1783499626.122652 yylex_token: end at WS
+1783499626.122654 yylex_token: -X
+1783499626.122657 yylex_token: end at WS
+1783499626.122659 yylex_token: select-line
+1783499626.122735 cmd_parse_build_commands 0:0: bind
+1783499626.122740 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.122743 cmd_parse_build_commands 0:2: V
+1783499626.122747 cmd_parse_build_commands 0:3 0:0: send
+1783499626.122750 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.122753 cmd_parse_build_commands 0:3 0:2: select-line
+1783499626.122758 cmd_parse_build_commands 0:0: send
+1783499626.122761 cmd_parse_build_commands 0:1: -X
+1783499626.122763 cmd_parse_build_commands 0:2: select-line
+1783499626.122770 args_parse_flags: next -X
+1783499626.122772 args_parse_flags: -X
+1783499626.122775 args_parse_flags: next select-line
+1783499626.122778 args_parse: flags end at 2 of 3
+1783499626.122781 args_parse: 2 = select-line (type STRING)
+1783499626.122789 cmd_parse_build_commands: send-keys -X select-line
+1783499626.122793 args_parse_flags: next -Tcopy-mode-vi
+1783499626.122796 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.122798 args_parse_flags: next V
+1783499626.122800 args_parse: flags end at 2 of 4
+1783499626.122803 args_parse: 2 = V (type STRING)
+1783499626.122810 args_parse: 3 = send-keys -X select-line (type COMMANDS)
+1783499626.122820 cmd_parse_build_commands: bind-key -T copy-mode-vi V { send-keys -X select-line }
+1783499626.122825 cmdq_get_command: [bind-key/0x58e47252cc50] group 2352
+1783499626.122828 cmdq_append <global>: [bind-key/0x58e47252cc50]
+1783499626.122834 yylex_token: end at WS
+1783499626.122836 yylex_token: bind
+1783499626.122840 yylex_token: end at WS
+1783499626.122842 yylex_token: -Tcopy-mode-vi
+1783499626.122845 yylex_token: end at WS
+1783499626.122847 yylex_token: W
+1783499626.122850 yylex_token: end at WS
+1783499626.122852 yylex_token: send
+1783499626.122854 yylex_token: end at WS
+1783499626.122856 yylex_token: -X
+1783499626.122859 yylex_token: end at WS
+1783499626.122862 yylex_token: next-space
+1783499626.122866 cmd_parse_build_commands 0:0: bind
+1783499626.122869 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.122872 cmd_parse_build_commands 0:2: W
+1783499626.122874 cmd_parse_build_commands 0:3 0:0: send
+1783499626.122877 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.122880 cmd_parse_build_commands 0:3 0:2: next-space
+1783499626.122884 cmd_parse_build_commands 0:0: send
+1783499626.122887 cmd_parse_build_commands 0:1: -X
+1783499626.122889 cmd_parse_build_commands 0:2: next-space
+1783499626.122894 args_parse_flags: next -X
+1783499626.122896 args_parse_flags: -X
+1783499626.122899 args_parse_flags: next next-space
+1783499626.122901 args_parse: flags end at 2 of 3
+1783499626.122904 args_parse: 2 = next-space (type STRING)
+1783499626.122910 cmd_parse_build_commands: send-keys -X next-space
+1783499626.122913 args_parse_flags: next -Tcopy-mode-vi
+1783499626.122916 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.122918 args_parse_flags: next W
+1783499626.122920 args_parse: flags end at 2 of 4
+1783499626.122923 args_parse: 2 = W (type STRING)
+1783499626.122928 args_parse: 3 = send-keys -X next-space (type COMMANDS)
+1783499626.122937 cmd_parse_build_commands: bind-key -T copy-mode-vi W { send-keys -X next-space }
+1783499626.122941 cmdq_get_command: [bind-key/0x58e47252ddd0] group 2360
+1783499626.122944 cmdq_append <global>: [bind-key/0x58e47252ddd0]
+1783499626.122949 yylex_token: end at WS
+1783499626.122951 yylex_token: bind
+1783499626.122954 yylex_token: end at WS
+1783499626.122956 yylex_token: -Tcopy-mode-vi
+1783499626.122959 yylex_token: end at WS
+1783499626.122961 yylex_token: X
+1783499626.122964 yylex_token: end at WS
+1783499626.122966 yylex_token: send
+1783499626.122968 yylex_token: end at WS
+1783499626.122970 yylex_token: -X
+1783499626.122973 yylex_token: end at WS
+1783499626.122975 yylex_token: set-mark
+1783499626.122979 cmd_parse_build_commands 0:0: bind
+1783499626.122981 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.122984 cmd_parse_build_commands 0:2: X
+1783499626.122987 cmd_parse_build_commands 0:3 0:0: send
+1783499626.122989 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.122992 cmd_parse_build_commands 0:3 0:2: set-mark
+1783499626.122996 cmd_parse_build_commands 0:0: send
+1783499626.123004 cmd_parse_build_commands 0:1: -X
+1783499626.123007 cmd_parse_build_commands 0:2: set-mark
+1783499626.123011 args_parse_flags: next -X
+1783499626.123014 args_parse_flags: -X
+1783499626.123016 args_parse_flags: next set-mark
+1783499626.123019 args_parse: flags end at 2 of 3
+1783499626.123021 args_parse: 2 = set-mark (type STRING)
+1783499626.123027 cmd_parse_build_commands: send-keys -X set-mark
+1783499626.123030 args_parse_flags: next -Tcopy-mode-vi
+1783499626.123033 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.123035 args_parse_flags: next X
+1783499626.123038 args_parse: flags end at 2 of 4
+1783499626.123040 args_parse: 2 = X (type STRING)
+1783499626.123045 args_parse: 3 = send-keys -X set-mark (type COMMANDS)
+1783499626.123054 cmd_parse_build_commands: bind-key -T copy-mode-vi X { send-keys -X set-mark }
+1783499626.123058 cmdq_get_command: [bind-key/0x58e47252e140] group 2368
+1783499626.123060 cmdq_append <global>: [bind-key/0x58e47252e140]
+1783499626.123065 yylex_token: end at WS
+1783499626.123067 yylex_token: bind
+1783499626.123070 yylex_token: end at WS
+1783499626.123073 yylex_token: -Tcopy-mode-vi
+1783499626.123075 yylex_token: end at WS
+1783499626.123077 yylex_token: ^
+1783499626.123080 yylex_token: end at WS
+1783499626.123082 yylex_token: send
+1783499626.123084 yylex_token: end at WS
+1783499626.123105 yylex_token: -X
+1783499626.123110 yylex_token: end at WS
+1783499626.123114 yylex_token: back-to-indentation
+1783499626.123120 cmd_parse_build_commands 0:0: bind
+1783499626.123123 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.123126 cmd_parse_build_commands 0:2: ^
+1783499626.123130 cmd_parse_build_commands 0:3 0:0: send
+1783499626.123133 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.123137 cmd_parse_build_commands 0:3 0:2: back-to-indentation
+1783499626.123142 cmd_parse_build_commands 0:0: send
+1783499626.123145 cmd_parse_build_commands 0:1: -X
+1783499626.123147 cmd_parse_build_commands 0:2: back-to-indentation
+1783499626.123154 args_parse_flags: next -X
+1783499626.123156 args_parse_flags: -X
+1783499626.123159 args_parse_flags: next back-to-indentation
+1783499626.123162 args_parse: flags end at 2 of 3
+1783499626.123166 args_parse: 2 = back-to-indentation (type STRING)
+1783499626.123174 cmd_parse_build_commands: send-keys -X back-to-indentation
+1783499626.123177 args_parse_flags: next -Tcopy-mode-vi
+1783499626.123180 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.123183 args_parse_flags: next ^
+1783499626.123185 args_parse: flags end at 2 of 4
+1783499626.123188 args_parse: 2 = ^ (type STRING)
+1783499626.123194 args_parse: 3 = send-keys -X back-to-indentation (type COMMANDS)
+1783499626.123204 cmd_parse_build_commands: bind-key -T copy-mode-vi ^ { send-keys -X back-to-indentation }
+1783499626.123209 cmdq_get_command: [bind-key/0x58e47252e520] group 2376
+1783499626.123212 cmdq_append <global>: [bind-key/0x58e47252e520]
+1783499626.123222 yylex_token: end at WS
+1783499626.123225 yylex_token: bind
+1783499626.123228 yylex_token: end at WS
+1783499626.123230 yylex_token: -Tcopy-mode-vi
+1783499626.123233 yylex_token: end at WS
+1783499626.123235 yylex_token: b
+1783499626.123238 yylex_token: end at WS
+1783499626.123240 yylex_token: send
+1783499626.123243 yylex_token: end at WS
+1783499626.123245 yylex_token: -X
+1783499626.123248 yylex_token: end at WS
+1783499626.123251 yylex_token: previous-word
+1783499626.123255 cmd_parse_build_commands 0:0: bind
+1783499626.123258 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.123261 cmd_parse_build_commands 0:2: b
+1783499626.123264 cmd_parse_build_commands 0:3 0:0: send
+1783499626.123267 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.123270 cmd_parse_build_commands 0:3 0:2: previous-word
+1783499626.123274 cmd_parse_build_commands 0:0: send
+1783499626.123276 cmd_parse_build_commands 0:1: -X
+1783499626.123279 cmd_parse_build_commands 0:2: previous-word
+1783499626.123284 args_parse_flags: next -X
+1783499626.123287 args_parse_flags: -X
+1783499626.123289 args_parse_flags: next previous-word
+1783499626.123292 args_parse: flags end at 2 of 3
+1783499626.123300 args_parse: 2 = previous-word (type STRING)
+1783499626.123306 cmd_parse_build_commands: send-keys -X previous-word
+1783499626.123309 args_parse_flags: next -Tcopy-mode-vi
+1783499626.123311 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.123314 args_parse_flags: next b
+1783499626.123316 args_parse: flags end at 2 of 4
+1783499626.123319 args_parse: 2 = b (type STRING)
+1783499626.123324 args_parse: 3 = send-keys -X previous-word (type COMMANDS)
+1783499626.123333 cmd_parse_build_commands: bind-key -T copy-mode-vi b { send-keys -X previous-word }
+1783499626.123337 cmdq_get_command: [bind-key/0x58e47252ea90] group 2384
+1783499626.123340 cmdq_append <global>: [bind-key/0x58e47252ea90]
+1783499626.123345 yylex_token: end at WS
+1783499626.123347 yylex_token: bind
+1783499626.123351 yylex_token: end at WS
+1783499626.123353 yylex_token: -Tcopy-mode-vi
+1783499626.123356 yylex_token: end at WS
+1783499626.123358 yylex_token: e
+1783499626.123361 yylex_token: end at WS
+1783499626.123363 yylex_token: send
+1783499626.123365 yylex_token: end at WS
+1783499626.123367 yylex_token: -X
+1783499626.123371 yylex_token: end at WS
+1783499626.123373 yylex_token: next-word-end
+1783499626.123377 cmd_parse_build_commands 0:0: bind
+1783499626.123380 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.123383 cmd_parse_build_commands 0:2: e
+1783499626.123386 cmd_parse_build_commands 0:3 0:0: send
+1783499626.123388 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.123391 cmd_parse_build_commands 0:3 0:2: next-word-end
+1783499626.123395 cmd_parse_build_commands 0:0: send
+1783499626.123397 cmd_parse_build_commands 0:1: -X
+1783499626.123400 cmd_parse_build_commands 0:2: next-word-end
+1783499626.123406 args_parse_flags: next -X
+1783499626.123409 args_parse_flags: -X
+1783499626.123411 args_parse_flags: next next-word-end
+1783499626.123414 args_parse: flags end at 2 of 3
+1783499626.123416 args_parse: 2 = next-word-end (type STRING)
+1783499626.123422 cmd_parse_build_commands: send-keys -X next-word-end
+1783499626.123424 args_parse_flags: next -Tcopy-mode-vi
+1783499626.123427 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.123429 args_parse_flags: next e
+1783499626.123432 args_parse: flags end at 2 of 4
+1783499626.123434 args_parse: 2 = e (type STRING)
+1783499626.123440 args_parse: 3 = send-keys -X next-word-end (type COMMANDS)
+1783499626.123448 cmd_parse_build_commands: bind-key -T copy-mode-vi e { send-keys -X next-word-end }
+1783499626.123452 cmdq_get_command: [bind-key/0x58e47252f260] group 2392
+1783499626.123455 cmdq_append <global>: [bind-key/0x58e47252f260]
+1783499626.123460 yylex_token: end at WS
+1783499626.123462 yylex_token: bind
+1783499626.123466 yylex_token: end at WS
+1783499626.123468 yylex_token: -Tcopy-mode-vi
+1783499626.123471 yylex_token: end at WS
+1783499626.123473 yylex_token: f
+1783499626.123476 yylex_token: end at WS
+1783499626.123479 yylex_token: command-prompt
+1783499626.123482 yylex_token: end at WS
+1783499626.123485 yylex_token: -1p(jump forward)
+1783499626.123487 yylex_token: end at WS
+1783499626.123490 yylex_token: send
+1783499626.123493 yylex_token: end at WS
+1783499626.123495 yylex_token: -X
+1783499626.123498 yylex_token: end at WS
+1783499626.123501 yylex_token: jump-forward
+1783499626.123503 yylex_token: end at WS
+1783499626.123505 yylex_token: %%
+1783499626.123510 cmd_parse_build_commands 0:0: bind
+1783499626.123513 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.123516 cmd_parse_build_commands 0:2: f
+1783499626.123519 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.123522 cmd_parse_build_commands 0:3 0:1: -1p(jump forward)
+1783499626.123525 cmd_parse_build_commands 0:3 0:2 0:0: send
+1783499626.123528 cmd_parse_build_commands 0:3 0:2 0:1: -X
+1783499626.123531 cmd_parse_build_commands 0:3 0:2 0:2: jump-forward
+1783499626.123534 cmd_parse_build_commands 0:3 0:2 0:3: %%
+1783499626.123537 cmd_parse_build_commands 0:0: command-prompt
+1783499626.123540 cmd_parse_build_commands 0:1: -1p(jump forward)
+1783499626.123543 cmd_parse_build_commands 0:2 0:0: send
+1783499626.123546 cmd_parse_build_commands 0:2 0:1: -X
+1783499626.123625 cmd_parse_build_commands 0:2 0:2: jump-forward
+1783499626.123630 cmd_parse_build_commands 0:2 0:3: %%
+1783499626.123636 cmd_parse_build_commands 0:0: send
+1783499626.123639 cmd_parse_build_commands 0:1: -X
+1783499626.123642 cmd_parse_build_commands 0:2: jump-forward
+1783499626.123644 cmd_parse_build_commands 0:3: %%
+1783499626.123652 args_parse_flags: next -X
+1783499626.123655 args_parse_flags: -X
+1783499626.123658 args_parse_flags: next jump-forward
+1783499626.123661 args_parse: flags end at 2 of 4
+1783499626.123664 args_parse: 2 = jump-forward (type STRING)
+1783499626.123667 args_parse: 3 = %% (type STRING)
+1783499626.123676 cmd_parse_build_commands: send-keys -X jump-forward "%%"
+1783499626.123679 args_parse_flags: next -1p(jump forward)
+1783499626.123682 args_parse_flags: -1
+1783499626.123689 args_parse_flag_argument: -p = (jump forward)
+1783499626.123692 args_parse: flags end at 2 of 3
+1783499626.123698 args_parse: 2 = send-keys -X jump-forward "%%" (type COMMANDS)
+1783499626.123709 cmd_parse_build_commands: command-prompt -1 -p "(jump forward)" { send-keys -X jump-forward "%%" }
+1783499626.123712 args_parse_flags: next -Tcopy-mode-vi
+1783499626.123715 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.123717 args_parse_flags: next f
+1783499626.123720 args_parse: flags end at 2 of 4
+1783499626.123722 args_parse: 2 = f (type STRING)
+1783499626.123731 args_parse: 3 = command-prompt -1 -p "(jump forward)" { send-keys -X jump-forward "%%" } (type COMMANDS)
+1783499626.123743 cmd_parse_build_commands: bind-key -T copy-mode-vi f { command-prompt -1 -p "(jump forward)" { send-keys -X jump-forward "%%" } }
+1783499626.123750 cmdq_get_command: [bind-key/0x58e4725307d0] group 2400
+1783499626.123753 cmdq_append <global>: [bind-key/0x58e4725307d0]
+1783499626.123763 yylex_token: end at WS
+1783499626.123766 yylex_token: bind
+1783499626.123770 yylex_token: end at WS
+1783499626.123772 yylex_token: -Tcopy-mode-vi
+1783499626.123775 yylex_token: end at WS
+1783499626.123777 yylex_token: g
+1783499626.123780 yylex_token: end at WS
+1783499626.123782 yylex_token: send
+1783499626.123784 yylex_token: end at WS
+1783499626.123787 yylex_token: -X
+1783499626.123790 yylex_token: end at WS
+1783499626.123792 yylex_token: history-top
+1783499626.123797 cmd_parse_build_commands 0:0: bind
+1783499626.123800 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.123803 cmd_parse_build_commands 0:2: g
+1783499626.123806 cmd_parse_build_commands 0:3 0:0: send
+1783499626.123853 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.123857 cmd_parse_build_commands 0:3 0:2: history-top
+1783499626.123863 cmd_parse_build_commands 0:0: send
+1783499626.123867 cmd_parse_build_commands 0:1: -X
+1783499626.123870 cmd_parse_build_commands 0:2: history-top
+1783499626.123877 args_parse_flags: next -X
+1783499626.123880 args_parse_flags: -X
+1783499626.123883 args_parse_flags: next history-top
+1783499626.123886 args_parse: flags end at 2 of 3
+1783499626.123890 args_parse: 2 = history-top (type STRING)
+1783499626.123898 cmd_parse_build_commands: send-keys -X history-top
+1783499626.123901 args_parse_flags: next -Tcopy-mode-vi
+1783499626.123904 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.123907 args_parse_flags: next g
+1783499626.123909 args_parse: flags end at 2 of 4
+1783499626.123912 args_parse: 2 = g (type STRING)
+1783499626.123918 args_parse: 3 = send-keys -X history-top (type COMMANDS)
+1783499626.123928 cmd_parse_build_commands: bind-key -T copy-mode-vi g { send-keys -X history-top }
+1783499626.123934 cmdq_get_command: [bind-key/0x58e47252f660] group 2412
+1783499626.123937 cmdq_append <global>: [bind-key/0x58e47252f660]
+1783499626.123943 yylex_token: end at WS
+1783499626.123946 yylex_token: bind
+1783499626.123950 yylex_token: end at WS
+1783499626.123952 yylex_token: -Tcopy-mode-vi
+1783499626.123955 yylex_token: end at WS
+1783499626.123957 yylex_token: h
+1783499626.123960 yylex_token: end at WS
+1783499626.123962 yylex_token: send
+1783499626.123965 yylex_token: end at WS
+1783499626.123967 yylex_token: -X
+1783499626.123976 yylex_token: end at WS
+1783499626.123979 yylex_token: cursor-left
+1783499626.123983 cmd_parse_build_commands 0:0: bind
+1783499626.123986 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.123988 cmd_parse_build_commands 0:2: h
+1783499626.123991 cmd_parse_build_commands 0:3 0:0: send
+1783499626.123994 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.123996 cmd_parse_build_commands 0:3 0:2: cursor-left
+1783499626.124000 cmd_parse_build_commands 0:0: send
+1783499626.124002 cmd_parse_build_commands 0:1: -X
+1783499626.124004 cmd_parse_build_commands 0:2: cursor-left
+1783499626.124010 args_parse_flags: next -X
+1783499626.124013 args_parse_flags: -X
+1783499626.124015 args_parse_flags: next cursor-left
+1783499626.124018 args_parse: flags end at 2 of 3
+1783499626.124021 args_parse: 2 = cursor-left (type STRING)
+1783499626.124027 cmd_parse_build_commands: send-keys -X cursor-left
+1783499626.124030 args_parse_flags: next -Tcopy-mode-vi
+1783499626.124032 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.124035 args_parse_flags: next h
+1783499626.124037 args_parse: flags end at 2 of 4
+1783499626.124039 args_parse: 2 = h (type STRING)
+1783499626.124044 args_parse: 3 = send-keys -X cursor-left (type COMMANDS)
+1783499626.124053 cmd_parse_build_commands: bind-key -T copy-mode-vi h { send-keys -X cursor-left }
+1783499626.124057 cmdq_get_command: [bind-key/0x58e472530930] group 2420
+1783499626.124060 cmdq_append <global>: [bind-key/0x58e472530930]
+1783499626.124065 yylex_token: end at WS
+1783499626.124067 yylex_token: bind
+1783499626.124071 yylex_token: end at WS
+1783499626.124073 yylex_token: -Tcopy-mode-vi
+1783499626.124075 yylex_token: end at WS
+1783499626.124078 yylex_token: j
+1783499626.124080 yylex_token: end at WS
+1783499626.124082 yylex_token: send
+1783499626.124085 yylex_token: end at WS
+1783499626.124087 yylex_token: -X
+1783499626.124090 yylex_token: end at WS
+1783499626.124093 yylex_token: cursor-down
+1783499626.124097 cmd_parse_build_commands 0:0: bind
+1783499626.124100 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.124102 cmd_parse_build_commands 0:2: j
+1783499626.124105 cmd_parse_build_commands 0:3 0:0: send
+1783499626.124108 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.124110 cmd_parse_build_commands 0:3 0:2: cursor-down
+1783499626.124114 cmd_parse_build_commands 0:0: send
+1783499626.124117 cmd_parse_build_commands 0:1: -X
+1783499626.124119 cmd_parse_build_commands 0:2: cursor-down
+1783499626.124124 args_parse_flags: next -X
+1783499626.124126 args_parse_flags: -X
+1783499626.124128 args_parse_flags: next cursor-down
+1783499626.124131 args_parse: flags end at 2 of 3
+1783499626.124133 args_parse: 2 = cursor-down (type STRING)
+1783499626.124139 cmd_parse_build_commands: send-keys -X cursor-down
+1783499626.124142 args_parse_flags: next -Tcopy-mode-vi
+1783499626.124144 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.124147 args_parse_flags: next j
+1783499626.124149 args_parse: flags end at 2 of 4
+1783499626.124152 args_parse: 2 = j (type STRING)
+1783499626.124157 args_parse: 3 = send-keys -X cursor-down (type COMMANDS)
+1783499626.124165 cmd_parse_build_commands: bind-key -T copy-mode-vi j { send-keys -X cursor-down }
+1783499626.124169 cmdq_get_command: [bind-key/0x58e472530d00] group 2428
+1783499626.124172 cmdq_append <global>: [bind-key/0x58e472530d00]
+1783499626.124177 yylex_token: end at WS
+1783499626.124179 yylex_token: bind
+1783499626.124182 yylex_token: end at WS
+1783499626.124185 yylex_token: -Tcopy-mode-vi
+1783499626.124187 yylex_token: end at WS
+1783499626.124189 yylex_token: k
+1783499626.124192 yylex_token: end at WS
+1783499626.124194 yylex_token: send
+1783499626.124197 yylex_token: end at WS
+1783499626.124199 yylex_token: -X
+1783499626.124202 yylex_token: end at WS
+1783499626.124204 yylex_token: cursor-up
+1783499626.124208 cmd_parse_build_commands 0:0: bind
+1783499626.124211 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.124213 cmd_parse_build_commands 0:2: k
+1783499626.124216 cmd_parse_build_commands 0:3 0:0: send
+1783499626.124219 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.124226 cmd_parse_build_commands 0:3 0:2: cursor-up
+1783499626.124229 cmd_parse_build_commands 0:0: send
+1783499626.124232 cmd_parse_build_commands 0:1: -X
+1783499626.124235 cmd_parse_build_commands 0:2: cursor-up
+1783499626.124240 args_parse_flags: next -X
+1783499626.124242 args_parse_flags: -X
+1783499626.124245 args_parse_flags: next cursor-up
+1783499626.124248 args_parse: flags end at 2 of 3
+1783499626.124251 args_parse: 2 = cursor-up (type STRING)
+1783499626.124256 cmd_parse_build_commands: send-keys -X cursor-up
+1783499626.124259 args_parse_flags: next -Tcopy-mode-vi
+1783499626.124262 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.124264 args_parse_flags: next k
+1783499626.124266 args_parse: flags end at 2 of 4
+1783499626.124269 args_parse: 2 = k (type STRING)
+1783499626.124274 args_parse: 3 = send-keys -X cursor-up (type COMMANDS)
+1783499626.124281 cmd_parse_build_commands: bind-key -T copy-mode-vi k { send-keys -X cursor-up }
+1783499626.124286 cmdq_get_command: [bind-key/0x58e472531210] group 2436
+1783499626.124288 cmdq_append <global>: [bind-key/0x58e472531210]
+1783499626.124350 yylex_token: end at WS
+1783499626.124375 yylex_token: bind
+1783499626.124383 yylex_token: end at WS
+1783499626.124388 yylex_token: -Tcopy-mode-vi
+1783499626.124393 yylex_token: end at WS
+1783499626.124397 yylex_token: z
+1783499626.124402 yylex_token: end at WS
+1783499626.124406 yylex_token: send
+1783499626.124411 yylex_token: end at WS
+1783499626.124414 yylex_token: -X
+1783499626.124420 yylex_token: end at WS
+1783499626.124423 yylex_token: scroll-middle
+1783499626.124436 cmd_parse_build_commands 0:0: bind
+1783499626.124441 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.124445 cmd_parse_build_commands 0:2: z
+1783499626.124451 cmd_parse_build_commands 0:3 0:0: send
+1783499626.124455 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.124460 cmd_parse_build_commands 0:3 0:2: scroll-middle
+1783499626.124472 cmd_parse_build_commands 0:0: send
+1783499626.124477 cmd_parse_build_commands 0:1: -X
+1783499626.124481 cmd_parse_build_commands 0:2: scroll-middle
+1783499626.124496 args_parse_flags: next -X
+1783499626.124500 args_parse_flags: -X
+1783499626.124506 args_parse_flags: next scroll-middle
+1783499626.124511 args_parse: flags end at 2 of 3
+1783499626.124517 args_parse: 2 = scroll-middle (type STRING)
+1783499626.124534 cmd_parse_build_commands: send-keys -X scroll-middle
+1783499626.124540 args_parse_flags: next -Tcopy-mode-vi
+1783499626.124545 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.124550 args_parse_flags: next z
+1783499626.124555 args_parse: flags end at 2 of 4
+1783499626.124559 args_parse: 2 = z (type STRING)
+1783499626.124571 args_parse: 3 = send-keys -X scroll-middle (type COMMANDS)
+1783499626.124592 cmd_parse_build_commands: bind-key -T copy-mode-vi z { send-keys -X scroll-middle }
+1783499626.124602 cmdq_get_command: [bind-key/0x58e472531780] group 2444
+1783499626.124608 cmdq_append <global>: [bind-key/0x58e472531780]
+1783499626.124631 yylex_token: end at WS
+1783499626.124636 yylex_token: bind
+1783499626.124642 yylex_token: end at WS
+1783499626.124645 yylex_token: -Tcopy-mode-vi
+1783499626.124650 yylex_token: end at WS
+1783499626.124654 yylex_token: l
+1783499626.124659 yylex_token: end at WS
+1783499626.124662 yylex_token: send
+1783499626.124667 yylex_token: end at WS
+1783499626.124671 yylex_token: -X
+1783499626.124676 yylex_token: end at WS
+1783499626.124680 yylex_token: cursor-right
+1783499626.124688 cmd_parse_build_commands 0:0: bind
+1783499626.124693 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.124697 cmd_parse_build_commands 0:2: l
+1783499626.124702 cmd_parse_build_commands 0:3 0:0: send
+1783499626.124707 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.124711 cmd_parse_build_commands 0:3 0:2: cursor-right
+1783499626.124720 cmd_parse_build_commands 0:0: send
+1783499626.124724 cmd_parse_build_commands 0:1: -X
+1783499626.124729 cmd_parse_build_commands 0:2: cursor-right
+1783499626.124740 args_parse_flags: next -X
+1783499626.124745 args_parse_flags: -X
+1783499626.124749 args_parse_flags: next cursor-right
+1783499626.124769 args_parse: flags end at 2 of 3
+1783499626.124776 args_parse: 2 = cursor-right (type STRING)
+1783499626.124851 cmd_parse_build_commands: send-keys -X cursor-right
+1783499626.124861 args_parse_flags: next -Tcopy-mode-vi
+1783499626.124866 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.124871 args_parse_flags: next l
+1783499626.124876 args_parse: flags end at 2 of 4
+1783499626.124881 args_parse: 2 = l (type STRING)
+1783499626.124893 args_parse: 3 = send-keys -X cursor-right (type COMMANDS)
+1783499626.124914 cmd_parse_build_commands: bind-key -T copy-mode-vi l { send-keys -X cursor-right }
+1783499626.124924 cmdq_get_command: [bind-key/0x58e472531cf0] group 2452
+1783499626.124930 cmdq_append <global>: [bind-key/0x58e472531cf0]
+1783499626.124941 yylex_token: end at WS
+1783499626.124946 yylex_token: bind
+1783499626.124952 yylex_token: end at WS
+1783499626.124957 yylex_token: -Tcopy-mode-vi
+1783499626.124961 yylex_token: end at WS
+1783499626.124965 yylex_token: n
+1783499626.124970 yylex_token: end at WS
+1783499626.124974 yylex_token: send
+1783499626.124978 yylex_token: end at WS
+1783499626.124982 yylex_token: -X
+1783499626.124987 yylex_token: end at WS
+1783499626.124991 yylex_token: search-again
+1783499626.125000 cmd_parse_build_commands 0:0: bind
+1783499626.125005 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.125009 cmd_parse_build_commands 0:2: n
+1783499626.125014 cmd_parse_build_commands 0:3 0:0: send
+1783499626.125019 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.125024 cmd_parse_build_commands 0:3 0:2: search-again
+1783499626.125033 cmd_parse_build_commands 0:0: send
+1783499626.125038 cmd_parse_build_commands 0:1: -X
+1783499626.125042 cmd_parse_build_commands 0:2: search-again
+1783499626.125053 args_parse_flags: next -X
+1783499626.125057 args_parse_flags: -X
+1783499626.125062 args_parse_flags: next search-again
+1783499626.125067 args_parse: flags end at 2 of 3
+1783499626.125071 args_parse: 2 = search-again (type STRING)
+1783499626.125082 cmd_parse_build_commands: send-keys -X search-again
+1783499626.125087 args_parse_flags: next -Tcopy-mode-vi
+1783499626.125092 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.125096 args_parse_flags: next n
+1783499626.125100 args_parse: flags end at 2 of 4
+1783499626.125104 args_parse: 2 = n (type STRING)
+1783499626.125113 args_parse: 3 = send-keys -X search-again (type COMMANDS)
+1783499626.125129 cmd_parse_build_commands: bind-key -T copy-mode-vi n { send-keys -X search-again }
+1783499626.125137 cmdq_get_command: [bind-key/0x58e472532400] group 2460
+1783499626.125142 cmdq_append <global>: [bind-key/0x58e472532400]
+1783499626.125160 yylex_token: end at WS
+1783499626.125165 yylex_token: bind
+1783499626.125170 yylex_token: end at WS
+1783499626.125174 yylex_token: -Tcopy-mode-vi
+1783499626.125179 yylex_token: end at WS
+1783499626.125183 yylex_token: o
+1783499626.125219 yylex_token: end at WS
+1783499626.125223 yylex_token: send
+1783499626.125228 yylex_token: end at WS
+1783499626.125245 yylex_token: -X
+1783499626.125252 yylex_token: end at WS
+1783499626.125256 yylex_token: other-end
+1783499626.125264 cmd_parse_build_commands 0:0: bind
+1783499626.125269 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.125273 cmd_parse_build_commands 0:2: o
+1783499626.125278 cmd_parse_build_commands 0:3 0:0: send
+1783499626.125282 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.125287 cmd_parse_build_commands 0:3 0:2: other-end
+1783499626.125295 cmd_parse_build_commands 0:0: send
+1783499626.125301 cmd_parse_build_commands 0:1: -X
+1783499626.125305 cmd_parse_build_commands 0:2: other-end
+1783499626.125317 args_parse_flags: next -X
+1783499626.125321 args_parse_flags: -X
+1783499626.125326 args_parse_flags: next other-end
+1783499626.125330 args_parse: flags end at 2 of 3
+1783499626.125334 args_parse: 2 = other-end (type STRING)
+1783499626.125345 cmd_parse_build_commands: send-keys -X other-end
+1783499626.125350 args_parse_flags: next -Tcopy-mode-vi
+1783499626.125355 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.125360 args_parse_flags: next o
+1783499626.125385 args_parse: flags end at 2 of 4
+1783499626.125391 args_parse: 2 = o (type STRING)
+1783499626.125400 args_parse: 3 = send-keys -X other-end (type COMMANDS)
+1783499626.125420 cmd_parse_build_commands: bind-key -T copy-mode-vi o { send-keys -X other-end }
+1783499626.125430 cmdq_get_command: [bind-key/0x58e472532ae0] group 2468
+1783499626.125435 cmdq_append <global>: [bind-key/0x58e472532ae0]
+1783499626.125446 yylex_token: end at WS
+1783499626.125450 yylex_token: bind
+1783499626.125456 yylex_token: end at WS
+1783499626.125461 yylex_token: -Tcopy-mode-vi
+1783499626.125466 yylex_token: end at WS
+1783499626.125471 yylex_token: q
+1783499626.125475 yylex_token: end at WS
+1783499626.125479 yylex_token: send
+1783499626.125483 yylex_token: end at WS
+1783499626.125487 yylex_token: -X
+1783499626.125492 yylex_token: end at WS
+1783499626.125496 yylex_token: cancel
+1783499626.125504 cmd_parse_build_commands 0:0: bind
+1783499626.125508 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.125513 cmd_parse_build_commands 0:2: q
+1783499626.125518 cmd_parse_build_commands 0:3 0:0: send
+1783499626.125523 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.125528 cmd_parse_build_commands 0:3 0:2: cancel
+1783499626.125535 cmd_parse_build_commands 0:0: send
+1783499626.125540 cmd_parse_build_commands 0:1: -X
+1783499626.125544 cmd_parse_build_commands 0:2: cancel
+1783499626.125555 args_parse_flags: next -X
+1783499626.125559 args_parse_flags: -X
+1783499626.125564 args_parse_flags: next cancel
+1783499626.125569 args_parse: flags end at 2 of 3
+1783499626.125574 args_parse: 2 = cancel (type STRING)
+1783499626.125586 cmd_parse_build_commands: send-keys -X cancel
+1783499626.125592 args_parse_flags: next -Tcopy-mode-vi
+1783499626.125597 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.125602 args_parse_flags: next q
+1783499626.125607 args_parse: flags end at 2 of 4
+1783499626.125611 args_parse: 2 = q (type STRING)
+1783499626.125621 args_parse: 3 = send-keys -X cancel (type COMMANDS)
+1783499626.125638 cmd_parse_build_commands: bind-key -T copy-mode-vi q { send-keys -X cancel }
+1783499626.125646 cmdq_get_command: [bind-key/0x58e472532f20] group 2476
+1783499626.125651 cmdq_append <global>: [bind-key/0x58e472532f20]
+1783499626.125661 yylex_token: end at WS
+1783499626.125665 yylex_token: bind
+1783499626.125671 yylex_token: end at WS
+1783499626.125675 yylex_token: -Tcopy-mode-vi
+1783499626.125680 yylex_token: end at WS
+1783499626.125684 yylex_token: r
+1783499626.125689 yylex_token: end at WS
+1783499626.125693 yylex_token: send
+1783499626.125698 yylex_token: end at WS
+1783499626.125702 yylex_token: -X
+1783499626.125709 yylex_token: end at WS
+1783499626.125715 yylex_token: refresh-from-pane
+1783499626.125723 cmd_parse_build_commands 0:0: bind
+1783499626.125730 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.125735 cmd_parse_build_commands 0:2: r
+1783499626.125739 cmd_parse_build_commands 0:3 0:0: send
+1783499626.125745 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.125750 cmd_parse_build_commands 0:3 0:2: refresh-from-pane
+1783499626.125757 cmd_parse_build_commands 0:0: send
+1783499626.125762 cmd_parse_build_commands 0:1: -X
+1783499626.125766 cmd_parse_build_commands 0:2: refresh-from-pane
+1783499626.125775 args_parse_flags: next -X
+1783499626.125780 args_parse_flags: -X
+1783499626.125784 args_parse_flags: next refresh-from-pane
+1783499626.125789 args_parse: flags end at 2 of 3
+1783499626.125794 args_parse: 2 = refresh-from-pane (type STRING)
+1783499626.125805 cmd_parse_build_commands: send-keys -X refresh-from-pane
+1783499626.125810 args_parse_flags: next -Tcopy-mode-vi
+1783499626.125815 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.125819 args_parse_flags: next r
+1783499626.125824 args_parse: flags end at 2 of 4
+1783499626.125828 args_parse: 2 = r (type STRING)
+1783499626.125838 args_parse: 3 = send-keys -X refresh-from-pane (type COMMANDS)
+1783499626.125854 cmd_parse_build_commands: bind-key -T copy-mode-vi r { send-keys -X refresh-from-pane }
+1783499626.125861 cmdq_get_command: [bind-key/0x58e4725332a0] group 2484
+1783499626.126087 cmdq_append <global>: [bind-key/0x58e4725332a0]
+1783499626.126120 yylex_token: end at WS
+1783499626.126127 yylex_token: bind
+1783499626.126135 yylex_token: end at WS
+1783499626.126141 yylex_token: -Tcopy-mode-vi
+1783499626.126147 yylex_token: end at WS
+1783499626.126151 yylex_token: t
+1783499626.126159 yylex_token: end at WS
+1783499626.126163 yylex_token: command-prompt
+1783499626.126172 yylex_token: end at WS
+1783499626.126177 yylex_token: -1p(jump to forward)
+1783499626.126184 yylex_token: end at WS
+1783499626.126188 yylex_token: send
+1783499626.126193 yylex_token: end at WS
+1783499626.126197 yylex_token: -X
+1783499626.126204 yylex_token: end at WS
+1783499626.126209 yylex_token: jump-to-forward
+1783499626.126215 yylex_token: end at WS
+1783499626.126219 yylex_token: %%
+1783499626.126232 cmd_parse_build_commands 0:0: bind
+1783499626.126238 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.126243 cmd_parse_build_commands 0:2: t
+1783499626.126251 cmd_parse_build_commands 0:3 0:0: command-prompt
+1783499626.126258 cmd_parse_build_commands 0:3 0:1: -1p(jump to forward)
+1783499626.126265 cmd_parse_build_commands 0:3 0:2 0:0: send
+1783499626.126271 cmd_parse_build_commands 0:3 0:2 0:1: -X
+1783499626.126277 cmd_parse_build_commands 0:3 0:2 0:2: jump-to-forward
+1783499626.126282 cmd_parse_build_commands 0:3 0:2 0:3: %%
+1783499626.126295 cmd_parse_build_commands 0:0: command-prompt
+1783499626.126300 cmd_parse_build_commands 0:1: -1p(jump to forward)
+1783499626.126306 cmd_parse_build_commands 0:2 0:0: send
+1783499626.126311 cmd_parse_build_commands 0:2 0:1: -X
+1783499626.126317 cmd_parse_build_commands 0:2 0:2: jump-to-forward
+1783499626.126322 cmd_parse_build_commands 0:2 0:3: %%
+1783499626.126330 cmd_parse_build_commands 0:0: send
+1783499626.126336 cmd_parse_build_commands 0:1: -X
+1783499626.126341 cmd_parse_build_commands 0:2: jump-to-forward
+1783499626.126347 cmd_parse_build_commands 0:3: %%
+1783499626.126361 args_parse_flags: next -X
+1783499626.126366 args_parse_flags: -X
+1783499626.126371 args_parse_flags: next jump-to-forward
+1783499626.126376 args_parse: flags end at 2 of 4
+1783499626.126384 args_parse: 2 = jump-to-forward (type STRING)
+1783499626.126390 args_parse: 3 = %% (type STRING)
+1783499626.126411 cmd_parse_build_commands: send-keys -X jump-to-forward "%%"
+1783499626.126419 args_parse_flags: next -1p(jump to forward)
+1783499626.126423 args_parse_flags: -1
+1783499626.126430 args_parse_flag_argument: -p = (jump to forward)
+1783499626.126435 args_parse: flags end at 2 of 3
+1783499626.126446 args_parse: 2 = send-keys -X jump-to-forward "%%" (type COMMANDS)
+1783499626.126471 cmd_parse_build_commands: command-prompt -1 -p "(jump to forward)" { send-keys -X jump-to-forward "%%" }
+1783499626.126478 args_parse_flags: next -Tcopy-mode-vi
+1783499626.126484 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.126489 args_parse_flags: next t
+1783499626.126494 args_parse: flags end at 2 of 4
+1783499626.126499 args_parse: 2 = t (type STRING)
+1783499626.126519 args_parse: 3 = command-prompt -1 -p "(jump to forward)" { send-keys -X jump-to-forward "%%" } (type COMMANDS)
+1783499626.126550 cmd_parse_build_commands: bind-key -T copy-mode-vi t { command-prompt -1 -p "(jump to forward)" { send-keys -X jump-to-forward "%%" } }
+1783499626.126563 cmdq_get_command: [bind-key/0x58e472534670] group 2492
+1783499626.126569 cmdq_append <global>: [bind-key/0x58e472534670]
+1783499626.126592 yylex_token: end at WS
+1783499626.126598 yylex_token: bind
+1783499626.126605 yylex_token: end at WS
+1783499626.126609 yylex_token: -Tcopy-mode-vi
+1783499626.126614 yylex_token: end at WS
+1783499626.126618 yylex_token: v
+1783499626.126623 yylex_token: end at WS
+1783499626.126628 yylex_token: send
+1783499626.126633 yylex_token: end at WS
+1783499626.126638 yylex_token: -X
+1783499626.126644 yylex_token: end at WS
+1783499626.126649 yylex_token: rectangle-toggle
+1783499626.126659 cmd_parse_build_commands 0:0: bind
+1783499626.126664 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.126670 cmd_parse_build_commands 0:2: v
+1783499626.126676 cmd_parse_build_commands 0:3 0:0: send
+1783499626.126694 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.126700 cmd_parse_build_commands 0:3 0:2: rectangle-toggle
+1783499626.126709 cmd_parse_build_commands 0:0: send
+1783499626.126713 cmd_parse_build_commands 0:1: -X
+1783499626.126718 cmd_parse_build_commands 0:2: rectangle-toggle
+1783499626.126728 args_parse_flags: next -X
+1783499626.126732 args_parse_flags: -X
+1783499626.126737 args_parse_flags: next rectangle-toggle
+1783499626.126741 args_parse: flags end at 2 of 3
+1783499626.126747 args_parse: 2 = rectangle-toggle (type STRING)
+1783499626.126758 cmd_parse_build_commands: send-keys -X rectangle-toggle
+1783499626.126764 args_parse_flags: next -Tcopy-mode-vi
+1783499626.126769 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.126774 args_parse_flags: next v
+1783499626.126778 args_parse: flags end at 2 of 4
+1783499626.126783 args_parse: 2 = v (type STRING)
+1783499626.126793 args_parse: 3 = send-keys -X rectangle-toggle (type COMMANDS)
+1783499626.126810 cmd_parse_build_commands: bind-key -T copy-mode-vi v { send-keys -X rectangle-toggle }
+1783499626.126819 cmdq_get_command: [bind-key/0x58e472533640] group 2504
+1783499626.126825 cmdq_append <global>: [bind-key/0x58e472533640]
+1783499626.126835 yylex_token: end at WS
+1783499626.126839 yylex_token: bind
+1783499626.126845 yylex_token: end at WS
+1783499626.126849 yylex_token: -Tcopy-mode-vi
+1783499626.126854 yylex_token: end at WS
+1783499626.126858 yylex_token: w
+1783499626.126863 yylex_token: end at WS
+1783499626.126867 yylex_token: send
+1783499626.126871 yylex_token: end at WS
+1783499626.126874 yylex_token: -X
+1783499626.126879 yylex_token: end at WS
+1783499626.126883 yylex_token: next-word
+1783499626.126891 cmd_parse_build_commands 0:0: bind
+1783499626.126895 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.126900 cmd_parse_build_commands 0:2: w
+1783499626.126906 cmd_parse_build_commands 0:3 0:0: send
+1783499626.126911 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.126916 cmd_parse_build_commands 0:3 0:2: next-word
+1783499626.126923 cmd_parse_build_commands 0:0: send
+1783499626.126928 cmd_parse_build_commands 0:1: -X
+1783499626.126933 cmd_parse_build_commands 0:2: next-word
+1783499626.126942 args_parse_flags: next -X
+1783499626.126945 args_parse_flags: -X
+1783499626.126950 args_parse_flags: next next-word
+1783499626.126955 args_parse: flags end at 2 of 3
+1783499626.126960 args_parse: 2 = next-word (type STRING)
+1783499626.126970 cmd_parse_build_commands: send-keys -X next-word
+1783499626.126975 args_parse_flags: next -Tcopy-mode-vi
+1783499626.126980 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.126984 args_parse_flags: next w
+1783499626.126989 args_parse: flags end at 2 of 4
+1783499626.126994 args_parse: 2 = w (type STRING)
+1783499626.127002 args_parse: 3 = send-keys -X next-word (type COMMANDS)
+1783499626.127018 cmd_parse_build_commands: bind-key -T copy-mode-vi w { send-keys -X next-word }
+1783499626.127026 cmdq_get_command: [bind-key/0x58e4725349e0] group 2512
+1783499626.127031 cmdq_append <global>: [bind-key/0x58e4725349e0]
+1783499626.127040 yylex_token: end at WS
+1783499626.127044 yylex_token: bind
+1783499626.127050 yylex_token: end at WS
+1783499626.127053 yylex_token: -Tcopy-mode-vi
+1783499626.127058 yylex_token: end at WS
+1783499626.127062 yylex_token: {
+1783499626.127066 yylex_token: end at WS
+1783499626.127071 yylex_token: send
+1783499626.127075 yylex_token: end at WS
+1783499626.127078 yylex_token: -X
+1783499626.127084 yylex_token: end at WS
+1783499626.127089 yylex_token: previous-paragraph
+1783499626.127096 cmd_parse_build_commands 0:0: bind
+1783499626.127100 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.127105 cmd_parse_build_commands 0:2: {
+1783499626.127110 cmd_parse_build_commands 0:3 0:0: send
+1783499626.127115 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.127120 cmd_parse_build_commands 0:3 0:2: previous-paragraph
+1783499626.127126 cmd_parse_build_commands 0:0: send
+1783499626.127132 cmd_parse_build_commands 0:1: -X
+1783499626.127136 cmd_parse_build_commands 0:2: previous-paragraph
+1783499626.127156 args_parse_flags: next -X
+1783499626.127160 args_parse_flags: -X
+1783499626.127165 args_parse_flags: next previous-paragraph
+1783499626.127169 args_parse: flags end at 2 of 3
+1783499626.127175 args_parse: 2 = previous-paragraph (type STRING)
+1783499626.127185 cmd_parse_build_commands: send-keys -X previous-paragraph
+1783499626.127190 args_parse_flags: next -Tcopy-mode-vi
+1783499626.127195 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.127199 args_parse_flags: next {
+1783499626.127204 args_parse: flags end at 2 of 4
+1783499626.127208 args_parse: 2 = { (type STRING)
+1783499626.127216 args_parse: 3 = send-keys -X previous-paragraph (type COMMANDS)
+1783499626.127233 cmd_parse_build_commands: bind-key -T copy-mode-vi \\{ { send-keys -X previous-paragraph }
+1783499626.127240 cmdq_get_command: [bind-key/0x58e472534e30] group 2520
+1783499626.127245 cmdq_append <global>: [bind-key/0x58e472534e30]
+1783499626.127255 yylex_token: end at WS
+1783499626.127259 yylex_token: bind
+1783499626.127264 yylex_token: end at WS
+1783499626.127268 yylex_token: -Tcopy-mode-vi
+1783499626.127273 yylex_token: end at WS
+1783499626.127277 yylex_token: }
+1783499626.127282 yylex_token: end at WS
+1783499626.127286 yylex_token: send
+1783499626.127291 yylex_token: end at WS
+1783499626.127294 yylex_token: -X
+1783499626.127300 yylex_token: end at WS
+1783499626.127304 yylex_token: next-paragraph
+1783499626.127312 cmd_parse_build_commands 0:0: bind
+1783499626.127316 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.127320 cmd_parse_build_commands 0:2: }
+1783499626.127325 cmd_parse_build_commands 0:3 0:0: send
+1783499626.127330 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.127335 cmd_parse_build_commands 0:3 0:2: next-paragraph
+1783499626.127343 cmd_parse_build_commands 0:0: send
+1783499626.127347 cmd_parse_build_commands 0:1: -X
+1783499626.127352 cmd_parse_build_commands 0:2: next-paragraph
+1783499626.127360 args_parse_flags: next -X
+1783499626.127365 args_parse_flags: -X
+1783499626.127370 args_parse_flags: next next-paragraph
+1783499626.127374 args_parse: flags end at 2 of 3
+1783499626.127381 args_parse: 2 = next-paragraph (type STRING)
+1783499626.127391 cmd_parse_build_commands: send-keys -X next-paragraph
+1783499626.127396 args_parse_flags: next -Tcopy-mode-vi
+1783499626.127401 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.127405 args_parse_flags: next }
+1783499626.127410 args_parse: flags end at 2 of 4
+1783499626.127414 args_parse: 2 = } (type STRING)
+1783499626.127423 args_parse: 3 = send-keys -X next-paragraph (type COMMANDS)
+1783499626.127438 cmd_parse_build_commands: bind-key -T copy-mode-vi \\} { send-keys -X next-paragraph }
+1783499626.127446 cmdq_get_command: [bind-key/0x58e472535410] group 2528
+1783499626.127451 cmdq_append <global>: [bind-key/0x58e472535410]
+1783499626.127467 yylex_token: end at WS
+1783499626.127472 yylex_token: bind
+1783499626.127478 yylex_token: end at WS
+1783499626.127482 yylex_token: -Tcopy-mode-vi
+1783499626.127488 yylex_get_word: %
+1783499626.127492 yylex_token: end at WS
+1783499626.127496 yylex_token: send
+1783499626.127501 yylex_token: end at WS
+1783499626.127505 yylex_token: -X
+1783499626.127511 yylex_token: end at WS
+1783499626.127515 yylex_token: next-matching-bracket
+1783499626.127522 cmd_parse_build_commands 0:0: bind
+1783499626.127528 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.127532 cmd_parse_build_commands 0:2: %
+1783499626.127537 cmd_parse_build_commands 0:3 0:0: send
+1783499626.127542 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.127547 cmd_parse_build_commands 0:3 0:2: next-matching-bracket
+1783499626.127555 cmd_parse_build_commands 0:0: send
+1783499626.127560 cmd_parse_build_commands 0:1: -X
+1783499626.127565 cmd_parse_build_commands 0:2: next-matching-bracket
+1783499626.127575 args_parse_flags: next -X
+1783499626.127579 args_parse_flags: -X
+1783499626.127584 args_parse_flags: next next-matching-bracket
+1783499626.127588 args_parse: flags end at 2 of 3
+1783499626.127593 args_parse: 2 = next-matching-bracket (type STRING)
+1783499626.127604 cmd_parse_build_commands: send-keys -X next-matching-bracket
+1783499626.127618 args_parse_flags: next -Tcopy-mode-vi
+1783499626.127624 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.127629 args_parse_flags: next %
+1783499626.127633 args_parse: flags end at 2 of 4
+1783499626.127638 args_parse: 2 = % (type STRING)
+1783499626.127649 args_parse: 3 = send-keys -X next-matching-bracket (type COMMANDS)
+1783499626.127669 cmd_parse_build_commands: bind-key -T copy-mode-vi \\% { send-keys -X next-matching-bracket }
+1783499626.127677 cmdq_get_command: [bind-key/0x58e472535b20] group 2536
+1783499626.127683 cmdq_append <global>: [bind-key/0x58e472535b20]
+1783499626.127693 yylex_token: end at WS
+1783499626.127697 yylex_token: bind
+1783499626.127703 yylex_token: end at WS
+1783499626.127707 yylex_token: -Tcopy-mode-vi
+1783499626.127712 yylex_token: end at WS
+1783499626.127717 yylex_token: Home
+1783499626.127722 yylex_token: end at WS
+1783499626.127726 yylex_token: send
+1783499626.127730 yylex_token: end at WS
+1783499626.127734 yylex_token: -X
+1783499626.127741 yylex_token: end at WS
+1783499626.127745 yylex_token: start-of-line
+1783499626.127754 cmd_parse_build_commands 0:0: bind
+1783499626.127760 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.127765 cmd_parse_build_commands 0:2: Home
+1783499626.127771 cmd_parse_build_commands 0:3 0:0: send
+1783499626.127776 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.127782 cmd_parse_build_commands 0:3 0:2: start-of-line
+1783499626.127789 cmd_parse_build_commands 0:0: send
+1783499626.127794 cmd_parse_build_commands 0:1: -X
+1783499626.127799 cmd_parse_build_commands 0:2: start-of-line
+1783499626.127811 args_parse_flags: next -X
+1783499626.127815 args_parse_flags: -X
+1783499626.127819 args_parse_flags: next start-of-line
+1783499626.127824 args_parse: flags end at 2 of 3
+1783499626.127830 args_parse: 2 = start-of-line (type STRING)
+1783499626.127840 cmd_parse_build_commands: send-keys -X start-of-line
+1783499626.127846 args_parse_flags: next -Tcopy-mode-vi
+1783499626.127851 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.127855 args_parse_flags: next Home
+1783499626.127860 args_parse: flags end at 2 of 4
+1783499626.127864 args_parse: 2 = Home (type STRING)
+1783499626.127874 args_parse: 3 = send-keys -X start-of-line (type COMMANDS)
+1783499626.127892 cmd_parse_build_commands: bind-key -T copy-mode-vi Home { send-keys -X start-of-line }
+1783499626.127900 cmdq_get_command: [bind-key/0x58e4725361a0] group 2544
+1783499626.127905 cmdq_append <global>: [bind-key/0x58e4725361a0]
+1783499626.127914 yylex_token: end at WS
+1783499626.127918 yylex_token: bind
+1783499626.127925 yylex_token: end at WS
+1783499626.127929 yylex_token: -Tcopy-mode-vi
+1783499626.127934 yylex_token: end at WS
+1783499626.127937 yylex_token: End
+1783499626.127942 yylex_token: end at WS
+1783499626.127946 yylex_token: send
+1783499626.127950 yylex_token: end at WS
+1783499626.127954 yylex_token: -X
+1783499626.127960 yylex_token: end at WS
+1783499626.127965 yylex_token: end-of-line
+1783499626.127982 cmd_parse_build_commands 0:0: bind
+1783499626.128000 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.128005 cmd_parse_build_commands 0:2: End
+1783499626.128011 cmd_parse_build_commands 0:3 0:0: send
+1783499626.128016 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.128021 cmd_parse_build_commands 0:3 0:2: end-of-line
+1783499626.128030 cmd_parse_build_commands 0:0: send
+1783499626.128035 cmd_parse_build_commands 0:1: -X
+1783499626.128040 cmd_parse_build_commands 0:2: end-of-line
+1783499626.128052 args_parse_flags: next -X
+1783499626.128056 args_parse_flags: -X
+1783499626.128136 args_parse_flags: next end-of-line
+1783499626.128151 args_parse: flags end at 2 of 3
+1783499626.128154 args_parse: 2 = end-of-line (type STRING)
+1783499626.128163 cmd_parse_build_commands: send-keys -X end-of-line
+1783499626.128166 args_parse_flags: next -Tcopy-mode-vi
+1783499626.128168 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.128169 args_parse_flags: next End
+1783499626.128171 args_parse: flags end at 2 of 4
+1783499626.128172 args_parse: 2 = End (type STRING)
+1783499626.128268 args_parse: 3 = send-keys -X end-of-line (type COMMANDS)
+1783499626.128280 cmd_parse_build_commands: bind-key -T copy-mode-vi End { send-keys -X end-of-line }
+1783499626.128288 cmdq_get_command: [bind-key/0x58e4725368a0] group 2552
+1783499626.128291 cmdq_append <global>: [bind-key/0x58e4725368a0]
+1783499626.128309 yylex_token: end at WS
+1783499626.128313 yylex_token: bind
+1783499626.128315 yylex_token: end at WS
+1783499626.128316 yylex_token: -Tcopy-mode-vi
+1783499626.128319 yylex_token: end at WS
+1783499626.128320 yylex_token: MouseDown1Pane
+1783499626.128322 yylex_token: end at WS
+1783499626.128323 yylex_token: select-pane
+1783499626.128339 cmd_parse_build_commands 0:0: bind
+1783499626.128341 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.128343 cmd_parse_build_commands 0:2: MouseDown1Pane
+1783499626.128345 cmd_parse_build_commands 0:3 0:0: select-pane
+1783499626.128348 cmd_parse_build_commands 0:0: select-pane
+1783499626.128353 args_parse: flags end at 1 of 1
+1783499626.128355 cmd_parse_build_commands: select-pane
+1783499626.128357 args_parse_flags: next -Tcopy-mode-vi
+1783499626.128358 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.128360 args_parse_flags: next MouseDown1Pane
+1783499626.128361 args_parse: flags end at 2 of 4
+1783499626.128363 args_parse: 2 = MouseDown1Pane (type STRING)
+1783499626.128365 args_parse: 3 = select-pane (type COMMANDS)
+1783499626.128370 cmd_parse_build_commands: bind-key -T copy-mode-vi MouseDown1Pane { select-pane }
+1783499626.128373 cmdq_get_command: [bind-key/0x58e472535a20] group 2560
+1783499626.128375 cmdq_append <global>: [bind-key/0x58e472535a20]
+1783499626.128377 yylex_token: end at WS
+1783499626.128379 yylex_token: bind
+1783499626.128380 yylex_token: end at WS
+1783499626.128381 yylex_token: -Tcopy-mode-vi
+1783499626.128383 yylex_token: end at WS
+1783499626.128384 yylex_token: MouseDrag1Pane
+1783499626.128386 yylex_token: end at ;
+1783499626.128387 yylex_token: select-pane
+1783499626.128388 yylex_token: end at WS
+1783499626.128389 yylex_token: send
+1783499626.128391 yylex_token: end at WS
+1783499626.128392 yylex_token: -X
+1783499626.128394 yylex_token: end at WS
+1783499626.128395 yylex_token: begin-selection
+1783499626.128398 cmd_parse_build_commands 0:0: bind
+1783499626.128400 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.128401 cmd_parse_build_commands 0:2: MouseDrag1Pane
+1783499626.128403 cmd_parse_build_commands 0:3 0:0: select-pane
+1783499626.128404 cmd_parse_build_commands 0:3 1:0: send
+1783499626.128406 cmd_parse_build_commands 0:3 1:1: -X
+1783499626.128407 cmd_parse_build_commands 0:3 1:2: begin-selection
+1783499626.128409 cmd_parse_build_commands 0:0: select-pane
+1783499626.128411 cmd_parse_build_commands 1:0: send
+1783499626.128412 cmd_parse_build_commands 1:1: -X
+1783499626.128413 cmd_parse_build_commands 1:2: begin-selection
+1783499626.128416 args_parse: flags end at 1 of 1
+1783499626.128420 args_parse_flags: next -X
+1783499626.128421 args_parse_flags: -X
+1783499626.128426 args_parse_flags: next begin-selection
+1783499626.128430 args_parse: flags end at 2 of 3
+1783499626.128432 args_parse: 2 = begin-selection (type STRING)
+1783499626.128437 cmd_parse_build_commands: select-pane ; send-keys -X begin-selection
+1783499626.128439 args_parse_flags: next -Tcopy-mode-vi
+1783499626.128440 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.128442 args_parse_flags: next MouseDrag1Pane
+1783499626.128443 args_parse: flags end at 2 of 4
+1783499626.128444 args_parse: 2 = MouseDrag1Pane (type STRING)
+1783499626.128447 args_parse: 3 = select-pane ; send-keys -X begin-selection (type COMMANDS)
+1783499626.128453 cmd_parse_build_commands: bind-key -T copy-mode-vi MouseDrag1Pane { select-pane ; send-keys -X begin-selection }
+1783499626.128456 cmdq_get_command: [bind-key/0x58e472535510] group 2568
+1783499626.128458 cmdq_append <global>: [bind-key/0x58e472535510]
+1783499626.128461 yylex_token: end at WS
+1783499626.128462 yylex_token: bind
+1783499626.128463 yylex_token: end at WS
+1783499626.128464 yylex_token: -Tcopy-mode-vi
+1783499626.128471 yylex_token: end at WS
+1783499626.128473 yylex_token: MouseDragEnd1Pane
+1783499626.128474 yylex_token: end at WS
+1783499626.128476 yylex_token: send
+1783499626.128477 yylex_token: end at WS
+1783499626.128478 yylex_token: -X
+1783499626.128479 yylex_token: end at WS
+1783499626.128481 yylex_token: copy-pipe-and-cancel
+1783499626.128484 cmd_parse_build_commands 0:0: bind
+1783499626.128485 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.128487 cmd_parse_build_commands 0:2: MouseDragEnd1Pane
+1783499626.128488 cmd_parse_build_commands 0:3 0:0: send
+1783499626.128489 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.128491 cmd_parse_build_commands 0:3 0:2: copy-pipe-and-cancel
+1783499626.128493 cmd_parse_build_commands 0:0: send
+1783499626.128494 cmd_parse_build_commands 0:1: -X
+1783499626.128496 cmd_parse_build_commands 0:2: copy-pipe-and-cancel
+1783499626.128499 args_parse_flags: next -X
+1783499626.128500 args_parse_flags: -X
+1783499626.128502 args_parse_flags: next copy-pipe-and-cancel
+1783499626.128503 args_parse: flags end at 2 of 3
+1783499626.128505 args_parse: 2 = copy-pipe-and-cancel (type STRING)
+1783499626.128508 cmd_parse_build_commands: send-keys -X copy-pipe-and-cancel
+1783499626.128513 args_parse_flags: next -Tcopy-mode-vi
+1783499626.128518 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.128519 args_parse_flags: next MouseDragEnd1Pane
+1783499626.128520 args_parse: flags end at 2 of 4
+1783499626.128522 args_parse: 2 = MouseDragEnd1Pane (type STRING)
+1783499626.128526 args_parse: 3 = send-keys -X copy-pipe-and-cancel (type COMMANDS)
+1783499626.128532 cmd_parse_build_commands: bind-key -T copy-mode-vi MouseDragEnd1Pane { send-keys -X copy-pipe-and-cancel }
+1783499626.128535 cmdq_get_command: [bind-key/0x58e472536ba0] group 2577
+1783499626.128537 cmdq_append <global>: [bind-key/0x58e472536ba0]
+1783499626.128539 yylex_token: end at WS
+1783499626.128540 yylex_token: bind
+1783499626.128542 yylex_token: end at WS
+1783499626.128543 yylex_token: -Tcopy-mode-vi
+1783499626.128545 yylex_token: end at WS
+1783499626.128546 yylex_token: WheelUpPane
+1783499626.128547 yylex_token: end at ;
+1783499626.128549 yylex_token: select-pane
+1783499626.128550 yylex_token: end at WS
+1783499626.128551 yylex_token: send
+1783499626.128552 yylex_token: end at WS
+1783499626.128553 yylex_token: -N5
+1783499626.128555 yylex_token: end at WS
+1783499626.128556 yylex_token: -X
+1783499626.128557 yylex_token: end at WS
+1783499626.128559 yylex_token: scroll-up
+1783499626.128561 cmd_parse_build_commands 0:0: bind
+1783499626.128563 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.128564 cmd_parse_build_commands 0:2: WheelUpPane
+1783499626.128566 cmd_parse_build_commands 0:3 0:0: select-pane
+1783499626.128567 cmd_parse_build_commands 0:3 1:0: send
+1783499626.128568 cmd_parse_build_commands 0:3 1:1: -N5
+1783499626.128570 cmd_parse_build_commands 0:3 1:2: -X
+1783499626.128571 cmd_parse_build_commands 0:3 1:3: scroll-up
+1783499626.128573 cmd_parse_build_commands 0:0: select-pane
+1783499626.128574 cmd_parse_build_commands 1:0: send
+1783499626.128575 cmd_parse_build_commands 1:1: -N5
+1783499626.128577 cmd_parse_build_commands 1:2: -X
+1783499626.128578 cmd_parse_build_commands 1:3: scroll-up
+1783499626.128581 args_parse: flags end at 1 of 1
+1783499626.128584 args_parse_flags: next -N5
+1783499626.128586 args_parse_flag_argument: -N = 5
+1783499626.128587 args_parse_flags: next -X
+1783499626.128588 args_parse_flags: -X
+1783499626.128590 args_parse_flags: next scroll-up
+1783499626.128591 args_parse: flags end at 3 of 4
+1783499626.128592 args_parse: 3 = scroll-up (type STRING)
+1783499626.128597 cmd_parse_build_commands: select-pane ; send-keys -X -N 5 scroll-up
+1783499626.128599 args_parse_flags: next -Tcopy-mode-vi
+1783499626.128600 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.128602 args_parse_flags: next WheelUpPane
+1783499626.128603 args_parse: flags end at 2 of 4
+1783499626.128604 args_parse: 2 = WheelUpPane (type STRING)
+1783499626.128608 args_parse: 3 = select-pane ; send-keys -X -N 5 scroll-up (type COMMANDS)
+1783499626.128613 cmd_parse_build_commands: bind-key -T copy-mode-vi WheelUpPane { select-pane ; send-keys -X -N 5 scroll-up }
+1783499626.128620 cmdq_get_command: [bind-key/0x58e472537030] group 2585
+1783499626.128621 cmdq_append <global>: [bind-key/0x58e472537030]
+1783499626.128631 yylex_token: end at WS
+1783499626.128635 yylex_token: bind
+1783499626.128637 yylex_token: end at WS
+1783499626.128643 yylex_token: -Tcopy-mode-vi
+1783499626.128645 yylex_token: end at WS
+1783499626.128647 yylex_token: WheelDownPane
+1783499626.128648 yylex_token: end at ;
+1783499626.128649 yylex_token: select-pane
+1783499626.128651 yylex_token: end at WS
+1783499626.128652 yylex_token: send
+1783499626.128653 yylex_token: end at WS
+1783499626.128654 yylex_token: -N5
+1783499626.128656 yylex_token: end at WS
+1783499626.128657 yylex_token: -X
+1783499626.128658 yylex_token: end at WS
+1783499626.128659 yylex_token: scroll-down
+1783499626.128662 cmd_parse_build_commands 0:0: bind
+1783499626.128664 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.128665 cmd_parse_build_commands 0:2: WheelDownPane
+1783499626.128667 cmd_parse_build_commands 0:3 0:0: select-pane
+1783499626.128668 cmd_parse_build_commands 0:3 1:0: send
+1783499626.128669 cmd_parse_build_commands 0:3 1:1: -N5
+1783499626.128670 cmd_parse_build_commands 0:3 1:2: -X
+1783499626.128672 cmd_parse_build_commands 0:3 1:3: scroll-down
+1783499626.128674 cmd_parse_build_commands 0:0: select-pane
+1783499626.128675 cmd_parse_build_commands 1:0: send
+1783499626.128677 cmd_parse_build_commands 1:1: -N5
+1783499626.128678 cmd_parse_build_commands 1:2: -X
+1783499626.128679 cmd_parse_build_commands 1:3: scroll-down
+1783499626.128683 args_parse: flags end at 1 of 1
+1783499626.128686 args_parse_flags: next -N5
+1783499626.128687 args_parse_flag_argument: -N = 5
+1783499626.128688 args_parse_flags: next -X
+1783499626.128690 args_parse_flags: -X
+1783499626.128691 args_parse_flags: next scroll-down
+1783499626.128692 args_parse: flags end at 3 of 4
+1783499626.128693 args_parse: 3 = scroll-down (type STRING)
+1783499626.128698 cmd_parse_build_commands: select-pane ; send-keys -X -N 5 scroll-down
+1783499626.128700 args_parse_flags: next -Tcopy-mode-vi
+1783499626.128701 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.128702 args_parse_flags: next WheelDownPane
+1783499626.128703 args_parse: flags end at 2 of 4
+1783499626.128705 args_parse: 2 = WheelDownPane (type STRING)
+1783499626.128708 args_parse: 3 = select-pane ; send-keys -X -N 5 scroll-down (type COMMANDS)
+1783499626.128713 cmd_parse_build_commands: bind-key -T copy-mode-vi WheelDownPane { select-pane ; send-keys -X -N 5 scroll-down }
+1783499626.128716 cmdq_get_command: [bind-key/0x58e4725371b0] group 2594
+1783499626.128718 cmdq_append <global>: [bind-key/0x58e4725371b0]
+1783499626.128720 yylex_token: end at WS
+1783499626.128722 yylex_token: bind
+1783499626.128723 yylex_token: end at WS
+1783499626.128724 yylex_token: -Tcopy-mode-vi
+1783499626.128726 yylex_token: end at WS
+1783499626.128727 yylex_token: DoubleClick1Pane
+1783499626.128729 yylex_token: end at ;
+1783499626.128730 yylex_token: select-pane
+1783499626.128731 yylex_token: end at WS
+1783499626.128732 yylex_token: send
+1783499626.128733 yylex_token: end at WS
+1783499626.128735 yylex_token: -X
+1783499626.128736 yylex_token: end at ;
+1783499626.128737 yylex_token: select-word
+1783499626.128739 yylex_token: end at WS
+1783499626.128740 yylex_token: run
+1783499626.128741 yylex_token: end at ;
+1783499626.128742 yylex_token: -d0.3
+1783499626.128743 yylex_token: end at WS
+1783499626.128744 yylex_token: send
+1783499626.128746 yylex_token: end at WS
+1783499626.128747 yylex_token: -X
+1783499626.128748 yylex_token: end at WS
+1783499626.128749 yylex_token: copy-pipe-and-cancel
+1783499626.128752 cmd_parse_build_commands 0:0: bind
+1783499626.128754 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.128755 cmd_parse_build_commands 0:2: DoubleClick1Pane
+1783499626.128759 cmd_parse_build_commands 0:3 0:0: select-pane
+1783499626.128764 cmd_parse_build_commands 0:3 1:0: send
+1783499626.128765 cmd_parse_build_commands 0:3 1:1: -X
+1783499626.128771 cmd_parse_build_commands 0:3 1:2: select-word
+1783499626.128773 cmd_parse_build_commands 0:3 2:0: run
+1783499626.128774 cmd_parse_build_commands 0:3 2:1: -d0.3
+1783499626.128775 cmd_parse_build_commands 0:3 3:0: send
+1783499626.128776 cmd_parse_build_commands 0:3 3:1: -X
+1783499626.128778 cmd_parse_build_commands 0:3 3:2: copy-pipe-and-cancel
+1783499626.128781 cmd_parse_build_commands 0:0: select-pane
+1783499626.128782 cmd_parse_build_commands 1:0: send
+1783499626.128783 cmd_parse_build_commands 1:1: -X
+1783499626.128785 cmd_parse_build_commands 1:2: select-word
+1783499626.128786 cmd_parse_build_commands 2:0: run
+1783499626.128787 cmd_parse_build_commands 2:1: -d0.3
+1783499626.128788 cmd_parse_build_commands 3:0: send
+1783499626.128789 cmd_parse_build_commands 3:1: -X
+1783499626.128791 cmd_parse_build_commands 3:2: copy-pipe-and-cancel
+1783499626.128794 args_parse: flags end at 1 of 1
+1783499626.128797 args_parse_flags: next -X
+1783499626.128798 args_parse_flags: -X
+1783499626.128799 args_parse_flags: next select-word
+1783499626.128801 args_parse: flags end at 2 of 3
+1783499626.128805 args_parse: 2 = select-word (type STRING)
+1783499626.128811 args_parse_flags: next -d0.3
+1783499626.128813 args_parse_flag_argument: -d = 0.3
+1783499626.128814 args_parse: flags end at 2 of 2
+1783499626.128817 args_parse_flags: next -X
+1783499626.128818 args_parse_flags: -X
+1783499626.128819 args_parse_flags: next copy-pipe-and-cancel
+1783499626.128821 args_parse: flags end at 2 of 3
+1783499626.128823 args_parse: 2 = copy-pipe-and-cancel (type STRING)
+1783499626.128829 cmd_parse_build_commands: select-pane ; send-keys -X select-word ; run-shell -d 0.3 ; send-keys -X copy-pipe-and-cancel
+1783499626.128831 args_parse_flags: next -Tcopy-mode-vi
+1783499626.128833 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.128834 args_parse_flags: next DoubleClick1Pane
+1783499626.128835 args_parse: flags end at 2 of 4
+1783499626.128837 args_parse: 2 = DoubleClick1Pane (type STRING)
+1783499626.128842 args_parse: 3 = select-pane ; send-keys -X select-word ; run-shell -d 0.3 ; send-keys -X copy-pipe-and-cancel (type COMMANDS)
+1783499626.128851 cmd_parse_build_commands: bind-key -T copy-mode-vi DoubleClick1Pane { select-pane ; send-keys -X select-word ; run-shell -d 0.3 ; send-keys -X copy-pipe-and-cancel }
+1783499626.128854 cmdq_get_command: [bind-key/0x58e4725380d0] group 2603
+1783499626.128855 cmdq_append <global>: [bind-key/0x58e4725380d0]
+1783499626.128864 yylex_token: end at WS
+1783499626.128867 yylex_token: bind
+1783499626.128869 yylex_token: end at WS
+1783499626.128870 yylex_token: -Tcopy-mode-vi
+1783499626.128872 yylex_token: end at WS
+1783499626.128874 yylex_token: TripleClick1Pane
+1783499626.128876 yylex_token: end at ;
+1783499626.128877 yylex_token: select-pane
+1783499626.128878 yylex_token: end at WS
+1783499626.128879 yylex_token: send
+1783499626.128880 yylex_token: end at WS
+1783499626.128881 yylex_token: -X
+1783499626.128883 yylex_token: end at ;
+1783499626.128884 yylex_token: select-line
+1783499626.128885 yylex_token: end at WS
+1783499626.128887 yylex_token: run
+1783499626.128888 yylex_token: end at ;
+1783499626.128889 yylex_token: -d0.3
+1783499626.128890 yylex_token: end at WS
+1783499626.128891 yylex_token: send
+1783499626.128892 yylex_token: end at WS
+1783499626.128893 yylex_token: -X
+1783499626.128895 yylex_token: end at WS
+1783499626.128896 yylex_token: copy-pipe-and-cancel
+1783499626.128899 cmd_parse_build_commands 0:0: bind
+1783499626.128901 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.128902 cmd_parse_build_commands 0:2: TripleClick1Pane
+1783499626.128904 cmd_parse_build_commands 0:3 0:0: select-pane
+1783499626.128905 cmd_parse_build_commands 0:3 1:0: send
+1783499626.128906 cmd_parse_build_commands 0:3 1:1: -X
+1783499626.128908 cmd_parse_build_commands 0:3 1:2: select-line
+1783499626.128909 cmd_parse_build_commands 0:3 2:0: run
+1783499626.128910 cmd_parse_build_commands 0:3 2:1: -d0.3
+1783499626.128911 cmd_parse_build_commands 0:3 3:0: send
+1783499626.128913 cmd_parse_build_commands 0:3 3:1: -X
+1783499626.128918 cmd_parse_build_commands 0:3 3:2: copy-pipe-and-cancel
+1783499626.128920 cmd_parse_build_commands 0:0: select-pane
+1783499626.128921 cmd_parse_build_commands 1:0: send
+1783499626.128923 cmd_parse_build_commands 1:1: -X
+1783499626.128924 cmd_parse_build_commands 1:2: select-line
+1783499626.128925 cmd_parse_build_commands 2:0: run
+1783499626.128926 cmd_parse_build_commands 2:1: -d0.3
+1783499626.128927 cmd_parse_build_commands 3:0: send
+1783499626.128929 cmd_parse_build_commands 3:1: -X
+1783499626.128930 cmd_parse_build_commands 3:2: copy-pipe-and-cancel
+1783499626.128934 args_parse: flags end at 1 of 1
+1783499626.128937 args_parse_flags: next -X
+1783499626.128938 args_parse_flags: -X
+1783499626.128939 args_parse_flags: next select-line
+1783499626.128940 args_parse: flags end at 2 of 3
+1783499626.128942 args_parse: 2 = select-line (type STRING)
+1783499626.128945 args_parse_flags: next -d0.3
+1783499626.128946 args_parse_flag_argument: -d = 0.3
+1783499626.128948 args_parse: flags end at 2 of 2
+1783499626.128950 args_parse_flags: next -X
+1783499626.128951 args_parse_flags: -X
+1783499626.128953 args_parse_flags: next copy-pipe-and-cancel
+1783499626.128954 args_parse: flags end at 2 of 3
+1783499626.128956 args_parse: 2 = copy-pipe-and-cancel (type STRING)
+1783499626.128962 cmd_parse_build_commands: select-pane ; send-keys -X select-line ; run-shell -d 0.3 ; send-keys -X copy-pipe-and-cancel
+1783499626.128964 args_parse_flags: next -Tcopy-mode-vi
+1783499626.128965 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.128967 args_parse_flags: next TripleClick1Pane
+1783499626.128968 args_parse: flags end at 2 of 4
+1783499626.128969 args_parse: 2 = TripleClick1Pane (type STRING)
+1783499626.128975 args_parse: 3 = select-pane ; send-keys -X select-line ; run-shell -d 0.3 ; send-keys -X copy-pipe-and-cancel (type COMMANDS)
+1783499626.128983 cmd_parse_build_commands: bind-key -T copy-mode-vi TripleClick1Pane { select-pane ; send-keys -X select-line ; run-shell -d 0.3 ; send-keys -X copy-pipe-and-cancel }
+1783499626.128986 cmdq_get_command: [bind-key/0x58e472537d10] group 2614
+1783499626.128987 cmdq_append <global>: [bind-key/0x58e472537d10]
+1783499626.128990 yylex_token: end at WS
+1783499626.128991 yylex_token: bind
+1783499626.128993 yylex_token: end at WS
+1783499626.128994 yylex_token: -Tcopy-mode-vi
+1783499626.128995 yylex_token: end at WS
+1783499626.128996 yylex_token: BSpace
+1783499626.128998 yylex_token: end at WS
+1783499626.128999 yylex_token: send
+1783499626.129000 yylex_token: end at WS
+1783499626.129001 yylex_token: -X
+1783499626.129003 yylex_token: end at WS
+1783499626.129004 yylex_token: cursor-left
+1783499626.129006 cmd_parse_build_commands 0:0: bind
+1783499626.129008 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.129009 cmd_parse_build_commands 0:2: BSpace
+1783499626.129010 cmd_parse_build_commands 0:3 0:0: send
+1783499626.129012 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.129013 cmd_parse_build_commands 0:3 0:2: cursor-left
+1783499626.129015 cmd_parse_build_commands 0:0: send
+1783499626.129016 cmd_parse_build_commands 0:1: -X
+1783499626.129017 cmd_parse_build_commands 0:2: cursor-left
+1783499626.129021 args_parse_flags: next -X
+1783499626.129022 args_parse_flags: -X
+1783499626.129023 args_parse_flags: next cursor-left
+1783499626.129024 args_parse: flags end at 2 of 3
+1783499626.129026 args_parse: 2 = cursor-left (type STRING)
+1783499626.129029 cmd_parse_build_commands: send-keys -X cursor-left
+1783499626.129030 args_parse_flags: next -Tcopy-mode-vi
+1783499626.129032 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.129033 args_parse_flags: next BSpace
+1783499626.129034 args_parse: flags end at 2 of 4
+1783499626.129035 args_parse: 2 = BSpace (type STRING)
+1783499626.129038 args_parse: 3 = send-keys -X cursor-left (type COMMANDS)
+1783499626.129043 cmd_parse_build_commands: bind-key -T copy-mode-vi BSpace { send-keys -X cursor-left }
+1783499626.129046 cmdq_get_command: [bind-key/0x58e4725386f0] group 2625
+1783499626.129048 cmdq_append <global>: [bind-key/0x58e4725386f0]
+1783499626.129050 yylex_token: end at WS
+1783499626.129054 yylex_token: bind
+1783499626.129055 yylex_token: end at WS
+1783499626.129057 yylex_token: -Tcopy-mode-vi
+1783499626.129058 yylex_token: end at WS
+1783499626.129059 yylex_token: NPage
+1783499626.129060 yylex_token: end at WS
+1783499626.129061 yylex_token: send
+1783499626.129063 yylex_token: end at WS
+1783499626.129064 yylex_token: -X
+1783499626.129065 yylex_token: end at WS
+1783499626.129066 yylex_token: page-down
+1783499626.129069 cmd_parse_build_commands 0:0: bind
+1783499626.129070 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.129072 cmd_parse_build_commands 0:2: NPage
+1783499626.129073 cmd_parse_build_commands 0:3 0:0: send
+1783499626.129074 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.129076 cmd_parse_build_commands 0:3 0:2: page-down
+1783499626.129084 cmd_parse_build_commands 0:0: send
+1783499626.129089 cmd_parse_build_commands 0:1: -X
+1783499626.129091 cmd_parse_build_commands 0:2: page-down
+1783499626.129098 args_parse_flags: next -X
+1783499626.129101 args_parse_flags: -X
+1783499626.129102 args_parse_flags: next page-down
+1783499626.129104 args_parse: flags end at 2 of 3
+1783499626.129105 args_parse: 2 = page-down (type STRING)
+1783499626.129109 cmd_parse_build_commands: send-keys -X page-down
+1783499626.129111 args_parse_flags: next -Tcopy-mode-vi
+1783499626.129113 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.129114 args_parse_flags: next NPage
+1783499626.129115 args_parse: flags end at 2 of 4
+1783499626.129116 args_parse: 2 = NPage (type STRING)
+1783499626.129119 args_parse: 3 = send-keys -X page-down (type COMMANDS)
+1783499626.129124 cmd_parse_build_commands: bind-key -T copy-mode-vi NPage { send-keys -X page-down }
+1783499626.129126 cmdq_get_command: [bind-key/0x58e472538ff0] group 2633
+1783499626.129128 cmdq_append <global>: [bind-key/0x58e472538ff0]
+1783499626.129136 yylex_token: end at WS
+1783499626.129139 yylex_token: bind
+1783499626.129141 yylex_token: end at WS
+1783499626.129142 yylex_token: -Tcopy-mode-vi
+1783499626.129144 yylex_token: end at WS
+1783499626.129145 yylex_token: PPage
+1783499626.129146 yylex_token: end at WS
+1783499626.129147 yylex_token: send
+1783499626.129148 yylex_token: end at WS
+1783499626.129149 yylex_token: -X
+1783499626.129151 yylex_token: end at WS
+1783499626.129152 yylex_token: page-up
+1783499626.129155 cmd_parse_build_commands 0:0: bind
+1783499626.129156 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.129157 cmd_parse_build_commands 0:2: PPage
+1783499626.129159 cmd_parse_build_commands 0:3 0:0: send
+1783499626.129160 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.129162 cmd_parse_build_commands 0:3 0:2: page-up
+1783499626.129164 cmd_parse_build_commands 0:0: send
+1783499626.129165 cmd_parse_build_commands 0:1: -X
+1783499626.129166 cmd_parse_build_commands 0:2: page-up
+1783499626.129169 args_parse_flags: next -X
+1783499626.129170 args_parse_flags: -X
+1783499626.129172 args_parse_flags: next page-up
+1783499626.129173 args_parse: flags end at 2 of 3
+1783499626.129174 args_parse: 2 = page-up (type STRING)
+1783499626.129178 cmd_parse_build_commands: send-keys -X page-up
+1783499626.129179 args_parse_flags: next -Tcopy-mode-vi
+1783499626.129181 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.129212 args_parse_flags: next PPage
+1783499626.129215 args_parse: flags end at 2 of 4
+1783499626.129217 args_parse: 2 = PPage (type STRING)
+1783499626.129220 args_parse: 3 = send-keys -X page-up (type COMMANDS)
+1783499626.129224 cmd_parse_build_commands: bind-key -T copy-mode-vi PPage { send-keys -X page-up }
+1783499626.129228 cmdq_get_command: [bind-key/0x58e4725397a0] group 2641
+1783499626.129229 cmdq_append <global>: [bind-key/0x58e4725397a0]
+1783499626.129231 yylex_token: end at WS
+1783499626.129232 yylex_token: bind
+1783499626.129234 yylex_token: end at WS
+1783499626.129235 yylex_token: -Tcopy-mode-vi
+1783499626.129236 yylex_token: end at WS
+1783499626.129237 yylex_token: Up
+1783499626.129239 yylex_token: end at WS
+1783499626.129240 yylex_token: send
+1783499626.129241 yylex_token: end at WS
+1783499626.129242 yylex_token: -X
+1783499626.129248 yylex_token: end at WS
+1783499626.129259 yylex_token: cursor-up
+1783499626.129262 cmd_parse_build_commands 0:0: bind
+1783499626.129264 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.129265 cmd_parse_build_commands 0:2: Up
+1783499626.129266 cmd_parse_build_commands 0:3 0:0: send
+1783499626.129268 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.129269 cmd_parse_build_commands 0:3 0:2: cursor-up
+1783499626.129271 cmd_parse_build_commands 0:0: send
+1783499626.129273 cmd_parse_build_commands 0:1: -X
+1783499626.129274 cmd_parse_build_commands 0:2: cursor-up
+1783499626.129295 args_parse_flags: next -X
+1783499626.129300 args_parse_flags: -X
+1783499626.129303 args_parse_flags: next cursor-up
+1783499626.129305 args_parse: flags end at 2 of 3
+1783499626.129307 args_parse: 2 = cursor-up (type STRING)
+1783499626.129312 cmd_parse_build_commands: send-keys -X cursor-up
+1783499626.129314 args_parse_flags: next -Tcopy-mode-vi
+1783499626.129316 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.129317 args_parse_flags: next Up
+1783499626.129319 args_parse: flags end at 2 of 4
+1783499626.129320 args_parse: 2 = Up (type STRING)
+1783499626.129323 args_parse: 3 = send-keys -X cursor-up (type COMMANDS)
+1783499626.129329 cmd_parse_build_commands: bind-key -T copy-mode-vi Up { send-keys -X cursor-up }
+1783499626.129333 cmdq_get_command: [bind-key/0x58e472539b90] group 2649
+1783499626.129335 cmdq_append <global>: [bind-key/0x58e472539b90]
+1783499626.129337 yylex_token: end at WS
+1783499626.129338 yylex_token: bind
+1783499626.129340 yylex_token: end at WS
+1783499626.129342 yylex_token: -Tcopy-mode-vi
+1783499626.129343 yylex_token: end at WS
+1783499626.129345 yylex_token: Down
+1783499626.129346 yylex_token: end at WS
+1783499626.129347 yylex_token: send
+1783499626.129349 yylex_token: end at WS
+1783499626.129350 yylex_token: -X
+1783499626.129351 yylex_token: end at WS
+1783499626.129353 yylex_token: cursor-down
+1783499626.129356 cmd_parse_build_commands 0:0: bind
+1783499626.129357 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.129359 cmd_parse_build_commands 0:2: Down
+1783499626.129360 cmd_parse_build_commands 0:3 0:0: send
+1783499626.129362 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.129363 cmd_parse_build_commands 0:3 0:2: cursor-down
+1783499626.129365 cmd_parse_build_commands 0:0: send
+1783499626.129367 cmd_parse_build_commands 0:1: -X
+1783499626.129368 cmd_parse_build_commands 0:2: cursor-down
+1783499626.129372 args_parse_flags: next -X
+1783499626.129373 args_parse_flags: -X
+1783499626.129374 args_parse_flags: next cursor-down
+1783499626.129376 args_parse: flags end at 2 of 3
+1783499626.129377 args_parse: 2 = cursor-down (type STRING)
+1783499626.129380 cmd_parse_build_commands: send-keys -X cursor-down
+1783499626.129382 args_parse_flags: next -Tcopy-mode-vi
+1783499626.129384 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.129385 args_parse_flags: next Down
+1783499626.129386 args_parse: flags end at 2 of 4
+1783499626.129388 args_parse: 2 = Down (type STRING)
+1783499626.129391 args_parse: 3 = send-keys -X cursor-down (type COMMANDS)
+1783499626.129395 cmd_parse_build_commands: bind-key -T copy-mode-vi Down { send-keys -X cursor-down }
+1783499626.129399 cmdq_get_command: [bind-key/0x58e472539fd0] group 2657
+1783499626.129400 cmdq_append <global>: [bind-key/0x58e472539fd0]
+1783499626.129402 yylex_token: end at WS
+1783499626.129403 yylex_token: bind
+1783499626.129405 yylex_token: end at WS
+1783499626.129410 yylex_token: -Tcopy-mode-vi
+1783499626.129417 yylex_token: end at WS
+1783499626.129418 yylex_token: Left
+1783499626.129420 yylex_token: end at WS
+1783499626.129421 yylex_token: send
+1783499626.129422 yylex_token: end at WS
+1783499626.129423 yylex_token: -X
+1783499626.129425 yylex_token: end at WS
+1783499626.129426 yylex_token: cursor-left
+1783499626.129430 cmd_parse_build_commands 0:0: bind
+1783499626.129432 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.129433 cmd_parse_build_commands 0:2: Left
+1783499626.129435 cmd_parse_build_commands 0:3 0:0: send
+1783499626.129436 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.129444 cmd_parse_build_commands 0:3 0:2: cursor-left
+1783499626.129447 cmd_parse_build_commands 0:0: send
+1783499626.129448 cmd_parse_build_commands 0:1: -X
+1783499626.129450 cmd_parse_build_commands 0:2: cursor-left
+1783499626.129453 args_parse_flags: next -X
+1783499626.129454 args_parse_flags: -X
+1783499626.129456 args_parse_flags: next cursor-left
+1783499626.129457 args_parse: flags end at 2 of 3
+1783499626.129458 args_parse: 2 = cursor-left (type STRING)
+1783499626.129462 cmd_parse_build_commands: send-keys -X cursor-left
+1783499626.129464 args_parse_flags: next -Tcopy-mode-vi
+1783499626.129465 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.129466 args_parse_flags: next Left
+1783499626.129468 args_parse: flags end at 2 of 4
+1783499626.129469 args_parse: 2 = Left (type STRING)
+1783499626.129472 args_parse: 3 = send-keys -X cursor-left (type COMMANDS)
+1783499626.129476 cmd_parse_build_commands: bind-key -T copy-mode-vi Left { send-keys -X cursor-left }
+1783499626.129479 cmdq_get_command: [bind-key/0x58e47253a330] group 2665
+1783499626.129481 cmdq_append <global>: [bind-key/0x58e47253a330]
+1783499626.129489 yylex_token: end at WS
+1783499626.129493 yylex_token: bind
+1783499626.129495 yylex_token: end at WS
+1783499626.129496 yylex_token: -Tcopy-mode-vi
+1783499626.129497 yylex_token: end at WS
+1783499626.129498 yylex_token: Right
+1783499626.129500 yylex_token: end at WS
+1783499626.129501 yylex_token: send
+1783499626.129502 yylex_token: end at WS
+1783499626.129503 yylex_token: -X
+1783499626.129505 yylex_token: end at WS
+1783499626.129506 yylex_token: cursor-right
+1783499626.129509 cmd_parse_build_commands 0:0: bind
+1783499626.129510 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.129512 cmd_parse_build_commands 0:2: Right
+1783499626.129513 cmd_parse_build_commands 0:3 0:0: send
+1783499626.129514 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.129516 cmd_parse_build_commands 0:3 0:2: cursor-right
+1783499626.129518 cmd_parse_build_commands 0:0: send
+1783499626.129520 cmd_parse_build_commands 0:1: -X
+1783499626.129521 cmd_parse_build_commands 0:2: cursor-right
+1783499626.129525 args_parse_flags: next -X
+1783499626.129526 args_parse_flags: -X
+1783499626.129527 args_parse_flags: next cursor-right
+1783499626.129528 args_parse: flags end at 2 of 3
+1783499626.129530 args_parse: 2 = cursor-right (type STRING)
+1783499626.129533 cmd_parse_build_commands: send-keys -X cursor-right
+1783499626.129535 args_parse_flags: next -Tcopy-mode-vi
+1783499626.129536 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.129537 args_parse_flags: next Right
+1783499626.129539 args_parse: flags end at 2 of 4
+1783499626.129540 args_parse: 2 = Right (type STRING)
+1783499626.129543 args_parse: 3 = send-keys -X cursor-right (type COMMANDS)
+1783499626.129548 cmd_parse_build_commands: bind-key -T copy-mode-vi Right { send-keys -X cursor-right }
+1783499626.129551 cmdq_get_command: [bind-key/0x58e47253a770] group 2673
+1783499626.129553 cmdq_append <global>: [bind-key/0x58e47253a770]
+1783499626.129555 yylex_token: end at WS
+1783499626.129556 yylex_token: bind
+1783499626.129557 yylex_token: end at WS
+1783499626.129558 yylex_token: -Tcopy-mode-vi
+1783499626.129560 yylex_token: end at WS
+1783499626.129561 yylex_token: M-x
+1783499626.129562 yylex_token: end at WS
+1783499626.129563 yylex_token: send
+1783499626.129564 yylex_token: end at WS
+1783499626.129566 yylex_token: -X
+1783499626.129567 yylex_token: end at WS
+1783499626.129569 yylex_token: jump-to-mark
+1783499626.129571 cmd_parse_build_commands 0:0: bind
+1783499626.129573 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.129574 cmd_parse_build_commands 0:2: M-x
+1783499626.129575 cmd_parse_build_commands 0:3 0:0: send
+1783499626.129577 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.129578 cmd_parse_build_commands 0:3 0:2: jump-to-mark
+1783499626.129580 cmd_parse_build_commands 0:0: send
+1783499626.129581 cmd_parse_build_commands 0:1: -X
+1783499626.129583 cmd_parse_build_commands 0:2: jump-to-mark
+1783499626.129586 args_parse_flags: next -X
+1783499626.129587 args_parse_flags: -X
+1783499626.129593 args_parse_flags: next jump-to-mark
+1783499626.129594 args_parse: flags end at 2 of 3
+1783499626.129595 args_parse: 2 = jump-to-mark (type STRING)
+1783499626.129599 cmd_parse_build_commands: send-keys -X jump-to-mark
+1783499626.129600 args_parse_flags: next -Tcopy-mode-vi
+1783499626.129602 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.129603 args_parse_flags: next M-x
+1783499626.129604 args_parse: flags end at 2 of 4
+1783499626.129606 args_parse: 2 = M-x (type STRING)
+1783499626.129608 args_parse: 3 = send-keys -X jump-to-mark (type COMMANDS)
+1783499626.129614 cmd_parse_build_commands: bind-key -T copy-mode-vi M-x { send-keys -X jump-to-mark }
+1783499626.129616 cmdq_get_command: [bind-key/0x58e47253ab40] group 2681
+1783499626.129618 cmdq_append <global>: [bind-key/0x58e47253ab40]
+1783499626.129619 yylex_token: end at WS
+1783499626.129620 yylex_token: bind
+1783499626.129622 yylex_token: end at WS
+1783499626.129623 yylex_token: -Tcopy-mode-vi
+1783499626.129625 yylex_token: end at WS
+1783499626.129626 yylex_token: C-Up
+1783499626.129627 yylex_token: end at WS
+1783499626.129628 yylex_token: send
+1783499626.129629 yylex_token: end at WS
+1783499626.129631 yylex_token: -X
+1783499626.129632 yylex_token: end at WS
+1783499626.129633 yylex_token: scroll-up
+1783499626.129636 cmd_parse_build_commands 0:0: bind
+1783499626.129637 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.129639 cmd_parse_build_commands 0:2: C-Up
+1783499626.129640 cmd_parse_build_commands 0:3 0:0: send
+1783499626.129641 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.129643 cmd_parse_build_commands 0:3 0:2: scroll-up
+1783499626.129645 cmd_parse_build_commands 0:0: send
+1783499626.129646 cmd_parse_build_commands 0:1: -X
+1783499626.129647 cmd_parse_build_commands 0:2: scroll-up
+1783499626.129650 args_parse_flags: next -X
+1783499626.129651 args_parse_flags: -X
+1783499626.129653 args_parse_flags: next scroll-up
+1783499626.129654 args_parse: flags end at 2 of 3
+1783499626.129655 args_parse: 2 = scroll-up (type STRING)
+1783499626.129658 cmd_parse_build_commands: send-keys -X scroll-up
+1783499626.129660 args_parse_flags: next -Tcopy-mode-vi
+1783499626.129661 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.129663 args_parse_flags: next C-Up
+1783499626.129664 args_parse: flags end at 2 of 4
+1783499626.129665 args_parse: 2 = C-Up (type STRING)
+1783499626.129668 args_parse: 3 = send-keys -X scroll-up (type COMMANDS)
+1783499626.129673 cmd_parse_build_commands: bind-key -T copy-mode-vi C-Up { send-keys -X scroll-up }
+1783499626.129675 cmdq_get_command: [bind-key/0x58e47253b200] group 2689
+1783499626.129676 cmdq_append <global>: [bind-key/0x58e47253b200]
+1783499626.129686 yylex_token: end at WS
+1783499626.129691 yylex_token: bind
+1783499626.129692 yylex_token: end at WS
+1783499626.129693 yylex_token: -Tcopy-mode-vi
+1783499626.129695 yylex_token: end at WS
+1783499626.129696 yylex_token: C-Down
+1783499626.129697 yylex_token: end at WS
+1783499626.129699 yylex_token: send
+1783499626.129700 yylex_token: end at WS
+1783499626.129701 yylex_token: -X
+1783499626.129703 yylex_token: end at WS
+1783499626.129704 yylex_token: scroll-down
+1783499626.129707 cmd_parse_build_commands 0:0: bind
+1783499626.129708 cmd_parse_build_commands 0:1: -Tcopy-mode-vi
+1783499626.129710 cmd_parse_build_commands 0:2: C-Down
+1783499626.129711 cmd_parse_build_commands 0:3 0:0: send
+1783499626.129712 cmd_parse_build_commands 0:3 0:1: -X
+1783499626.129714 cmd_parse_build_commands 0:3 0:2: scroll-down
+1783499626.129716 cmd_parse_build_commands 0:0: send
+1783499626.129717 cmd_parse_build_commands 0:1: -X
+1783499626.129718 cmd_parse_build_commands 0:2: scroll-down
+1783499626.129721 args_parse_flags: next -X
+1783499626.129723 args_parse_flags: -X
+1783499626.129724 args_parse_flags: next scroll-down
+1783499626.129725 args_parse: flags end at 2 of 3
+1783499626.129727 args_parse: 2 = scroll-down (type STRING)
+1783499626.129730 cmd_parse_build_commands: send-keys -X scroll-down
+1783499626.129732 args_parse_flags: next -Tcopy-mode-vi
+1783499626.129733 args_parse_flag_argument: -T = copy-mode-vi
+1783499626.129738 args_parse_flags: next C-Down
+1783499626.129740 args_parse: flags end at 2 of 4
+1783499626.129741 args_parse: 2 = C-Down (type STRING)
+1783499626.129744 args_parse: 3 = send-keys -X scroll-down (type COMMANDS)
+1783499626.129749 cmd_parse_build_commands: bind-key -T copy-mode-vi C-Down { send-keys -X scroll-down }
+1783499626.129751 cmdq_get_command: [bind-key/0x58e47253b6f0] group 2697
+1783499626.129753 cmdq_append <global>: [bind-key/0x58e47253b6f0]
+1783499626.129756 cmdq_append <global>: [key_bindings_init_done/0x58e47253bc70]
+1783499626.131764 add peer 0x58e47253c880: 8 (0x58e47253bd70)
+1783499626.132073 new client 0x58e47253bd70
+1783499626.132151 server loop enter
+1783499626.132448 peer 0x58e47253c880 message 100
+1783499626.132587 client 0x58e47253bd70 IDENTIFY_FLAGS 0x18010000
+1783499626.132600 peer 0x58e47253c880 message 111
+1783499626.132603 client 0x58e47253bd70 IDENTIFY_LONGFLAGS 0x18010000
+1783499626.132605 peer 0x58e47253c880 message 101
+1783499626.132641 client 0x58e47253bd70 IDENTIFY_TERM dumb
+1783499626.132648 peer 0x58e47253c880 message 109
+1783499626.132670 client 0x58e47253bd70 IDENTIFY_FEATURES 
+1783499626.132674 peer 0x58e47253c880 message 102
+1783499626.132676 client 0x58e47253bd70 IDENTIFY_TTYNAME 
+1783499626.132678 peer 0x58e47253c880 message 108
+1783499626.132689 client 0x58e47253bd70 IDENTIFY_CWD /home/sme/p/coding_agent_cli_toolset
+1783499626.132691 peer 0x58e47253c880 message 104
+1783499626.132693 client 0x58e47253bd70 IDENTIFY_STDIN 6
+1783499626.132785 cmdq_next <global>: enter
+1783499626.132800 cmdq_next <global>: [bind-key/0x58e4724b71a0] (0), flags 0
+1783499626.132840 cmd_find_best_session: 0 sessions to try
+1783499626.132848 cmd_find_current_client: no target, return (nil)
+1783499626.132851 cmd_find_best_session: 0 sessions to try
+1783499626.132853 cmd_find_current_client: no target, return (nil)
+1783499626.132895 cmd_find_best_session: 0 sessions to try
+1783499626.132902 cmd_find_best_session: 0 sessions to try
+1783499626.133019 key_bindings_add: 0x2 C-b = send-prefix
+1783499626.133076 cmd_find_best_session: 0 sessions to try
+1783499626.133087 cmdq_next <global>: [bind-key/0x58e4724b7500] (0), flags 0
+1783499626.133090 cmd_find_best_session: 0 sessions to try
+1783499626.133092 cmd_find_current_client: no target, return (nil)
+1783499626.133094 cmd_find_best_session: 0 sessions to try
+1783499626.133097 cmd_find_current_client: no target, return (nil)
+1783499626.133098 cmd_find_best_session: 0 sessions to try
+1783499626.133100 cmd_find_best_session: 0 sessions to try
+1783499626.133108 key_bindings_add: 0xf C-o = rotate-window
+1783499626.133110 cmd_find_best_session: 0 sessions to try
+1783499626.133113 cmdq_next <global>: [bind-key/0x58e4724b7ba0] (0), flags 0
+1783499626.133115 cmd_find_best_session: 0 sessions to try
+1783499626.133117 cmd_find_current_client: no target, return (nil)
+1783499626.133119 cmd_find_best_session: 0 sessions to try
+1783499626.133121 cmd_find_current_client: no target, return (nil)
+1783499626.133123 cmd_find_best_session: 0 sessions to try
+1783499626.133124 cmd_find_best_session: 0 sessions to try
+1783499626.133129 key_bindings_add: 0x1a C-z = suspend-client
+1783499626.133131 cmd_find_best_session: 0 sessions to try
+1783499626.133134 cmdq_next <global>: [bind-key/0x58e4724b8150] (0), flags 0
+1783499626.133136 cmd_find_best_session: 0 sessions to try
+1783499626.133138 cmd_find_current_client: no target, return (nil)
+1783499626.133139 cmd_find_best_session: 0 sessions to try
+1783499626.133141 cmd_find_current_client: no target, return (nil)
+1783499626.133143 cmd_find_best_session: 0 sessions to try
+1783499626.133145 cmd_find_best_session: 0 sessions to try
+1783499626.133149 key_bindings_add: 0x20 Space = next-layout
+1783499626.133151 cmd_find_best_session: 0 sessions to try
+1783499626.133154 cmdq_next <global>: [bind-key/0x58e4724b8670] (0), flags 0
+1783499626.133156 cmd_find_best_session: 0 sessions to try
+1783499626.133158 cmd_find_current_client: no target, return (nil)
+1783499626.133159 cmd_find_best_session: 0 sessions to try
+1783499626.133172 cmd_find_current_client: no target, return (nil)
+1783499626.133174 cmd_find_best_session: 0 sessions to try
+1783499626.133181 cmd_find_best_session: 0 sessions to try
+1783499626.133213 key_bindings_add: 0x21 ! = break-pane
+1783499626.133215 cmd_find_best_session: 0 sessions to try
+1783499626.133218 cmdq_next <global>: [bind-key/0x58e4724b8cb0] (0), flags 0
+1783499626.133220 cmd_find_best_session: 0 sessions to try
+1783499626.133222 cmd_find_current_client: no target, return (nil)
+1783499626.133224 cmd_find_best_session: 0 sessions to try
+1783499626.133226 cmd_find_current_client: no target, return (nil)
+1783499626.133228 cmd_find_best_session: 0 sessions to try
+1783499626.133230 cmd_find_best_session: 0 sessions to try
+1783499626.133233 key_bindings_add: 0x22 " = split-window
+1783499626.133235 cmd_find_best_session: 0 sessions to try
+1783499626.133237 cmdq_next <global>: [bind-key/0x58e4724b92e0] (0), flags 0
+1783499626.133239 cmd_find_best_session: 0 sessions to try
+1783499626.133241 cmd_find_current_client: no target, return (nil)
+1783499626.133243 cmd_find_best_session: 0 sessions to try
+1783499626.133245 cmd_find_current_client: no target, return (nil)
+1783499626.133247 cmd_find_best_session: 0 sessions to try
+1783499626.133249 cmd_find_best_session: 0 sessions to try
+1783499626.133252 key_bindings_add: 0x23 # = list-buffers
+1783499626.133254 cmd_find_best_session: 0 sessions to try
+1783499626.133256 cmdq_next <global>: [bind-key/0x58e4724b9c30] (0), flags 0
+1783499626.133258 cmd_find_best_session: 0 sessions to try
+1783499626.133260 cmd_find_current_client: no target, return (nil)
+1783499626.133262 cmd_find_best_session: 0 sessions to try
+1783499626.133264 cmd_find_current_client: no target, return (nil)
+1783499626.133266 cmd_find_best_session: 0 sessions to try
+1783499626.133267 cmd_find_best_session: 0 sessions to try
+1783499626.133276 key_bindings_add: 0x24 $ = command-prompt -I "#S" { rename-session "%%" }
+1783499626.133278 cmd_find_best_session: 0 sessions to try
+1783499626.133281 cmdq_next <global>: [bind-key/0x58e4724ba520] (0), flags 0
+1783499626.133283 cmd_find_best_session: 0 sessions to try
+1783499626.133285 cmd_find_current_client: no target, return (nil)
+1783499626.133287 cmd_find_best_session: 0 sessions to try
+1783499626.133288 cmd_find_current_client: no target, return (nil)
+1783499626.133290 cmd_find_best_session: 0 sessions to try
+1783499626.133292 cmd_find_best_session: 0 sessions to try
+1783499626.133296 key_bindings_add: 0x25 % = split-window -h
+1783499626.133298 cmd_find_best_session: 0 sessions to try
+1783499626.133301 cmdq_next <global>: [bind-key/0x58e4724bac40] (0), flags 0
+1783499626.133302 cmd_find_best_session: 0 sessions to try
+1783499626.133304 cmd_find_current_client: no target, return (nil)
+1783499626.133306 cmd_find_best_session: 0 sessions to try
+1783499626.133308 cmd_find_current_client: no target, return (nil)
+1783499626.133309 cmd_find_best_session: 0 sessions to try
+1783499626.133317 cmd_find_best_session: 0 sessions to try
+1783499626.133328 key_bindings_add: 0x26 & = confirm-before -p "kill-window #W? (y/n)" kill-window
+1783499626.133330 cmd_find_best_session: 0 sessions to try
+1783499626.133333 cmdq_next <global>: [bind-key/0x58e4724bbc30] (0), flags 0
+1783499626.133335 cmd_find_best_session: 0 sessions to try
+1783499626.133337 cmd_find_current_client: no target, return (nil)
+1783499626.133338 cmd_find_best_session: 0 sessions to try
+1783499626.133340 cmd_find_current_client: no target, return (nil)
+1783499626.133342 cmd_find_best_session: 0 sessions to try
+1783499626.133344 cmd_find_best_session: 0 sessions to try
+1783499626.133352 key_bindings_add: 0x27 ' = command-prompt -T window-target -p index { select-window -t ":%%" }
+1783499626.133354 cmd_find_best_session: 0 sessions to try
+1783499626.133357 cmdq_next <global>: [bind-key/0x58e4724bbff0] (0), flags 0
+1783499626.133359 cmd_find_best_session: 0 sessions to try
+1783499626.133360 cmd_find_current_client: no target, return (nil)
+1783499626.133362 cmd_find_best_session: 0 sessions to try
+1783499626.133382 cmd_find_current_client: no target, return (nil)
+1783499626.133384 cmd_find_best_session: 0 sessions to try
+1783499626.133386 cmd_find_best_session: 0 sessions to try
+1783499626.133390 key_bindings_add: 0x28 ( = switch-client -p
+1783499626.133392 cmd_find_best_session: 0 sessions to try
+1783499626.133395 cmdq_next <global>: [bind-key/0x58e4724bc290] (0), flags 0
+1783499626.133397 cmd_find_best_session: 0 sessions to try
+1783499626.133398 cmd_find_current_client: no target, return (nil)
+1783499626.133400 cmd_find_best_session: 0 sessions to try
+1783499626.133402 cmd_find_current_client: no target, return (nil)
+1783499626.133404 cmd_find_best_session: 0 sessions to try
+1783499626.133405 cmd_find_best_session: 0 sessions to try
+1783499626.133409 key_bindings_add: 0x29 ) = switch-client -n
+1783499626.133411 cmd_find_best_session: 0 sessions to try
+1783499626.133413 cmdq_next <global>: [bind-key/0x58e4724bcca0] (0), flags 0
+1783499626.133415 cmd_find_best_session: 0 sessions to try
+1783499626.133417 cmd_find_current_client: no target, return (nil)
+1783499626.133419 cmd_find_best_session: 0 sessions to try
+1783499626.133420 cmd_find_current_client: no target, return (nil)
+1783499626.133422 cmd_find_best_session: 0 sessions to try
+1783499626.133424 cmd_find_best_session: 0 sessions to try
+1783499626.133431 key_bindings_add: 0x2c , = command-prompt -I "#W" { rename-window "%%" }
+1783499626.133433 cmd_find_best_session: 0 sessions to try
+1783499626.133436 cmdq_next <global>: [bind-key/0x58e4724bd9a0] (0), flags 0
+1783499626.133438 cmd_find_best_session: 0 sessions to try
+1783499626.133440 cmd_find_current_client: no target, return (nil)
+1783499626.133441 cmd_find_best_session: 0 sessions to try
+1783499626.133443 cmd_find_current_client: no target, return (nil)
+1783499626.133445 cmd_find_best_session: 0 sessions to try
+1783499626.133446 cmd_find_best_session: 0 sessions to try
+1783499626.133455 key_bindings_add: 0x2d - = delete-buffer
+1783499626.133460 cmd_find_best_session: 0 sessions to try
+1783499626.133463 cmdq_next <global>: [bind-key/0x58e4724bdd70] (0), flags 0
+1783499626.133465 cmd_find_best_session: 0 sessions to try
+1783499626.133467 cmd_find_current_client: no target, return (nil)
+1783499626.133469 cmd_find_best_session: 0 sessions to try
+1783499626.133471 cmd_find_current_client: no target, return (nil)
+1783499626.133472 cmd_find_best_session: 0 sessions to try
+1783499626.133474 cmd_find_best_session: 0 sessions to try
+1783499626.133481 key_bindings_add: 0x2e . = command-prompt -T target { move-window -t "%%" }
+1783499626.133483 cmd_find_best_session: 0 sessions to try
+1783499626.133486 cmdq_next <global>: [bind-key/0x58e4724bf000] (0), flags 0
+1783499626.133488 cmd_find_best_session: 0 sessions to try
+1783499626.133490 cmd_find_current_client: no target, return (nil)
+1783499626.133491 cmd_find_best_session: 0 sessions to try
+1783499626.133493 cmd_find_current_client: no target, return (nil)
+1783499626.133495 cmd_find_best_session: 0 sessions to try
+1783499626.133497 cmd_find_best_session: 0 sessions to try
+1783499626.133503 key_bindings_add: 0x2f / = command-prompt -k -p key { list-keys -1N "%%" }
+1783499626.133509 cmd_find_best_session: 0 sessions to try
+1783499626.133515 cmdq_next <global>: [bind-key/0x58e4724bf1a0] (0), flags 0
+1783499626.133517 cmd_find_best_session: 0 sessions to try
+1783499626.133519 cmd_find_current_client: no target, return (nil)
+1783499626.133521 cmd_find_best_session: 0 sessions to try
+1783499626.133522 cmd_find_current_client: no target, return (nil)
+1783499626.133524 cmd_find_best_session: 0 sessions to try
+1783499626.133526 cmd_find_best_session: 0 sessions to try
+1783499626.133530 key_bindings_add: 0x30 0 = select-window -t :=0
+1783499626.133532 cmd_find_best_session: 0 sessions to try
+1783499626.133535 cmdq_next <global>: [bind-key/0x58e4724bf5b0] (0), flags 0
+1783499626.133536 cmd_find_best_session: 0 sessions to try
+1783499626.133538 cmd_find_current_client: no target, return (nil)
+1783499626.133540 cmd_find_best_session: 0 sessions to try
+1783499626.133542 cmd_find_current_client: no target, return (nil)
+1783499626.133547 cmd_find_best_session: 0 sessions to try
+1783499626.133549 cmd_find_best_session: 0 sessions to try
+1783499626.133553 key_bindings_add: 0x31 1 = select-window -t :=1
+1783499626.133555 cmd_find_best_session: 0 sessions to try
+1783499626.133557 cmdq_next <global>: [bind-key/0x58e4724bf9e0] (0), flags 0
+1783499626.133559 cmd_find_best_session: 0 sessions to try
+1783499626.133561 cmd_find_current_client: no target, return (nil)
+1783499626.133563 cmd_find_best_session: 0 sessions to try
+1783499626.133564 cmd_find_current_client: no target, return (nil)
+1783499626.133566 cmd_find_best_session: 0 sessions to try
+1783499626.133568 cmd_find_best_session: 0 sessions to try
+1783499626.133571 key_bindings_add: 0x32 2 = select-window -t :=2
+1783499626.133577 cmd_find_best_session: 0 sessions to try
+1783499626.133583 cmdq_next <global>: [bind-key/0x58e4724bffb0] (0), flags 0
+1783499626.133585 cmd_find_best_session: 0 sessions to try
+1783499626.133587 cmd_find_current_client: no target, return (nil)
+1783499626.133588 cmd_find_best_session: 0 sessions to try
+1783499626.133590 cmd_find_current_client: no target, return (nil)
+1783499626.133592 cmd_find_best_session: 0 sessions to try
+1783499626.133593 cmd_find_best_session: 0 sessions to try
+1783499626.133597 key_bindings_add: 0x33 3 = select-window -t :=3
+1783499626.133599 cmd_find_best_session: 0 sessions to try
+1783499626.133602 cmdq_next <global>: [bind-key/0x58e4724c0a40] (0), flags 0
+1783499626.133604 cmd_find_best_session: 0 sessions to try
+1783499626.133605 cmd_find_current_client: no target, return (nil)
+1783499626.133607 cmd_find_best_session: 0 sessions to try
+1783499626.133609 cmd_find_current_client: no target, return (nil)
+1783499626.133610 cmd_find_best_session: 0 sessions to try
+1783499626.133612 cmd_find_best_session: 0 sessions to try
+1783499626.133616 key_bindings_add: 0x34 4 = select-window -t :=4
+1783499626.133618 cmd_find_best_session: 0 sessions to try
+1783499626.133621 cmdq_next <global>: [bind-key/0x58e4724c07d0] (0), flags 0
+1783499626.133623 cmd_find_best_session: 0 sessions to try
+1783499626.133624 cmd_find_current_client: no target, return (nil)
+1783499626.133626 cmd_find_best_session: 0 sessions to try
+1783499626.133628 cmd_find_current_client: no target, return (nil)
+1783499626.133630 cmd_find_best_session: 0 sessions to try
+1783499626.133631 cmd_find_best_session: 0 sessions to try
+1783499626.133634 key_bindings_add: 0x35 5 = select-window -t :=5
+1783499626.133636 cmd_find_best_session: 0 sessions to try
+1783499626.133639 cmdq_next <global>: [bind-key/0x58e4724c11e0] (0), flags 0
+1783499626.133641 cmd_find_best_session: 0 sessions to try
+1783499626.133643 cmd_find_current_client: no target, return (nil)
+1783499626.133644 cmd_find_best_session: 0 sessions to try
+1783499626.133646 cmd_find_current_client: no target, return (nil)
+1783499626.133648 cmd_find_best_session: 0 sessions to try
+1783499626.133649 cmd_find_best_session: 0 sessions to try
+1783499626.133653 key_bindings_add: 0x36 6 = select-window -t :=6
+1783499626.133655 cmd_find_best_session: 0 sessions to try
+1783499626.133657 cmdq_next <global>: [bind-key/0x58e4724c1c70] (0), flags 0
+1783499626.133659 cmd_find_best_session: 0 sessions to try
+1783499626.133661 cmd_find_current_client: no target, return (nil)
+1783499626.133663 cmd_find_best_session: 0 sessions to try
+1783499626.133664 cmd_find_current_client: no target, return (nil)
+1783499626.133666 cmd_find_best_session: 0 sessions to try
+1783499626.133668 cmd_find_best_session: 0 sessions to try
+1783499626.133672 key_bindings_add: 0x37 7 = select-window -t :=7
+1783499626.133674 cmd_find_best_session: 0 sessions to try
+1783499626.133677 cmdq_next <global>: [bind-key/0x58e4724c1a00] (0), flags 0
+1783499626.133679 cmd_find_best_session: 0 sessions to try
+1783499626.133681 cmd_find_current_client: no target, return (nil)
+1783499626.133682 cmd_find_best_session: 0 sessions to try
+1783499626.133684 cmd_find_current_client: no target, return (nil)
+1783499626.133686 cmd_find_best_session: 0 sessions to try
+1783499626.133692 cmd_find_best_session: 0 sessions to try
+1783499626.133701 key_bindings_add: 0x38 8 = select-window -t :=8
+1783499626.133705 cmd_find_best_session: 0 sessions to try
+1783499626.133709 cmdq_next <global>: [bind-key/0x58e4724c2490] (0), flags 0
+1783499626.133710 cmd_find_best_session: 0 sessions to try
+1783499626.133712 cmd_find_current_client: no target, return (nil)
+1783499626.133714 cmd_find_best_session: 0 sessions to try
+1783499626.133716 cmd_find_current_client: no target, return (nil)
+1783499626.133717 cmd_find_best_session: 0 sessions to try
+1783499626.133719 cmd_find_best_session: 0 sessions to try
+1783499626.133724 key_bindings_add: 0x39 9 = select-window -t :=9
+1783499626.133726 cmd_find_best_session: 0 sessions to try
+1783499626.133729 cmdq_next <global>: [bind-key/0x58e4724c2830] (0), flags 0
+1783499626.133731 cmd_find_best_session: 0 sessions to try
+1783499626.133733 cmd_find_current_client: no target, return (nil)
+1783499626.133735 cmd_find_best_session: 0 sessions to try
+1783499626.133736 cmd_find_current_client: no target, return (nil)
+1783499626.133738 cmd_find_best_session: 0 sessions to try
+1783499626.133740 cmd_find_best_session: 0 sessions to try
+1783499626.133743 key_bindings_add: 0x3a : = command-prompt
+1783499626.133745 cmd_find_best_session: 0 sessions to try
+1783499626.133747 cmdq_next <global>: [bind-key/0x58e4724c33e0] (0), flags 0
+1783499626.133749 cmd_find_best_session: 0 sessions to try
+1783499626.133751 cmd_find_current_client: no target, return (nil)
+1783499626.133753 cmd_find_best_session: 0 sessions to try
+1783499626.133755 cmd_find_current_client: no target, return (nil)
+1783499626.133756 cmd_find_best_session: 0 sessions to try
+1783499626.133758 cmd_find_best_session: 0 sessions to try
+1783499626.133762 key_bindings_add: 0x3b ; = last-pane
+1783499626.133764 cmd_find_best_session: 0 sessions to try
+1783499626.133766 cmdq_next <global>: [bind-key/0x58e4724c3610] (0), flags 0
+1783499626.133768 cmd_find_best_session: 0 sessions to try
+1783499626.133770 cmd_find_current_client: no target, return (nil)
+1783499626.133772 cmd_find_best_session: 0 sessions to try
+1783499626.133773 cmd_find_current_client: no target, return (nil)
+1783499626.133775 cmd_find_best_session: 0 sessions to try
+1783499626.133777 cmd_find_best_session: 0 sessions to try
+1783499626.133780 key_bindings_add: 0x3d = = choose-buffer -Z
+1783499626.133782 cmd_find_best_session: 0 sessions to try
+1783499626.133785 cmdq_next <global>: [bind-key/0x58e4724c3e00] (0), flags 0
+1783499626.133786 cmd_find_best_session: 0 sessions to try
+1783499626.133788 cmd_find_current_client: no target, return (nil)
+1783499626.133790 cmd_find_best_session: 0 sessions to try
+1783499626.133792 cmd_find_current_client: no target, return (nil)
+1783499626.133793 cmd_find_best_session: 0 sessions to try
+1783499626.133795 cmd_find_best_session: 0 sessions to try
+1783499626.133798 key_bindings_add: 0x3f ? = list-keys -N
+1783499626.133805 cmd_find_best_session: 0 sessions to try
+1783499626.133811 cmdq_next <global>: [bind-key/0x58e4724c4830] (0), flags 0
+1783499626.133813 cmd_find_best_session: 0 sessions to try
+1783499626.133815 cmd_find_current_client: no target, return (nil)
+1783499626.133817 cmd_find_best_session: 0 sessions to try
+1783499626.133818 cmd_find_current_client: no target, return (nil)
+1783499626.133820 cmd_find_best_session: 0 sessions to try
+1783499626.133822 cmd_find_best_session: 0 sessions to try
+1783499626.133826 key_bindings_add: 0x44 D = choose-client -Z
+1783499626.133828 cmd_find_best_session: 0 sessions to try
+1783499626.133831 cmdq_next <global>: [bind-key/0x58e4724c4930] (0), flags 0
+1783499626.133833 cmd_find_best_session: 0 sessions to try
+1783499626.133835 cmd_find_current_client: no target, return (nil)
+1783499626.133836 cmd_find_best_session: 0 sessions to try
+1783499626.133838 cmd_find_current_client: no target, return (nil)
+1783499626.133840 cmd_find_best_session: 0 sessions to try
+1783499626.133842 cmd_find_best_session: 0 sessions to try
+1783499626.133845 key_bindings_add: 0x45 E = select-layout -E
+1783499626.133850 cmd_find_best_session: 0 sessions to try
+1783499626.133855 cmdq_next <global>: [bind-key/0x58e4724c4f40] (0), flags 0
+1783499626.133857 cmd_find_best_session: 0 sessions to try
+1783499626.133859 cmd_find_current_client: no target, return (nil)
+1783499626.133860 cmd_find_best_session: 0 sessions to try
+1783499626.133862 cmd_find_current_client: no target, return (nil)
+1783499626.133864 cmd_find_best_session: 0 sessions to try
+1783499626.133866 cmd_find_best_session: 0 sessions to try
+1783499626.133869 key_bindings_add: 0x4c L = switch-client -l
+1783499626.133870 cmd_find_best_session: 0 sessions to try
+1783499626.133873 cmdq_next <global>: [bind-key/0x58e4724c51c0] (0), flags 0
+1783499626.133875 cmd_find_best_session: 0 sessions to try
+1783499626.133877 cmd_find_current_client: no target, return (nil)
+1783499626.133879 cmd_find_best_session: 0 sessions to try
+1783499626.133880 cmd_find_current_client: no target, return (nil)
+1783499626.133882 cmd_find_best_session: 0 sessions to try
+1783499626.133884 cmd_find_best_session: 0 sessions to try
+1783499626.133887 key_bindings_add: 0x4d M = select-pane -M
+1783499626.133889 cmd_find_best_session: 0 sessions to try
+1783499626.133892 cmdq_next <global>: [bind-key/0x58e4724c57f0] (0), flags 0
+1783499626.133893 cmd_find_best_session: 0 sessions to try
+1783499626.133895 cmd_find_current_client: no target, return (nil)
+1783499626.133897 cmd_find_best_session: 0 sessions to try
+1783499626.133899 cmd_find_current_client: no target, return (nil)
+1783499626.133901 cmd_find_best_session: 0 sessions to try
+1783499626.133902 cmd_find_best_session: 0 sessions to try
+1783499626.133906 key_bindings_add: 0x5b [ = copy-mode
+1783499626.133908 cmd_find_best_session: 0 sessions to try
+1783499626.133910 cmdq_next <global>: [bind-key/0x58e4724c6180] (0), flags 0
+1783499626.133912 cmd_find_best_session: 0 sessions to try
+1783499626.133914 cmd_find_current_client: no target, return (nil)
+1783499626.133915 cmd_find_best_session: 0 sessions to try
+1783499626.133917 cmd_find_current_client: no target, return (nil)
+1783499626.133919 cmd_find_best_session: 0 sessions to try
+1783499626.133921 cmd_find_best_session: 0 sessions to try
+1783499626.133924 key_bindings_add: 0x5d ] = paste-buffer -p
+1783499626.133926 cmd_find_best_session: 0 sessions to try
+1783499626.133929 cmdq_next <global>: [bind-key/0x58e4724c6580] (0), flags 0
+1783499626.133931 cmd_find_best_session: 0 sessions to try
+1783499626.133932 cmd_find_current_client: no target, return (nil)
+1783499626.133934 cmd_find_best_session: 0 sessions to try
+1783499626.133936 cmd_find_current_client: no target, return (nil)
+1783499626.133938 cmd_find_best_session: 0 sessions to try
+1783499626.133939 cmd_find_best_session: 0 sessions to try
+1783499626.133943 key_bindings_add: 0x63 c = new-window
+1783499626.133944 cmd_find_best_session: 0 sessions to try
+1783499626.133947 cmdq_next <global>: [bind-key/0x58e4724c6930] (0), flags 0
+1783499626.133949 cmd_find_best_session: 0 sessions to try
+1783499626.133951 cmd_find_current_client: no target, return (nil)
+1783499626.133953 cmd_find_best_session: 0 sessions to try
+1783499626.133954 cmd_find_current_client: no target, return (nil)
+1783499626.133956 cmd_find_best_session: 0 sessions to try
+1783499626.133958 cmd_find_best_session: 0 sessions to try
+1783499626.133961 key_bindings_add: 0x64 d = detach-client
+1783499626.133963 cmd_find_best_session: 0 sessions to try
+1783499626.133966 cmdq_next <global>: [bind-key/0x58e4724c78f0] (0), flags 0
+1783499626.133968 cmd_find_best_session: 0 sessions to try
+1783499626.133970 cmd_find_current_client: no target, return (nil)
+1783499626.133971 cmd_find_best_session: 0 sessions to try
+1783499626.133973 cmd_find_current_client: no target, return (nil)
+1783499626.133975 cmd_find_best_session: 0 sessions to try
+1783499626.133977 cmd_find_best_session: 0 sessions to try
+1783499626.133982 key_bindings_add: 0x66 f = command-prompt { find-window -Z "%%" }
+1783499626.133984 cmd_find_best_session: 0 sessions to try
+1783499626.133987 cmdq_next <global>: [bind-key/0x58e4724c6cb0] (0), flags 0
+1783499626.133991 cmd_find_best_session: 0 sessions to try
+1783499626.133993 cmd_find_current_client: no target, return (nil)
+1783499626.133995 cmd_find_best_session: 0 sessions to try
+1783499626.133997 cmd_find_current_client: no target, return (nil)
+1783499626.133998 cmd_find_best_session: 0 sessions to try
+1783499626.134000 cmd_find_best_session: 0 sessions to try
+1783499626.134003 key_bindings_add: 0x69 i = display-message
+1783499626.134010 cmd_find_best_session: 0 sessions to try
+1783499626.134016 cmdq_next <global>: [bind-key/0x58e4724c7e40] (0), flags 0
+1783499626.134018 cmd_find_best_session: 0 sessions to try
+1783499626.134020 cmd_find_current_client: no target, return (nil)
+1783499626.134022 cmd_find_best_session: 0 sessions to try
+1783499626.134023 cmd_find_current_client: no target, return (nil)
+1783499626.134025 cmd_find_best_session: 0 sessions to try
+1783499626.134027 cmd_find_best_session: 0 sessions to try
+1783499626.134030 key_bindings_add: 0x6c l = last-window
+1783499626.134032 cmd_find_best_session: 0 sessions to try
+1783499626.134035 cmdq_next <global>: [bind-key/0x58e4724c8550] (0), flags 0
+1783499626.134036 cmd_find_best_session: 0 sessions to try
+1783499626.134038 cmd_find_current_client: no target, return (nil)
+1783499626.134040 cmd_find_best_session: 0 sessions to try
+1783499626.134042 cmd_find_current_client: no target, return (nil)
+1783499626.134043 cmd_find_best_session: 0 sessions to try
+1783499626.134045 cmd_find_best_session: 0 sessions to try
+1783499626.134048 key_bindings_add: 0x6d m = select-pane -m
+1783499626.134050 cmd_find_best_session: 0 sessions to try
+1783499626.134053 cmdq_next <global>: [bind-key/0x58e4724c8760] (0), flags 0
+1783499626.134055 cmd_find_best_session: 0 sessions to try
+1783499626.134057 cmd_find_current_client: no target, return (nil)
+1783499626.134058 cmd_find_best_session: 0 sessions to try
+1783499626.134060 cmd_find_current_client: no target, return (nil)
+1783499626.134062 cmd_find_best_session: 0 sessions to try
+1783499626.134063 cmd_find_best_session: 0 sessions to try
+1783499626.134067 key_bindings_add: 0x6e n = next-window
+1783499626.134068 cmd_find_best_session: 0 sessions to try
+1783499626.134071 cmdq_next <global>: [bind-key/0x58e4724c8dc0] (0), flags 0
+1783499626.134072 cmd_find_best_session: 0 sessions to try
+1783499626.134074 cmd_find_current_client: no target, return (nil)
+1783499626.134076 cmd_find_best_session: 0 sessions to try
+1783499626.134078 cmd_find_current_client: no target, return (nil)
+1783499626.134080 cmd_find_best_session: 0 sessions to try
+1783499626.134081 cmd_find_best_session: 0 sessions to try
+1783499626.134085 key_bindings_add: 0x6f o = select-pane -t :.+
+1783499626.134087 cmd_find_best_session: 0 sessions to try
+1783499626.134090 cmdq_next <global>: [bind-key/0x58e4724c92c0] (0), flags 0
+1783499626.134091 cmd_find_best_session: 0 sessions to try
+1783499626.134093 cmd_find_current_client: no target, return (nil)
+1783499626.134095 cmd_find_best_session: 0 sessions to try
+1783499626.134097 cmd_find_current_client: no target, return (nil)
+1783499626.134098 cmd_find_best_session: 0 sessions to try
+1783499626.134100 cmd_find_best_session: 0 sessions to try
+1783499626.134108 key_bindings_add: 0x43 C = customize-mode -Z
+1783499626.134113 cmd_find_best_session: 0 sessions to try
+1783499626.134116 cmdq_next <global>: [bind-key/0x58e4724c9740] (0), flags 0
+1783499626.134118 cmd_find_best_session: 0 sessions to try
+1783499626.134120 cmd_find_current_client: no target, return (nil)
+1783499626.134121 cmd_find_best_session: 0 sessions to try
+1783499626.134123 cmd_find_current_client: no target, return (nil)
+1783499626.134125 cmd_find_best_session: 0 sessions to try
+1783499626.134126 cmd_find_best_session: 0 sessions to try
+1783499626.134131 key_bindings_add: 0x70 p = previous-window
+1783499626.134132 cmd_find_best_session: 0 sessions to try
+1783499626.134135 cmdq_next <global>: [bind-key/0x58e4724c9c20] (0), flags 0
+1783499626.134137 cmd_find_best_session: 0 sessions to try
+1783499626.134138 cmd_find_current_client: no target, return (nil)
+1783499626.134143 cmd_find_best_session: 0 sessions to try
+1783499626.134145 cmd_find_current_client: no target, return (nil)
+1783499626.134146 cmd_find_best_session: 0 sessions to try
+1783499626.134148 cmd_find_best_session: 0 sessions to try
+1783499626.134151 key_bindings_add: 0x71 q = display-panes
+1783499626.134153 cmd_find_best_session: 0 sessions to try
+1783499626.134156 cmdq_next <global>: [bind-key/0x58e4724ca230] (0), flags 0
+1783499626.134158 cmd_find_best_session: 0 sessions to try
+1783499626.134159 cmd_find_current_client: no target, return (nil)
+1783499626.134161 cmd_find_best_session: 0 sessions to try
+1783499626.134163 cmd_find_current_client: no target, return (nil)
+1783499626.134164 cmd_find_best_session: 0 sessions to try
+1783499626.134166 cmd_find_best_session: 0 sessions to try
+1783499626.134169 key_bindings_add: 0x72 r = refresh-client
+1783499626.134171 cmd_find_best_session: 0 sessions to try
+1783499626.134174 cmdq_next <global>: [bind-key/0x58e4724ca8d0] (0), flags 0
+1783499626.134176 cmd_find_best_session: 0 sessions to try
+1783499626.134177 cmd_find_current_client: no target, return (nil)
+1783499626.134179 cmd_find_best_session: 0 sessions to try
+1783499626.134181 cmd_find_current_client: no target, return (nil)
+1783499626.134183 cmd_find_best_session: 0 sessions to try
+1783499626.134184 cmd_find_best_session: 0 sessions to try
+1783499626.134188 key_bindings_add: 0x73 s = choose-tree -Zs
+1783499626.134189 cmd_find_best_session: 0 sessions to try
+1783499626.134192 cmdq_next <global>: [bind-key/0x58e4724caec0] (0), flags 0
+1783499626.134194 cmd_find_best_session: 0 sessions to try
+1783499626.134196 cmd_find_current_client: no target, return (nil)
+1783499626.134198 cmd_find_best_session: 0 sessions to try
+1783499626.134199 cmd_find_current_client: no target, return (nil)
+1783499626.134201 cmd_find_best_session: 0 sessions to try
+1783499626.134278 cmd_find_best_session: 0 sessions to try
+1783499626.134288 key_bindings_add: 0x74 t = clock-mode
+1783499626.134292 cmd_find_best_session: 0 sessions to try
+1783499626.134296 cmdq_next <global>: [bind-key/0x58e4724cb460] (0), flags 0
+1783499626.134299 cmd_find_best_session: 0 sessions to try
+1783499626.134301 cmd_find_current_client: no target, return (nil)
+1783499626.134303 cmd_find_best_session: 0 sessions to try
+1783499626.134305 cmd_find_current_client: no target, return (nil)
+1783499626.134307 cmd_find_best_session: 0 sessions to try
+1783499626.134309 cmd_find_best_session: 0 sessions to try
+1783499626.134314 key_bindings_add: 0x77 w = choose-tree -Zw
+1783499626.134316 cmd_find_best_session: 0 sessions to try
+1783499626.134319 cmdq_next <global>: [bind-key/0x58e4724cbf70] (0), flags 0
+1783499626.134321 cmd_find_best_session: 0 sessions to try
+1783499626.134323 cmd_find_current_client: no target, return (nil)
+1783499626.134325 cmd_find_best_session: 0 sessions to try
+1783499626.134327 cmd_find_current_client: no target, return (nil)
+1783499626.134329 cmd_find_best_session: 0 sessions to try
+1783499626.134331 cmd_find_best_session: 0 sessions to try
+1783499626.134337 key_bindings_add: 0x78 x = confirm-before -p "kill-pane #P? (y/n)" kill-pane
+1783499626.134339 cmd_find_best_session: 0 sessions to try
+1783499626.134342 cmdq_next <global>: [bind-key/0x58e4724cc3d0] (0), flags 0
+1783499626.134344 cmd_find_best_session: 0 sessions to try
+1783499626.134346 cmd_find_current_client: no target, return (nil)
+1783499626.134348 cmd_find_best_session: 0 sessions to try
+1783499626.134350 cmd_find_current_client: no target, return (nil)
+1783499626.134352 cmd_find_best_session: 0 sessions to try
+1783499626.134354 cmd_find_best_session: 0 sessions to try
+1783499626.134357 key_bindings_add: 0x7a z = resize-pane -Z
+1783499626.134359 cmd_find_best_session: 0 sessions to try
+1783499626.134362 cmdq_next <global>: [bind-key/0x58e4724cc950] (0), flags 0
+1783499626.134364 cmd_find_best_session: 0 sessions to try
+1783499626.134366 cmd_find_current_client: no target, return (nil)
+1783499626.134368 cmd_find_best_session: 0 sessions to try
+1783499626.134370 cmd_find_current_client: no target, return (nil)
+1783499626.134378 cmd_find_best_session: 0 sessions to try
+1783499626.134380 cmd_find_best_session: 0 sessions to try
+1783499626.134383 key_bindings_add: 0x7b { = swap-pane -U
+1783499626.134385 cmd_find_best_session: 0 sessions to try
+1783499626.134389 cmdq_next <global>: [bind-key/0x58e4724cd060] (0), flags 0
+1783499626.134391 cmd_find_best_session: 0 sessions to try
+1783499626.134393 cmd_find_current_client: no target, return (nil)
+1783499626.134394 cmd_find_best_session: 0 sessions to try
+1783499626.134396 cmd_find_current_client: no target, return (nil)
+1783499626.134398 cmd_find_best_session: 0 sessions to try
+1783499626.134400 cmd_find_best_session: 0 sessions to try
+1783499626.134403 key_bindings_add: 0x7d } = swap-pane -D
+1783499626.134405 cmd_find_best_session: 0 sessions to try
+1783499626.134408 cmdq_next <global>: [bind-key/0x58e4724cd4c0] (0), flags 0
+1783499626.134410 cmd_find_best_session: 0 sessions to try
+1783499626.134412 cmd_find_current_client: no target, return (nil)
+1783499626.134413 cmd_find_best_session: 0 sessions to try
+1783499626.134415 cmd_find_current_client: no target, return (nil)
+1783499626.134417 cmd_find_best_session: 0 sessions to try
+1783499626.134419 cmd_find_best_session: 0 sessions to try
+1783499626.134422 key_bindings_add: 0x7e ~ = show-messages
+1783499626.134424 cmd_find_best_session: 0 sessions to try
+1783499626.134427 cmdq_next <global>: [bind-key/0x58e4724cdc50] (0), flags 0
+1783499626.134429 cmd_find_best_session: 0 sessions to try
+1783499626.134431 cmd_find_current_client: no target, return (nil)
+1783499626.134433 cmd_find_best_session: 0 sessions to try
+1783499626.134434 cmd_find_current_client: no target, return (nil)
+1783499626.134436 cmd_find_best_session: 0 sessions to try
+1783499626.134438 cmd_find_best_session: 0 sessions to try
+1783499626.134442 key_bindings_add: 0x10e1a6 PPage = copy-mode -u
+1783499626.134444 cmd_find_best_session: 0 sessions to try
+1783499626.134446 cmdq_next <global>: [bind-key/0x58e4724ce280] (0), flags 0
+1783499626.134448 cmd_find_best_session: 0 sessions to try
+1783499626.134450 cmd_find_current_client: no target, return (nil)
+1783499626.134452 cmd_find_best_session: 0 sessions to try
+1783499626.134454 cmd_find_current_client: no target, return (nil)
+1783499626.134456 cmd_find_best_session: 0 sessions to try
+1783499626.134458 cmd_find_best_session: 0 sessions to try
+1783499626.134462 key_bindings_add: 0x10e1a8 Up = select-pane -U
+1783499626.134464 cmd_find_best_session: 0 sessions to try
+1783499626.134467 cmdq_next <global>: [bind-key/0x58e4724ceaa0] (0), flags 0
+1783499626.134469 cmd_find_best_session: 0 sessions to try
+1783499626.134471 cmd_find_current_client: no target, return (nil)
+1783499626.134473 cmd_find_best_session: 0 sessions to try
+1783499626.134475 cmd_find_current_client: no target, return (nil)
+1783499626.134477 cmd_find_best_session: 0 sessions to try
+1783499626.134478 cmd_find_best_session: 0 sessions to try
+1783499626.134482 key_bindings_add: 0x10e1a9 Down = select-pane -D
+1783499626.134484 cmd_find_best_session: 0 sessions to try
+1783499626.134487 cmdq_next <global>: [bind-key/0x58e4724cf3f0] (0), flags 0
+1783499626.134489 cmd_find_best_session: 0 sessions to try
+1783499626.134491 cmd_find_current_client: no target, return (nil)
+1783499626.134493 cmd_find_best_session: 0 sessions to try
+1783499626.134495 cmd_find_current_client: no target, return (nil)
+1783499626.134497 cmd_find_best_session: 0 sessions to try
+1783499626.134499 cmd_find_best_session: 0 sessions to try
+1783499626.134502 key_bindings_add: 0x10e1aa Left = select-pane -L
+1783499626.134504 cmd_find_best_session: 0 sessions to try
+1783499626.134507 cmdq_next <global>: [bind-key/0x58e4724cf8c0] (0), flags 0
+1783499626.134508 cmd_find_best_session: 0 sessions to try
+1783499626.134510 cmd_find_current_client: no target, return (nil)
+1783499626.134512 cmd_find_best_session: 0 sessions to try
+1783499626.134514 cmd_find_current_client: no target, return (nil)
+1783499626.134516 cmd_find_best_session: 0 sessions to try
+1783499626.134518 cmd_find_best_session: 0 sessions to try
+1783499626.134524 key_bindings_add: 0x10e1ab Right = select-pane -R
+1783499626.134527 cmd_find_best_session: 0 sessions to try
+1783499626.134530 cmdq_next <global>: [bind-key/0x58e4724cfef0] (0), flags 0
+1783499626.134532 cmd_find_best_session: 0 sessions to try
+1783499626.134533 cmd_find_current_client: no target, return (nil)
+1783499626.134535 cmd_find_best_session: 0 sessions to try
+1783499626.134537 cmd_find_current_client: no target, return (nil)
+1783499626.134539 cmd_find_best_session: 0 sessions to try
+1783499626.134541 cmd_find_best_session: 0 sessions to try
+1783499626.134546 key_bindings_add: 0x100000000031 M-1 = select-layout even-horizontal
+1783499626.134548 cmd_find_best_session: 0 sessions to try
+1783499626.134551 cmdq_next <global>: [bind-key/0x58e4724d0560] (0), flags 0
+1783499626.134553 cmd_find_best_session: 0 sessions to try
+1783499626.134555 cmd_find_current_client: no target, return (nil)
+1783499626.134556 cmd_find_best_session: 0 sessions to try
+1783499626.134558 cmd_find_current_client: no target, return (nil)
+1783499626.134560 cmd_find_best_session: 0 sessions to try
+1783499626.134562 cmd_find_best_session: 0 sessions to try
+1783499626.134566 key_bindings_add: 0x100000000032 M-2 = select-layout even-vertical
+1783499626.134568 cmd_find_best_session: 0 sessions to try
+1783499626.134571 cmdq_next <global>: [bind-key/0x58e4724d0b00] (0), flags 0
+1783499626.134573 cmd_find_best_session: 0 sessions to try
+1783499626.134575 cmd_find_current_client: no target, return (nil)
+1783499626.134576 cmd_find_best_session: 0 sessions to try
+1783499626.134578 cmd_find_current_client: no target, return (nil)
+1783499626.134580 cmd_find_best_session: 0 sessions to try
+1783499626.134582 cmd_find_best_session: 0 sessions to try
+1783499626.134586 key_bindings_add: 0x100000000033 M-3 = select-layout main-horizontal
+1783499626.134588 cmd_find_best_session: 0 sessions to try
+1783499626.134591 cmdq_next <global>: [bind-key/0x58e4724d0ee0] (0), flags 0
+1783499626.134593 cmd_find_best_session: 0 sessions to try
+1783499626.134595 cmd_find_current_client: no target, return (nil)
+1783499626.134597 cmd_find_best_session: 0 sessions to try
+1783499626.134599 cmd_find_current_client: no target, return (nil)
+1783499626.134601 cmd_find_best_session: 0 sessions to try
+1783499626.134602 cmd_find_best_session: 0 sessions to try
+1783499626.134607 key_bindings_add: 0x100000000034 M-4 = select-layout main-vertical
+1783499626.134609 cmd_find_best_session: 0 sessions to try
+1783499626.134612 cmdq_next <global>: [bind-key/0x58e4724d13f0] (0), flags 0
+1783499626.134614 cmd_find_best_session: 0 sessions to try
+1783499626.134615 cmd_find_current_client: no target, return (nil)
+1783499626.134617 cmd_find_best_session: 0 sessions to try
+1783499626.134619 cmd_find_current_client: no target, return (nil)
+1783499626.134621 cmd_find_best_session: 0 sessions to try
+1783499626.134623 cmd_find_best_session: 0 sessions to try
+1783499626.134627 key_bindings_add: 0x100000000035 M-5 = select-layout tiled
+1783499626.134629 cmd_find_best_session: 0 sessions to try
+1783499626.134632 cmdq_next <global>: [bind-key/0x58e4724d17e0] (0), flags 0
+1783499626.134634 cmd_find_best_session: 0 sessions to try
+1783499626.134636 cmd_find_current_client: no target, return (nil)
+1783499626.134638 cmd_find_best_session: 0 sessions to try
+1783499626.134640 cmd_find_current_client: no target, return (nil)
+1783499626.134641 cmd_find_best_session: 0 sessions to try
+1783499626.134643 cmd_find_best_session: 0 sessions to try
+1783499626.134647 key_bindings_add: 0x10000000006e M-n = next-window -a
+1783499626.134649 cmd_find_best_session: 0 sessions to try
+1783499626.134652 cmdq_next <global>: [bind-key/0x58e4724d1540] (0), flags 0
+1783499626.134653 cmd_find_best_session: 0 sessions to try
+1783499626.134655 cmd_find_current_client: no target, return (nil)
+1783499626.134657 cmd_find_best_session: 0 sessions to try
+1783499626.134659 cmd_find_current_client: no target, return (nil)
+1783499626.134661 cmd_find_best_session: 0 sessions to try
+1783499626.134665 cmd_find_best_session: 0 sessions to try
+1783499626.134669 key_bindings_add: 0x10000000006f M-o = rotate-window -D
+1783499626.134671 cmd_find_best_session: 0 sessions to try
+1783499626.134675 cmdq_next <global>: [bind-key/0x58e4724d2430] (0), flags 0
+1783499626.134677 cmd_find_best_session: 0 sessions to try
+1783499626.134678 cmd_find_current_client: no target, return (nil)
+1783499626.134680 cmd_find_best_session: 0 sessions to try
+1783499626.134682 cmd_find_current_client: no target, return (nil)
+1783499626.134684 cmd_find_best_session: 0 sessions to try
+1783499626.134686 cmd_find_best_session: 0 sessions to try
+1783499626.134689 key_bindings_add: 0x100000000070 M-p = previous-window -a
+1783499626.134691 cmd_find_best_session: 0 sessions to try
+1783499626.134695 cmdq_next <global>: [bind-key/0x58e4724d2e80] (0), flags 0
+1783499626.134697 cmd_find_best_session: 0 sessions to try
+1783499626.134698 cmd_find_current_client: no target, return (nil)
+1783499626.134700 cmd_find_best_session: 0 sessions to try
+1783499626.134702 cmd_find_current_client: no target, return (nil)
+1783499626.134704 cmd_find_best_session: 0 sessions to try
+1783499626.134705 cmd_find_best_session: 0 sessions to try
+1783499626.134711 key_bindings_add: 0x40000010e1a8 S-Up = refresh-client -U 10
+1783499626.134713 cmd_find_best_session: 0 sessions to try
+1783499626.134716 cmdq_next <global>: [bind-key/0x58e4724d35c0] (0), flags 0
+1783499626.134718 cmd_find_best_session: 0 sessions to try
+1783499626.134720 cmd_find_current_client: no target, return (nil)
+1783499626.134721 cmd_find_best_session: 0 sessions to try
+1783499626.134723 cmd_find_current_client: no target, return (nil)
+1783499626.134725 cmd_find_best_session: 0 sessions to try
+1783499626.134727 cmd_find_best_session: 0 sessions to try
+1783499626.134731 key_bindings_add: 0x40000010e1a9 S-Down = refresh-client -D 10
+1783499626.134733 cmd_find_best_session: 0 sessions to try
+1783499626.134736 cmdq_next <global>: [bind-key/0x58e4724d3cc0] (0), flags 0
+1783499626.134738 cmd_find_best_session: 0 sessions to try
+1783499626.134740 cmd_find_current_client: no target, return (nil)
+1783499626.134742 cmd_find_best_session: 0 sessions to try
+1783499626.134744 cmd_find_current_client: no target, return (nil)
+1783499626.134746 cmd_find_best_session: 0 sessions to try
+1783499626.134747 cmd_find_best_session: 0 sessions to try
+1783499626.134752 key_bindings_add: 0x40000010e1aa S-Left = refresh-client -L 10
+1783499626.134754 cmd_find_best_session: 0 sessions to try
+1783499626.134757 cmdq_next <global>: [bind-key/0x58e4724d45b0] (0), flags 0
+1783499626.134759 cmd_find_best_session: 0 sessions to try
+1783499626.134761 cmd_find_current_client: no target, return (nil)
+1783499626.134763 cmd_find_best_session: 0 sessions to try
+1783499626.134764 cmd_find_current_client: no target, return (nil)
+1783499626.134766 cmd_find_best_session: 0 sessions to try
+1783499626.134768 cmd_find_best_session: 0 sessions to try
+1783499626.134772 key_bindings_add: 0x40000010e1ab S-Right = refresh-client -R 10
+1783499626.134774 cmd_find_best_session: 0 sessions to try
+1783499626.134777 cmdq_next <global>: [bind-key/0x58e4724bbef0] (0), flags 0
+1783499626.134779 cmd_find_best_session: 0 sessions to try
+1783499626.134781 cmd_find_current_client: no target, return (nil)
+1783499626.134782 cmd_find_best_session: 0 sessions to try
+1783499626.134784 cmd_find_current_client: no target, return (nil)
+1783499626.134786 cmd_find_best_session: 0 sessions to try
+1783499626.134788 cmd_find_best_session: 0 sessions to try
+1783499626.134792 key_bindings_add: 0x10e1a2 DC = refresh-client -c
+1783499626.134793 cmd_find_best_session: 0 sessions to try
+1783499626.134796 cmdq_next <global>: [bind-key/0x58e4724d5200] (0), flags 0
+1783499626.134798 cmd_find_best_session: 0 sessions to try
+1783499626.134800 cmd_find_current_client: no target, return (nil)
+1783499626.134802 cmd_find_best_session: 0 sessions to try
+1783499626.134804 cmd_find_current_client: no target, return (nil)
+1783499626.134805 cmd_find_best_session: 0 sessions to try
+1783499626.134807 cmd_find_best_session: 0 sessions to try
+1783499626.134814 key_bindings_add: 0x10000010e1a8 M-Up = resize-pane -U 5
+1783499626.134816 cmd_find_best_session: 0 sessions to try
+1783499626.134819 cmdq_next <global>: [bind-key/0x58e4724d5850] (0), flags 0
+1783499626.134821 cmd_find_best_session: 0 sessions to try
+1783499626.134823 cmd_find_current_client: no target, return (nil)
+1783499626.134825 cmd_find_best_session: 0 sessions to try
+1783499626.134826 cmd_find_current_client: no target, return (nil)
+1783499626.134828 cmd_find_best_session: 0 sessions to try
+1783499626.134830 cmd_find_best_session: 0 sessions to try
+1783499626.134834 key_bindings_add: 0x10000010e1a9 M-Down = resize-pane -D 5
+1783499626.134836 cmd_find_best_session: 0 sessions to try
+1783499626.134839 cmdq_next <global>: [bind-key/0x58e4724d5e10] (0), flags 0
+1783499626.134841 cmd_find_best_session: 0 sessions to try
+1783499626.134843 cmd_find_current_client: no target, return (nil)
+1783499626.134844 cmd_find_best_session: 0 sessions to try
+1783499626.134846 cmd_find_current_client: no target, return (nil)
+1783499626.134848 cmd_find_best_session: 0 sessions to try
+1783499626.134850 cmd_find_best_session: 0 sessions to try
+1783499626.134854 key_bindings_add: 0x10000010e1aa M-Left = resize-pane -L 5
+1783499626.134856 cmd_find_best_session: 0 sessions to try
+1783499626.134859 cmdq_next <global>: [bind-key/0x58e4724d6460] (0), flags 0
+1783499626.134861 cmd_find_best_session: 0 sessions to try
+1783499626.134863 cmd_find_current_client: no target, return (nil)
+1783499626.134865 cmd_find_best_session: 0 sessions to try
+1783499626.134866 cmd_find_current_client: no target, return (nil)
+1783499626.134868 cmd_find_best_session: 0 sessions to try
+1783499626.134870 cmd_find_best_session: 0 sessions to try
+1783499626.134874 key_bindings_add: 0x10000010e1ab M-Right = resize-pane -R 5
+1783499626.134876 cmd_find_best_session: 0 sessions to try
+1783499626.134879 cmdq_next <global>: [bind-key/0x58e4724d61d0] (0), flags 0
+1783499626.134881 cmd_find_best_session: 0 sessions to try
+1783499626.134883 cmd_find_current_client: no target, return (nil)
+1783499626.134885 cmd_find_best_session: 0 sessions to try
+1783499626.134887 cmd_find_current_client: no target, return (nil)
+1783499626.134889 cmd_find_best_session: 0 sessions to try
+1783499626.134890 cmd_find_best_session: 0 sessions to try
+1783499626.134895 key_bindings_add: 0x20000010e1a8 C-Up = resize-pane -U
+1783499626.134897 cmd_find_best_session: 0 sessions to try
+1783499626.134899 cmdq_next <global>: [bind-key/0x58e4724d6a10] (0), flags 0
+1783499626.134901 cmd_find_best_session: 0 sessions to try
+1783499626.134903 cmd_find_current_client: no target, return (nil)
+1783499626.134905 cmd_find_best_session: 0 sessions to try
+1783499626.134907 cmd_find_current_client: no target, return (nil)
+1783499626.134909 cmd_find_best_session: 0 sessions to try
+1783499626.134910 cmd_find_best_session: 0 sessions to try
+1783499626.134915 key_bindings_add: 0x20000010e1a9 C-Down = resize-pane -D
+1783499626.134917 cmd_find_best_session: 0 sessions to try
+1783499626.134920 cmdq_next <global>: [bind-key/0x58e4724d6c40] (0), flags 0
+1783499626.134921 cmd_find_best_session: 0 sessions to try
+1783499626.134923 cmd_find_current_client: no target, return (nil)
+1783499626.134925 cmd_find_best_session: 0 sessions to try
+1783499626.134927 cmd_find_current_client: no target, return (nil)
+1783499626.134929 cmd_find_best_session: 0 sessions to try
+1783499626.134930 cmd_find_best_session: 0 sessions to try
+1783499626.134934 key_bindings_add: 0x20000010e1aa C-Left = resize-pane -L
+1783499626.134937 cmd_find_best_session: 0 sessions to try
+1783499626.134939 cmdq_next <global>: [bind-key/0x58e4724d6ef0] (0), flags 0
+1783499626.134941 cmd_find_best_session: 0 sessions to try
+1783499626.134943 cmd_find_current_client: no target, return (nil)
+1783499626.134945 cmd_find_best_session: 0 sessions to try
+1783499626.134946 cmd_find_current_client: no target, return (nil)
+1783499626.134948 cmd_find_best_session: 0 sessions to try
+1783499626.134950 cmd_find_best_session: 0 sessions to try
+1783499626.134957 key_bindings_add: 0x20000010e1ab C-Right = resize-pane -R
+1783499626.134959 cmd_find_best_session: 0 sessions to try
+1783499626.134962 cmdq_next <global>: [bind-key/0x58e4724dcae0] (0), flags 0
+1783499626.134964 cmd_find_best_session: 0 sessions to try
+1783499626.134966 cmd_find_current_client: no target, return (nil)
+1783499626.134968 cmd_find_best_session: 0 sessions to try
+1783499626.134970 cmd_find_current_client: no target, return (nil)
+1783499626.134971 cmd_find_best_session: 0 sessions to try
+1783499626.134973 cmd_find_best_session: 0 sessions to try
+1783499626.135058 key_bindings_add: 0x3c < = display-menu -T "#[align=centre]#{window_index}:#{window_name}" -x W -y W "#{?#{>:#{session_windows},1},,-}Swap Left" l { swap-window -t :-1 } "#{?#{>:#{session_windows},1},,-}Swap Right" r { swap-window -t :+1 } "#{?pane_marked_set,,-}Swap Marked" s { swap-window } '' Kill X { kill-window } Respawn R { respawn-window -k } "#{?pane_marked,Unmark,Mark}" m { select-pane -m } Rename n { command-prompt -F -I "#W" { rename-window -t "#{window_id}" "%%" } } '' "New After" w { new-window -a } "New At End" W { new-window }
+1783499626.135062 cmd_find_best_session: 0 sessions to try
+1783499626.135065 cmdq_next <global>: [bind-key/0x58e4724d66a0] (0), flags 0
+1783499626.135067 cmd_find_best_session: 0 sessions to try
+1783499626.135068 cmd_find_current_client: no target, return (nil)
+1783499626.135070 cmd_find_best_session: 0 sessions to try
+1783499626.135072 cmd_find_current_client: no target, return (nil)
+1783499626.135074 cmd_find_best_session: 0 sessions to try
+1783499626.135076 cmd_find_best_session: 0 sessions to try
+1783499626.135168 key_bindings_add: 0x3e > = display-menu -T "#[align=centre]#{pane_index} (#{pane_id})" -x P -y P "#{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,}" < { send-keys -X history-top } "#{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Bottom,}" > { send-keys -X history-bottom } '' "#{?mouse_word,Search For #[underscore]#{=/9/...:mouse_word},}" C-r { if-shell -F "#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}" "copy-mode -t=" ; send-keys -X -t = search-backward "#{q:mouse_word}" } "#{?mouse_word,Type #[underscore]#{=/9/...:mouse_word},}" C-y { copy-mode -q ; send-keys -l "#{q:mouse_word}" } "#{?mouse_word,Copy #[underscore]#{=/9/...:mouse_word},}" c { copy-mode -q ; set-buffer "#{q:mouse_word}" } "#{?mouse_line,Copy Line,}" l { copy-mode -q ; set-buffer "#{q:mouse_line}" } '' "#{?mouse_hyperlink,Type #[underscore]#{=/9/...:mouse_hyperlink},}" C-h { copy-mode -q ; send-keys -l "#{q:mouse_hyperlink}" } "#{?mouse_hyperlink,Copy #[underscore]#{=/9/...:mouse_hyperlink},}" h { copy-mode -q ; set-buffer "#{q:mouse_hyperlink}" } '' "Horizontal Split" h { split-window -h } "Vertical Split" v { split-window -v } '' "#{?#{>:#{window_panes},1},,-}Swap Up" u { swap-pane -U } "#{?#{>:#{window_panes},1},,-}Swap Down" d { swap-pane -D } "#{?pane_marked_set,,-}Swap Marked" s { swap-pane } '' Kill X { kill-pane } Respawn R { respawn-pane -k } "#{?pane_marked,Unmark,Mark}" m { select-pane -m } "#{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom}" z { resize-pane -Z }
+1783499626.135172 cmd_find_best_session: 0 sessions to try
+1783499626.135174 cmdq_next <global>: [bind-key/0x58e4724d8540] (0), flags 0
+1783499626.135176 cmd_find_best_session: 0 sessions to try
+1783499626.135178 cmd_find_current_client: no target, return (nil)
+1783499626.135180 cmd_find_best_session: 0 sessions to try
+1783499626.135182 cmd_find_current_client: no target, return (nil)
+1783499626.135184 cmd_find_best_session: 0 sessions to try
+1783499626.135186 cmd_find_best_session: 0 sessions to try
+1783499626.135191 key_bindings_add: 0x10e00e MouseDown1Pane = select-pane -t = ; send-keys -M
+1783499626.135193 cmd_find_best_session: 0 sessions to try
+1783499626.135196 cmdq_next <global>: [bind-key/0x58e4724e0610] (0), flags 0
+1783499626.135198 cmd_find_best_session: 0 sessions to try
+1783499626.135200 cmd_find_current_client: no target, return (nil)
+1783499626.135201 cmd_find_best_session: 0 sessions to try
+1783499626.135203 cmd_find_current_client: no target, return (nil)
+1783499626.135214 cmd_find_best_session: 0 sessions to try
+1783499626.135216 cmd_find_best_session: 0 sessions to try
+1783499626.135228 key_bindings_add: 0x10e07a MouseDrag1Pane = if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" { send-keys -M } { copy-mode -M }
+1783499626.135230 cmd_find_best_session: 0 sessions to try
+1783499626.135234 cmdq_next <global>: [bind-key/0x58e4724d7fd0] (0), flags 0
+1783499626.135236 cmd_find_best_session: 0 sessions to try
+1783499626.135238 cmd_find_current_client: no target, return (nil)
+1783499626.135239 cmd_find_best_session: 0 sessions to try
+1783499626.135241 cmd_find_current_client: no target, return (nil)
+1783499626.135243 cmd_find_best_session: 0 sessions to try
+1783499626.135245 cmd_find_best_session: 0 sessions to try
+1783499626.135305 key_bindings_add: 0x10e0e6 WheelUpPane = if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" { send-keys -M } { copy-mode -e }
+1783499626.135314 cmd_find_best_session: 0 sessions to try
+1783499626.135319 cmdq_next <global>: [bind-key/0x58e4724e7000] (0), flags 0
+1783499626.135322 cmd_find_best_session: 0 sessions to try
+1783499626.135324 cmd_find_current_client: no target, return (nil)
+1783499626.135326 cmd_find_best_session: 0 sessions to try
+1783499626.135328 cmd_find_current_client: no target, return (nil)
+1783499626.135330 cmd_find_best_session: 0 sessions to try
+1783499626.135332 cmd_find_best_session: 0 sessions to try
+1783499626.135344 key_bindings_add: 0x10e014 MouseDown2Pane = select-pane -t = ; if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" { send-keys -M } { paste-buffer -p }
+1783499626.135346 cmd_find_best_session: 0 sessions to try
+1783499626.135349 cmdq_next <global>: [bind-key/0x58e4724e9290] (0), flags 0
+1783499626.135351 cmd_find_best_session: 0 sessions to try
+1783499626.135353 cmd_find_current_client: no target, return (nil)
+1783499626.135355 cmd_find_best_session: 0 sessions to try
+1783499626.135357 cmd_find_current_client: no target, return (nil)
+1783499626.135359 cmd_find_best_session: 0 sessions to try
+1783499626.135361 cmd_find_best_session: 0 sessions to try
+1783499626.135381 key_bindings_add: 0x10e128 DoubleClick1Pane = select-pane -t = ; if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" { send-keys -M } { copy-mode -H ; send-keys -X select-word ; run-shell -d 0.3 ; send-keys -X copy-pipe-and-cancel }
+1783499626.135383 cmd_find_best_session: 0 sessions to try
+1783499626.135386 cmdq_next <global>: [bind-key/0x58e4724ea530] (0), flags 0
+1783499626.135389 cmd_find_best_session: 0 sessions to try
+1783499626.135391 cmd_find_current_client: no target, return (nil)
+1783499626.135392 cmd_find_best_session: 0 sessions to try
+1783499626.135394 cmd_find_current_client: no target, return (nil)
+1783499626.135396 cmd_find_best_session: 0 sessions to try
+1783499626.135398 cmd_find_best_session: 0 sessions to try
+1783499626.135416 key_bindings_add: 0x10e15e TripleClick1Pane = select-pane -t = ; if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" { send-keys -M } { copy-mode -H ; send-keys -X select-line ; run-shell -d 0.3 ; send-keys -X copy-pipe-and-cancel }
+1783499626.135418 cmd_find_best_session: 0 sessions to try
+1783499626.135422 cmdq_next <global>: [bind-key/0x58e4724e99a0] (0), flags 0
+1783499626.135424 cmd_find_best_session: 0 sessions to try
+1783499626.135426 cmd_find_current_client: no target, return (nil)
+1783499626.135427 cmd_find_best_session: 0 sessions to try
+1783499626.135430 cmd_find_current_client: no target, return (nil)
+1783499626.135431 cmd_find_best_session: 0 sessions to try
+1783499626.135433 cmd_find_best_session: 0 sessions to try
+1783499626.135438 key_bindings_add: 0x10e07f MouseDrag1Border = resize-pane -M
+1783499626.135440 cmd_find_best_session: 0 sessions to try
+1783499626.135444 cmdq_next <global>: [bind-key/0x58e4724d2270] (0), flags 0
+1783499626.135446 cmd_find_best_session: 0 sessions to try
+1783499626.135448 cmd_find_current_client: no target, return (nil)
+1783499626.135449 cmd_find_best_session: 0 sessions to try
+1783499626.135452 cmd_find_current_client: no target, return (nil)
+1783499626.135460 cmd_find_best_session: 0 sessions to try
+1783499626.135462 cmd_find_best_session: 0 sessions to try
+1783499626.135467 key_bindings_add: 0x10e00f MouseDown1Status = select-window -t =
+1783499626.135469 cmd_find_best_session: 0 sessions to try
+1783499626.135472 cmdq_next <global>: [bind-key/0x58e4724e1590] (0), flags 0
+1783499626.135474 cmd_find_best_session: 0 sessions to try
+1783499626.135476 cmd_find_current_client: no target, return (nil)
+1783499626.135478 cmd_find_best_session: 0 sessions to try
+1783499626.135480 cmd_find_current_client: no target, return (nil)
+1783499626.135481 cmd_find_best_session: 0 sessions to try
+1783499626.135483 cmd_find_best_session: 0 sessions to try
+1783499626.135488 key_bindings_add: 0x10e0ed WheelDownStatus = next-window
+1783499626.135490 cmd_find_best_session: 0 sessions to try
+1783499626.135493 cmdq_next <global>: [bind-key/0x58e4724e8f50] (0), flags 0
+1783499626.135495 cmd_find_best_session: 0 sessions to try
+1783499626.135496 cmd_find_current_client: no target, return (nil)
+1783499626.135498 cmd_find_best_session: 0 sessions to try
+1783499626.135500 cmd_find_current_client: no target, return (nil)
+1783499626.135502 cmd_find_best_session: 0 sessions to try
+1783499626.135504 cmd_find_best_session: 0 sessions to try
+1783499626.135509 key_bindings_add: 0x10e0e7 WheelUpStatus = previous-window
+1783499626.135511 cmd_find_best_session: 0 sessions to try
+1783499626.135514 cmdq_next <global>: [bind-key/0x58e4724ed6e0] (0), flags 0
+1783499626.135516 cmd_find_best_session: 0 sessions to try
+1783499626.135518 cmd_find_current_client: no target, return (nil)
+1783499626.135519 cmd_find_best_session: 0 sessions to try
+1783499626.135521 cmd_find_current_client: no target, return (nil)
+1783499626.135523 cmd_find_best_session: 0 sessions to try
+1783499626.135525 cmd_find_best_session: 0 sessions to try
+1783499626.135563 key_bindings_add: 0x10e01c MouseDown3StatusLeft = display-menu -T "#[align=centre]#{session_name}" -t = -x M -y W Next n { switch-client -n } Previous p { switch-client -p } '' Renumber N { move-window -r } Rename n { command-prompt -I "#S" { rename-session "%%" } } '' "New Session" s { new-session } "New Window" w { new-window }
+1783499626.135565 cmd_find_best_session: 0 sessions to try
+1783499626.135568 cmdq_next <global>: [bind-key/0x58e4724eedf0] (0), flags 0
+1783499626.135570 cmd_find_best_session: 0 sessions to try
+1783499626.135572 cmd_find_current_client: no target, return (nil)
+1783499626.135574 cmd_find_best_session: 0 sessions to try
+1783499626.135576 cmd_find_current_client: no target, return (nil)
+1783499626.135578 cmd_find_best_session: 0 sessions to try
+1783499626.135579 cmd_find_best_session: 0 sessions to try
+1783499626.135606 key_bindings_add: 0x10000010e01c M-MouseDown3StatusLeft = display-menu -T "#[align=centre]#{session_name}" -t = -x M -y W Next n { switch-client -n } Previous p { switch-client -p } '' Renumber N { move-window -r } Rename n { command-prompt -I "#S" { rename-session "%%" } } '' "New Session" s { new-session } "New Window" w { new-window }
+1783499626.135609 cmd_find_best_session: 0 sessions to try
+1783499626.135611 cmdq_next <global>: [bind-key/0x58e4724f0620] (0), flags 0
+1783499626.135613 cmd_find_best_session: 0 sessions to try
+1783499626.135615 cmd_find_current_client: no target, return (nil)
+1783499626.135617 cmd_find_best_session: 0 sessions to try
+1783499626.135618 cmd_find_current_client: no target, return (nil)
+1783499626.135620 cmd_find_best_session: 0 sessions to try
+1783499626.135622 cmd_find_best_session: 0 sessions to try
+1783499626.135664 key_bindings_add: 0x10e01b MouseDown3Status = display-menu -T "#[align=centre]#{window_index}:#{window_name}" -t = -x W -y W "#{?#{>:#{session_windows},1},,-}Swap Left" l { swap-window -t :-1 } "#{?#{>:#{session_windows},1},,-}Swap Right" r { swap-window -t :+1 } "#{?pane_marked_set,,-}Swap Marked" s { swap-window } '' Kill X { kill-window } Respawn R { respawn-window -k } "#{?pane_marked,Unmark,Mark}" m { select-pane -m } Rename n { command-prompt -F -I "#W" { rename-window -t "#{window_id}" "%%" } } '' "New After" w { new-window -a } "New At End" W { new-window }
+1783499626.135670 cmd_find_best_session: 0 sessions to try
+1783499626.135673 cmdq_next <global>: [bind-key/0x58e4724f5740] (0), flags 0
+1783499626.135675 cmd_find_best_session: 0 sessions to try
+1783499626.135677 cmd_find_current_client: no target, return (nil)
+1783499626.135679 cmd_find_best_session: 0 sessions to try
+1783499626.135681 cmd_find_current_client: no target, return (nil)
+1783499626.135683 cmd_find_best_session: 0 sessions to try
+1783499626.135684 cmd_find_best_session: 0 sessions to try
+1783499626.135721 key_bindings_add: 0x10000010e01b M-MouseDown3Status = display-menu -T "#[align=centre]#{window_index}:#{window_name}" -t = -x W -y W "#{?#{>:#{session_windows},1},,-}Swap Left" l { swap-window -t :-1 } "#{?#{>:#{session_windows},1},,-}Swap Right" r { swap-window -t :+1 } "#{?pane_marked_set,,-}Swap Marked" s { swap-window } '' Kill X { kill-window } Respawn R { respawn-window -k } "#{?pane_marked,Unmark,Mark}" m { select-pane -m } Rename n { command-prompt -F -I "#W" { rename-window -t "#{window_id}" "%%" } } '' "New After" w { new-window -a } "New At End" W { new-window }
+1783499626.135724 cmd_find_best_session: 0 sessions to try
+1783499626.135727 cmdq_next <global>: [bind-key/0x58e4724f8000] (0), flags 0
+1783499626.135729 cmd_find_best_session: 0 sessions to try
+1783499626.135730 cmd_find_current_client: no target, return (nil)
+1783499626.135732 cmd_find_best_session: 0 sessions to try
+1783499626.135734 cmd_find_current_client: no target, return (nil)
+1783499626.135736 cmd_find_best_session: 0 sessions to try
+1783499626.135738 cmd_find_best_session: 0 sessions to try
+1783499626.135837 key_bindings_add: 0x10e01a MouseDown3Pane = if-shell -F -t = "#{||:#{mouse_any_flag},#{&&:#{pane_in_mode},#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}}}" { select-pane -t = ; send-keys -M } { display-menu -T "#[align=centre]#{pane_index} (#{pane_id})" -t = -x M -y M "#{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,}" < { send-keys -X history-top } "#{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Bottom,}" > { send-keys -X history-bottom } '' "#{?mouse_word,Search For #[underscore]#{=/9/...:mouse_word},}" C-r { if-shell -F "#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}" "copy-mode -t=" ; send-keys -X -t = search-backward "#{q:mouse_word}" } "#{?mouse_word,Type #[underscore]#{=/9/...:mouse_word},}" C-y { copy-mode -q ; send-keys -l "#{q:mouse_word}" } "#{?mouse_word,Copy #[underscore]#{=/9/...:mouse_word},}" c { copy-mode -q ; set-buffer "#{q:mouse_word}" } "#{?mouse_line,Copy Line,}" l { copy-mode -q ; set-buffer "#{q:mouse_line}" } '' "#{?mouse_hyperlink,Type #[underscore]#{=/9/...:mouse_hyperlink},}" C-h { copy-mode -q ; send-keys -l "#{q:mouse_hyperlink}" } "#{?mouse_hyperlink,Copy #[underscore]#{=/9/...:mouse_hyperlink},}" h { copy-mode -q ; set-buffer "#{q:mouse_hyperlink}" } '' "Horizontal Split" h { split-window -h } "Vertical Split" v { split-window -v } '' "#{?#{>:#{window_panes},1},,-}Swap Up" u { swap-pane -U } "#{?#{>:#{window_panes},1},,-}Swap Down" d { swap-pane -D } "#{?pane_marked_set,,-}Swap Marked" s { swap-pane } '' Kill X { kill-pane } Respawn R { respawn-pane -k } "#{?pane_marked,Unmark,Mark}" m { select-pane -m } "#{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom}" z { resize-pane -Z } }
+1783499626.135841 cmd_find_best_session: 0 sessions to try
+1783499626.135844 cmdq_next <global>: [bind-key/0x58e4724e0b40] (0), flags 0
+1783499626.135846 cmd_find_best_session: 0 sessions to try
+1783499626.135848 cmd_find_current_client: no target, return (nil)
+1783499626.135850 cmd_find_best_session: 0 sessions to try
+1783499626.135852 cmd_find_current_client: no target, return (nil)
+1783499626.135853 cmd_find_best_session: 0 sessions to try
+1783499626.135855 cmd_find_best_session: 0 sessions to try
+1783499626.135955 key_bindings_add: 0x10000010e01a M-MouseDown3Pane = display-menu -T "#[align=centre]#{pane_index} (#{pane_id})" -t = -x M -y M "#{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Top,}" < { send-keys -X history-top } "#{?#{m/r:(copy|view)-mode,#{pane_mode}},Go To Bottom,}" > { send-keys -X history-bottom } '' "#{?mouse_word,Search For #[underscore]#{=/9/...:mouse_word},}" C-r { if-shell -F "#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}" "copy-mode -t=" ; send-keys -X -t = search-backward "#{q:mouse_word}" } "#{?mouse_word,Type #[underscore]#{=/9/...:mouse_word},}" C-y { copy-mode -q ; send-keys -l "#{q:mouse_word}" } "#{?mouse_word,Copy #[underscore]#{=/9/...:mouse_word},}" c { copy-mode -q ; set-buffer "#{q:mouse_word}" } "#{?mouse_line,Copy Line,}" l { copy-mode -q ; set-buffer "#{q:mouse_line}" } '' "#{?mouse_hyperlink,Type #[underscore]#{=/9/...:mouse_hyperlink},}" C-h { copy-mode -q ; send-keys -l "#{q:mouse_hyperlink}" } "#{?mouse_hyperlink,Copy #[underscore]#{=/9/...:mouse_hyperlink},}" h { copy-mode -q ; set-buffer "#{q:mouse_hyperlink}" } '' "Horizontal Split" h { split-window -h } "Vertical Split" v { split-window -v } '' "#{?#{>:#{window_panes},1},,-}Swap Up" u { swap-pane -U } "#{?#{>:#{window_panes},1},,-}Swap Down" d { swap-pane -D } "#{?pane_marked_set,,-}Swap Marked" s { swap-pane } '' Kill X { kill-pane } Respawn R { respawn-pane -k } "#{?pane_marked,Unmark,Mark}" m { select-pane -m } "#{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom}" z { resize-pane -Z }
+1783499626.135972 cmd_find_best_session: 0 sessions to try
+1783499626.135978 cmdq_next <global>: [bind-key/0x58e4724f8560] (0), flags 0
+1783499626.135985 cmd_find_best_session: 0 sessions to try
+1783499626.135987 cmd_find_current_client: no target, return (nil)
+1783499626.135992 cmd_find_best_session: 0 sessions to try
+1783499626.135996 cmd_find_current_client: no target, return (nil)
+1783499626.135998 cmd_find_best_session: 0 sessions to try
+1783499626.136002 cmd_find_best_session: 0 sessions to try
+1783499626.136014 key_bindings_add: 0 C-Space = send-keys -X begin-selection
+1783499626.136019 cmd_find_best_session: 0 sessions to try
+1783499626.136022 cmdq_next <global>: [bind-key/0x58e4724ffce0] (0), flags 0
+1783499626.136027 cmd_find_best_session: 0 sessions to try
+1783499626.136031 cmd_find_current_client: no target, return (nil)
+1783499626.136033 cmd_find_best_session: 0 sessions to try
+1783499626.136038 cmd_find_current_client: no target, return (nil)
+1783499626.136043 cmd_find_best_session: 0 sessions to try
+1783499626.136044 cmd_find_best_session: 0 sessions to try
+1783499626.136054 key_bindings_add: 0x1 C-a = send-keys -X start-of-line
+1783499626.136062 cmd_find_best_session: 0 sessions to try
+1783499626.136068 cmdq_next <global>: [bind-key/0x58e4724f8cd0] (0), flags 0
+1783499626.136070 cmd_find_best_session: 0 sessions to try
+1783499626.136072 cmd_find_current_client: no target, return (nil)
+1783499626.136079 cmd_find_best_session: 0 sessions to try
+1783499626.136081 cmd_find_current_client: no target, return (nil)
+1783499626.136083 cmd_find_best_session: 0 sessions to try
+1783499626.136085 cmd_find_best_session: 0 sessions to try
+1783499626.136093 key_bindings_add: 0x3 C-c = send-keys -X cancel
+1783499626.136098 cmd_find_best_session: 0 sessions to try
+1783499626.136104 cmdq_next <global>: [bind-key/0x58e4724f0410] (0), flags 0
+1783499626.136109 cmd_find_best_session: 0 sessions to try
+1783499626.136111 cmd_find_current_client: no target, return (nil)
+1783499626.136112 cmd_find_best_session: 0 sessions to try
+1783499626.136114 cmd_find_current_client: no target, return (nil)
+1783499626.136116 cmd_find_best_session: 0 sessions to try
+1783499626.136118 cmd_find_best_session: 0 sessions to try
+1783499626.136127 key_bindings_add: 0x5 C-e = send-keys -X end-of-line
+1783499626.136132 cmd_find_best_session: 0 sessions to try
+1783499626.136138 cmdq_next <global>: [bind-key/0x58e4725000a0] (0), flags 0
+1783499626.136143 cmd_find_best_session: 0 sessions to try
+1783499626.136144 cmd_find_current_client: no target, return (nil)
+1783499626.136146 cmd_find_best_session: 0 sessions to try
+1783499626.136148 cmd_find_current_client: no target, return (nil)
+1783499626.136150 cmd_find_best_session: 0 sessions to try
+1783499626.136155 cmd_find_best_session: 0 sessions to try
+1783499626.136161 key_bindings_add: 0x6 C-f = send-keys -X cursor-right
+1783499626.136163 cmd_find_best_session: 0 sessions to try
+1783499626.136166 cmdq_next <global>: [bind-key/0x58e472500e70] (0), flags 0
+1783499626.136168 cmd_find_best_session: 0 sessions to try
+1783499626.136170 cmd_find_current_client: no target, return (nil)
+1783499626.136171 cmd_find_best_session: 0 sessions to try
+1783499626.136173 cmd_find_current_client: no target, return (nil)
+1783499626.136175 cmd_find_best_session: 0 sessions to try
+1783499626.136177 cmd_find_best_session: 0 sessions to try
+1783499626.136181 key_bindings_add: 0x2 C-b = send-keys -X cursor-left
+1783499626.136183 cmd_find_best_session: 0 sessions to try
+1783499626.136186 cmdq_next <global>: [bind-key/0x58e4724ff2a0] (0), flags 0
+1783499626.136189 cmd_find_best_session: 0 sessions to try
+1783499626.136191 cmd_find_current_client: no target, return (nil)
+1783499626.136193 cmd_find_best_session: 0 sessions to try
+1783499626.136195 cmd_find_current_client: no target, return (nil)
+1783499626.136196 cmd_find_best_session: 0 sessions to try
+1783499626.136198 cmd_find_best_session: 0 sessions to try
+1783499626.136203 key_bindings_add: 0x7 C-g = send-keys -X clear-selection
+1783499626.136205 cmd_find_best_session: 0 sessions to try
+1783499626.136208 cmdq_next <global>: [bind-key/0x58e472500f70] (0), flags 0
+1783499626.136210 cmd_find_best_session: 0 sessions to try
+1783499626.136212 cmd_find_current_client: no target, return (nil)
+1783499626.136213 cmd_find_best_session: 0 sessions to try
+1783499626.136215 cmd_find_current_client: no target, return (nil)
+1783499626.136217 cmd_find_best_session: 0 sessions to try
+1783499626.136219 cmd_find_best_session: 0 sessions to try
+1783499626.136224 key_bindings_add: 0xb C-k = send-keys -X copy-pipe-end-of-line-and-cancel
+1783499626.136226 cmd_find_best_session: 0 sessions to try
+1783499626.136229 cmdq_next <global>: [bind-key/0x58e472504b90] (0), flags 0
+1783499626.136255 cmd_find_best_session: 0 sessions to try
+1783499626.136263 cmd_find_current_client: no target, return (nil)
+1783499626.136266 cmd_find_best_session: 0 sessions to try
+1783499626.136269 cmd_find_current_client: no target, return (nil)
+1783499626.136271 cmd_find_best_session: 0 sessions to try
+1783499626.136273 cmd_find_best_session: 0 sessions to try
+1783499626.136280 key_bindings_add: 0xe C-n = send-keys -X cursor-down
+1783499626.136283 cmd_find_best_session: 0 sessions to try
+1783499626.136286 cmdq_next <global>: [bind-key/0x58e472505120] (0), flags 0
+1783499626.136288 cmd_find_best_session: 0 sessions to try
+1783499626.136291 cmd_find_current_client: no target, return (nil)
+1783499626.136293 cmd_find_best_session: 0 sessions to try
+1783499626.136295 cmd_find_current_client: no target, return (nil)
+1783499626.136297 cmd_find_best_session: 0 sessions to try
+1783499626.136299 cmd_find_best_session: 0 sessions to try
+1783499626.136304 key_bindings_add: 0x10 C-p = send-keys -X cursor-up
+1783499626.136306 cmd_find_best_session: 0 sessions to try
+1783499626.136310 cmdq_next <global>: [bind-key/0x58e472506120] (0), flags 0
+1783499626.136312 cmd_find_best_session: 0 sessions to try
+1783499626.136314 cmd_find_current_client: no target, return (nil)
+1783499626.136316 cmd_find_best_session: 0 sessions to try
+1783499626.136318 cmd_find_current_client: no target, return (nil)
+1783499626.136320 cmd_find_best_session: 0 sessions to try
+1783499626.136322 cmd_find_best_session: 0 sessions to try
+1783499626.136338 key_bindings_add: 0x12 C-r = command-prompt -i -I "#{pane_search_string}" -T search -p "(search up)" { send-keys -X search-backward-incremental "%%" }
+1783499626.136345 cmd_find_best_session: 0 sessions to try
+1783499626.136349 cmdq_next <global>: [bind-key/0x58e472506920] (0), flags 0
+1783499626.136351 cmd_find_best_session: 0 sessions to try
+1783499626.136353 cmd_find_current_client: no target, return (nil)
+1783499626.136355 cmd_find_best_session: 0 sessions to try
+1783499626.136357 cmd_find_current_client: no target, return (nil)
+1783499626.136366 cmd_find_best_session: 0 sessions to try
+1783499626.136368 cmd_find_best_session: 0 sessions to try
+1783499626.136384 key_bindings_add: 0x13 C-s = command-prompt -i -I "#{pane_search_string}" -T search -p "(search down)" { send-keys -X search-forward-incremental "%%" }
+1783499626.136390 cmd_find_best_session: 0 sessions to try
+1783499626.136393 cmdq_next <global>: [bind-key/0x58e4725075c0] (0), flags 0
+1783499626.136395 cmd_find_best_session: 0 sessions to try
+1783499626.136397 cmd_find_current_client: no target, return (nil)
+1783499626.136399 cmd_find_best_session: 0 sessions to try
+1783499626.136401 cmd_find_current_client: no target, return (nil)
+1783499626.136403 cmd_find_best_session: 0 sessions to try
+1783499626.136405 cmd_find_best_session: 0 sessions to try
+1783499626.136410 key_bindings_add: 0x16 C-v = send-keys -X page-down
+1783499626.136412 cmd_find_best_session: 0 sessions to try
+1783499626.136415 cmdq_next <global>: [bind-key/0x58e4725079f0] (0), flags 0
+1783499626.136417 cmd_find_best_session: 0 sessions to try
+1783499626.136419 cmd_find_current_client: no target, return (nil)
+1783499626.136421 cmd_find_best_session: 0 sessions to try
+1783499626.136423 cmd_find_current_client: no target, return (nil)
+1783499626.136424 cmd_find_best_session: 0 sessions to try
+1783499626.136426 cmd_find_best_session: 0 sessions to try
+1783499626.136432 key_bindings_add: 0x17 C-w = send-keys -X copy-pipe-and-cancel
+1783499626.136434 cmd_find_best_session: 0 sessions to try
+1783499626.136437 cmdq_next <global>: [bind-key/0x58e472507e20] (0), flags 0
+1783499626.136439 cmd_find_best_session: 0 sessions to try
+1783499626.136441 cmd_find_current_client: no target, return (nil)
+1783499626.136443 cmd_find_best_session: 0 sessions to try
+1783499626.136445 cmd_find_current_client: no target, return (nil)
+1783499626.136447 cmd_find_best_session: 0 sessions to try
+1783499626.136448 cmd_find_best_session: 0 sessions to try
+1783499626.136453 key_bindings_add: 0x1b Escape = send-keys -X cancel
+1783499626.136455 cmd_find_best_session: 0 sessions to try
+1783499626.136458 cmdq_next <global>: [bind-key/0x58e4725083e0] (0), flags 0
+1783499626.136460 cmd_find_best_session: 0 sessions to try
+1783499626.136462 cmd_find_current_client: no target, return (nil)
+1783499626.136464 cmd_find_best_session: 0 sessions to try
+1783499626.136466 cmd_find_current_client: no target, return (nil)
+1783499626.136468 cmd_find_best_session: 0 sessions to try
+1783499626.136470 cmd_find_best_session: 0 sessions to try
+1783499626.136474 key_bindings_add: 0x20 Space = send-keys -X page-down
+1783499626.136476 cmd_find_best_session: 0 sessions to try
+1783499626.136479 cmdq_next <global>: [bind-key/0x58e472508850] (0), flags 0
+1783499626.136481 cmd_find_best_session: 0 sessions to try
+1783499626.136483 cmd_find_current_client: no target, return (nil)
+1783499626.136485 cmd_find_best_session: 0 sessions to try
+1783499626.136487 cmd_find_current_client: no target, return (nil)
+1783499626.136489 cmd_find_best_session: 0 sessions to try
+1783499626.136491 cmd_find_best_session: 0 sessions to try
+1783499626.136495 key_bindings_add: 0x2c , = send-keys -X jump-reverse
+1783499626.136497 cmd_find_best_session: 0 sessions to try
+1783499626.136500 cmdq_next <global>: [bind-key/0x58e472508b30] (0), flags 0
+1783499626.136502 cmd_find_best_session: 0 sessions to try
+1783499626.136504 cmd_find_current_client: no target, return (nil)
+1783499626.136506 cmd_find_best_session: 0 sessions to try
+1783499626.136508 cmd_find_current_client: no target, return (nil)
+1783499626.136510 cmd_find_best_session: 0 sessions to try
+1783499626.136512 cmd_find_best_session: 0 sessions to try
+1783499626.136516 key_bindings_add: 0x3b ; = send-keys -X jump-again
+1783499626.136518 cmd_find_best_session: 0 sessions to try
+1783499626.136524 cmdq_next <global>: [bind-key/0x58e472509ac0] (0), flags 0
+1783499626.136530 cmd_find_best_session: 0 sessions to try
+1783499626.136533 cmd_find_current_client: no target, return (nil)
+1783499626.136535 cmd_find_best_session: 0 sessions to try
+1783499626.136541 cmd_find_current_client: no target, return (nil)
+1783499626.136543 cmd_find_best_session: 0 sessions to try
+1783499626.136545 cmd_find_best_session: 0 sessions to try
+1783499626.136555 key_bindings_add: 0x46 F = command-prompt -1 -p "(jump backward)" { send-keys -X jump-backward "%%" }
+1783499626.136558 cmd_find_best_session: 0 sessions to try
+1783499626.136561 cmdq_next <global>: [bind-key/0x58e472508d90] (0), flags 0
+1783499626.136563 cmd_find_best_session: 0 sessions to try
+1783499626.136564 cmd_find_current_client: no target, return (nil)
+1783499626.136566 cmd_find_best_session: 0 sessions to try
+1783499626.136568 cmd_find_current_client: no target, return (nil)
+1783499626.136574 cmd_find_best_session: 0 sessions to try
+1783499626.136578 cmd_find_best_session: 0 sessions to try
+1783499626.136583 key_bindings_add: 0x4e N = send-keys -X search-reverse
+1783499626.136585 cmd_find_best_session: 0 sessions to try
+1783499626.136588 cmdq_next <global>: [bind-key/0x58e472509e80] (0), flags 0
+1783499626.136596 cmd_find_best_session: 0 sessions to try
+1783499626.136598 cmd_find_current_client: no target, return (nil)
+1783499626.136600 cmd_find_best_session: 0 sessions to try
+1783499626.136601 cmd_find_current_client: no target, return (nil)
+1783499626.136603 cmd_find_best_session: 0 sessions to try
+1783499626.136605 cmd_find_best_session: 0 sessions to try
+1783499626.136610 key_bindings_add: 0x50 P = send-keys -X toggle-position
+1783499626.136612 cmd_find_best_session: 0 sessions to try
+1783499626.136615 cmdq_next <global>: [bind-key/0x58e47250a200] (0), flags 0
+1783499626.136617 cmd_find_best_session: 0 sessions to try
+1783499626.136619 cmd_find_current_client: no target, return (nil)
+1783499626.136621 cmd_find_best_session: 0 sessions to try
+1783499626.136623 cmd_find_current_client: no target, return (nil)
+1783499626.136624 cmd_find_best_session: 0 sessions to try
+1783499626.136626 cmd_find_best_session: 0 sessions to try
+1783499626.136630 key_bindings_add: 0x52 R = send-keys -X rectangle-toggle
+1783499626.136632 cmd_find_best_session: 0 sessions to try
+1783499626.136635 cmdq_next <global>: [bind-key/0x58e47250b1e0] (0), flags 0
+1783499626.136637 cmd_find_best_session: 0 sessions to try
+1783499626.136639 cmd_find_current_client: no target, return (nil)
+1783499626.136641 cmd_find_best_session: 0 sessions to try
+1783499626.136643 cmd_find_current_client: no target, return (nil)
+1783499626.136645 cmd_find_best_session: 0 sessions to try
+1783499626.136646 cmd_find_best_session: 0 sessions to try
+1783499626.136655 key_bindings_add: 0x54 T = command-prompt -1 -p "(jump to backward)" { send-keys -X jump-to-backward "%%" }
+1783499626.136657 cmd_find_best_session: 0 sessions to try
+1783499626.136660 cmdq_next <global>: [bind-key/0x58e47250a450] (0), flags 0
+1783499626.136661 cmd_find_best_session: 0 sessions to try
+1783499626.136663 cmd_find_current_client: no target, return (nil)
+1783499626.136665 cmd_find_best_session: 0 sessions to try
+1783499626.136667 cmd_find_current_client: no target, return (nil)
+1783499626.136669 cmd_find_best_session: 0 sessions to try
+1783499626.136670 cmd_find_best_session: 0 sessions to try
+1783499626.136674 key_bindings_add: 0x58 X = send-keys -X set-mark
+1783499626.136676 cmd_find_best_session: 0 sessions to try
+1783499626.136679 cmdq_next <global>: [bind-key/0x58e47250c050] (0), flags 0
+1783499626.136681 cmd_find_best_session: 0 sessions to try
+1783499626.136683 cmd_find_current_client: no target, return (nil)
+1783499626.136685 cmd_find_best_session: 0 sessions to try
+1783499626.136687 cmd_find_current_client: no target, return (nil)
+1783499626.136689 cmd_find_best_session: 0 sessions to try
+1783499626.136691 cmd_find_best_session: 0 sessions to try
+1783499626.136703 key_bindings_add: 0x66 f = command-prompt -1 -p "(jump forward)" { send-keys -X jump-forward "%%" }
+1783499626.136708 cmd_find_best_session: 0 sessions to try
+1783499626.136711 cmdq_next <global>: [bind-key/0x58e47250c6c0] (0), flags 0
+1783499626.136713 cmd_find_best_session: 0 sessions to try
+1783499626.136715 cmd_find_current_client: no target, return (nil)
+1783499626.136720 cmd_find_best_session: 0 sessions to try
+1783499626.136722 cmd_find_current_client: no target, return (nil)
+1783499626.136724 cmd_find_best_session: 0 sessions to try
+1783499626.136726 cmd_find_best_session: 0 sessions to try
+1783499626.136733 key_bindings_add: 0x67 g = command-prompt -p "(goto line)" { send-keys -X goto-line "%%" }
+1783499626.136735 cmd_find_best_session: 0 sessions to try
+1783499626.136738 cmdq_next <global>: [bind-key/0x58e47250bd00] (0), flags 0
+1783499626.136740 cmd_find_best_session: 0 sessions to try
+1783499626.136742 cmd_find_current_client: no target, return (nil)
+1783499626.136744 cmd_find_best_session: 0 sessions to try
+1783499626.136746 cmd_find_current_client: no target, return (nil)
+1783499626.136748 cmd_find_best_session: 0 sessions to try
+1783499626.136749 cmd_find_best_session: 0 sessions to try
+1783499626.136754 key_bindings_add: 0x6e n = send-keys -X search-again
+1783499626.136755 cmd_find_best_session: 0 sessions to try
+1783499626.136758 cmdq_next <global>: [bind-key/0x58e47250ca30] (0), flags 0
+1783499626.136760 cmd_find_best_session: 0 sessions to try
+1783499626.136762 cmd_find_current_client: no target, return (nil)
+1783499626.136764 cmd_find_best_session: 0 sessions to try
+1783499626.136766 cmd_find_current_client: no target, return (nil)
+1783499626.136767 cmd_find_best_session: 0 sessions to try
+1783499626.136769 cmd_find_best_session: 0 sessions to try
+1783499626.136773 key_bindings_add: 0x71 q = send-keys -X cancel
+1783499626.136781 cmd_find_best_session: 0 sessions to try
+1783499626.136784 cmdq_next <global>: [bind-key/0x58e47250ceb0] (0), flags 0
+1783499626.136786 cmd_find_best_session: 0 sessions to try
+1783499626.136788 cmd_find_current_client: no target, return (nil)
+1783499626.136790 cmd_find_best_session: 0 sessions to try
+1783499626.136792 cmd_find_current_client: no target, return (nil)
+1783499626.136793 cmd_find_best_session: 0 sessions to try
+1783499626.136795 cmd_find_best_session: 0 sessions to try
+1783499626.136800 key_bindings_add: 0x72 r = send-keys -X refresh-from-pane
+1783499626.136802 cmd_find_best_session: 0 sessions to try
+1783499626.136805 cmdq_next <global>: [bind-key/0x58e47250dec0] (0), flags 0
+1783499626.136807 cmd_find_best_session: 0 sessions to try
+1783499626.136811 cmd_find_current_client: no target, return (nil)
+1783499626.136816 cmd_find_best_session: 0 sessions to try
+1783499626.136818 cmd_find_current_client: no target, return (nil)
+1783499626.136820 cmd_find_best_session: 0 sessions to try
+1783499626.136822 cmd_find_best_session: 0 sessions to try
+1783499626.136831 key_bindings_add: 0x74 t = command-prompt -1 -p "(jump to forward)" { send-keys -X jump-to-forward "%%" }
+1783499626.136833 cmd_find_best_session: 0 sessions to try
+1783499626.136836 cmdq_next <global>: [bind-key/0x58e47250dbb0] (0), flags 0
+1783499626.136838 cmd_find_best_session: 0 sessions to try
+1783499626.136840 cmd_find_current_client: no target, return (nil)
+1783499626.136841 cmd_find_best_session: 0 sessions to try
+1783499626.136843 cmd_find_current_client: no target, return (nil)
+1783499626.136845 cmd_find_best_session: 0 sessions to try
+1783499626.136847 cmd_find_best_session: 0 sessions to try
+1783499626.136851 key_bindings_add: 0x10e1a3 Home = send-keys -X start-of-line
+1783499626.136853 cmd_find_best_session: 0 sessions to try
+1783499626.136856 cmdq_next <global>: [bind-key/0x58e47250e240] (0), flags 0
+1783499626.136858 cmd_find_best_session: 0 sessions to try
+1783499626.136860 cmd_find_current_client: no target, return (nil)
+1783499626.136862 cmd_find_best_session: 0 sessions to try
+1783499626.136878 cmd_find_current_client: no target, return (nil)
+1783499626.136885 cmd_find_best_session: 0 sessions to try
+1783499626.136888 cmd_find_best_session: 0 sessions to try
+1783499626.136895 key_bindings_add: 0x10e1a4 End = send-keys -X end-of-line
+1783499626.136898 cmd_find_best_session: 0 sessions to try
+1783499626.136901 cmdq_next <global>: [bind-key/0x58e47250e500] (0), flags 0
+1783499626.136904 cmd_find_best_session: 0 sessions to try
+1783499626.136912 cmd_find_current_client: no target, return (nil)
+1783499626.136914 cmd_find_best_session: 0 sessions to try
+1783499626.136916 cmd_find_current_client: no target, return (nil)
+1783499626.136918 cmd_find_best_session: 0 sessions to try
+1783499626.136920 cmd_find_best_session: 0 sessions to try
+1783499626.136970 yylex_token: end at EOF
+1783499626.136976 yylex_token: select-pane
+1783499626.136981 cmd_parse_build_commands 0:0: select-pane
+1783499626.136991 args_parse: flags end at 1 of 1
+1783499626.136994 cmd_parse_build_commands: select-pane
+1783499626.136998 key_bindings_add: 0x10e00e MouseDown1Pane = select-pane
+1783499626.137000 cmd_find_best_session: 0 sessions to try
+1783499626.137003 cmdq_next <global>: [bind-key/0x58e47250eef0] (0), flags 0
+1783499626.137005 cmd_find_best_session: 0 sessions to try
+1783499626.137007 cmd_find_current_client: no target, return (nil)
+1783499626.137009 cmd_find_best_session: 0 sessions to try
+1783499626.137011 cmd_find_current_client: no target, return (nil)
+1783499626.137013 cmd_find_best_session: 0 sessions to try
+1783499626.137015 cmd_find_best_session: 0 sessions to try
+1783499626.137022 key_bindings_add: 0x10e07a MouseDrag1Pane = select-pane ; send-keys -X begin-selection
+1783499626.137024 cmd_find_best_session: 0 sessions to try
+1783499626.137027 cmdq_next <global>: [bind-key/0x58e47250f250] (0), flags 0
+1783499626.137029 cmd_find_best_session: 0 sessions to try
+1783499626.137031 cmd_find_current_client: no target, return (nil)
+1783499626.137033 cmd_find_best_session: 0 sessions to try
+1783499626.137035 cmd_find_current_client: no target, return (nil)
+1783499626.137036 cmd_find_best_session: 0 sessions to try
+1783499626.137038 cmd_find_best_session: 0 sessions to try
+1783499626.137045 key_bindings_add: 0x10e0b0 MouseDragEnd1Pane = send-keys -X copy-pipe-and-cancel
+1783499626.137047 cmd_find_best_session: 0 sessions to try
+1783499626.137050 cmdq_next <global>: [bind-key/0x58e47250fc00] (0), flags 0
+1783499626.137052 cmd_find_best_session: 0 sessions to try
+1783499626.137054 cmd_find_current_client: no target, return (nil)
+1783499626.137055 cmd_find_best_session: 0 sessions to try
+1783499626.137057 cmd_find_current_client: no target, return (nil)
+1783499626.137059 cmd_find_best_session: 0 sessions to try
+1783499626.137061 cmd_find_best_session: 0 sessions to try
+1783499626.137069 key_bindings_add: 0x10e0e6 WheelUpPane = select-pane ; send-keys -X -N 5 scroll-up
+1783499626.137071 cmd_find_best_session: 0 sessions to try
+1783499626.137074 cmdq_next <global>: [bind-key/0x58e472510220] (0), flags 0
+1783499626.137076 cmd_find_best_session: 0 sessions to try
+1783499626.137078 cmd_find_current_client: no target, return (nil)
+1783499626.137080 cmd_find_best_session: 0 sessions to try
+1783499626.137082 cmd_find_current_client: no target, return (nil)
+1783499626.137083 cmd_find_best_session: 0 sessions to try
+1783499626.137085 cmd_find_best_session: 0 sessions to try
+1783499626.137093 key_bindings_add: 0x10e0ec WheelDownPane = select-pane ; send-keys -X -N 5 scroll-down
+1783499626.137095 cmd_find_best_session: 0 sessions to try
+1783499626.137098 cmdq_next <global>: [bind-key/0x58e472510f30] (0), flags 0
+1783499626.137100 cmd_find_best_session: 0 sessions to try
+1783499626.137102 cmd_find_current_client: no target, return (nil)
+1783499626.137104 cmd_find_best_session: 0 sessions to try
+1783499626.137106 cmd_find_current_client: no target, return (nil)
+1783499626.137107 cmd_find_best_session: 0 sessions to try
+1783499626.137109 cmd_find_best_session: 0 sessions to try
+1783499626.137121 key_bindings_add: 0x10e128 DoubleClick1Pane = select-pane ; send-keys -X select-word ; run-shell -d 0.3 ; send-keys -X copy-pipe-and-cancel
+1783499626.137124 cmd_find_best_session: 0 sessions to try
+1783499626.137127 cmdq_next <global>: [bind-key/0x58e472511570] (0), flags 0
+1783499626.137129 cmd_find_best_session: 0 sessions to try
+1783499626.137131 cmd_find_current_client: no target, return (nil)
+1783499626.137133 cmd_find_best_session: 0 sessions to try
+1783499626.137135 cmd_find_current_client: no target, return (nil)
+1783499626.137142 cmd_find_best_session: 0 sessions to try
+1783499626.137144 cmd_find_best_session: 0 sessions to try
+1783499626.137155 key_bindings_add: 0x10e15e TripleClick1Pane = select-pane ; send-keys -X select-line ; run-shell -d 0.3 ; send-keys -X copy-pipe-and-cancel
+1783499626.137158 cmd_find_best_session: 0 sessions to try
+1783499626.137161 cmdq_next <global>: [bind-key/0x58e472510ba0] (0), flags 0
+1783499626.137163 cmd_find_best_session: 0 sessions to try
+1783499626.137165 cmd_find_current_client: no target, return (nil)
+1783499626.137167 cmd_find_best_session: 0 sessions to try
+1783499626.137169 cmd_find_current_client: no target, return (nil)
+1783499626.137171 cmd_find_best_session: 0 sessions to try
+1783499626.137172 cmd_find_best_session: 0 sessions to try
+1783499626.137177 key_bindings_add: 0x10e1a5 NPage = send-keys -X page-down
+1783499626.137179 cmd_find_best_session: 0 sessions to try
+1783499626.137181 cmdq_next <global>: [bind-key/0x58e472511860] (0), flags 0
+1783499626.137380 cmd_find_best_session: 0 sessions to try
+1783499626.137384 cmd_find_current_client: no target, return (nil)
+1783499626.137386 cmd_find_best_session: 0 sessions to try
+1783499626.137388 cmd_find_current_client: no target, return (nil)
+1783499626.137391 cmd_find_best_session: 0 sessions to try
+1783499626.137393 cmd_find_best_session: 0 sessions to try
+1783499626.137405 key_bindings_add: 0x10e1a6 PPage = send-keys -X page-up
+1783499626.137410 cmd_find_best_session: 0 sessions to try
+1783499626.137414 cmdq_next <global>: [bind-key/0x58e472511ab0] (0), flags 0
+1783499626.137416 cmd_find_best_session: 0 sessions to try
+1783499626.137418 cmd_find_current_client: no target, return (nil)
+1783499626.137420 cmd_find_best_session: 0 sessions to try
+1783499626.137422 cmd_find_current_client: no target, return (nil)
+1783499626.137424 cmd_find_best_session: 0 sessions to try
+1783499626.137426 cmd_find_best_session: 0 sessions to try
+1783499626.137431 key_bindings_add: 0x10e1a8 Up = send-keys -X cursor-up
+1783499626.137433 cmd_find_best_session: 0 sessions to try
+1783499626.137437 cmdq_next <global>: [bind-key/0x58e472511e80] (0), flags 0
+1783499626.137439 cmd_find_best_session: 0 sessions to try
+1783499626.137441 cmd_find_current_client: no target, return (nil)
+1783499626.137442 cmd_find_best_session: 0 sessions to try
+1783499626.137444 cmd_find_current_client: no target, return (nil)
+1783499626.137446 cmd_find_best_session: 0 sessions to try
+1783499626.137448 cmd_find_best_session: 0 sessions to try
+1783499626.137453 key_bindings_add: 0x10e1a9 Down = send-keys -X cursor-down
+1783499626.137455 cmd_find_best_session: 0 sessions to try
+1783499626.137459 cmdq_next <global>: [bind-key/0x58e472512450] (0), flags 0
+1783499626.137461 cmd_find_best_session: 0 sessions to try
+1783499626.137463 cmd_find_current_client: no target, return (nil)
+1783499626.137464 cmd_find_best_session: 0 sessions to try
+1783499626.137466 cmd_find_current_client: no target, return (nil)
+1783499626.137468 cmd_find_best_session: 0 sessions to try
+1783499626.137470 cmd_find_best_session: 0 sessions to try
+1783499626.137475 key_bindings_add: 0x10e1aa Left = send-keys -X cursor-left
+1783499626.137477 cmd_find_best_session: 0 sessions to try
+1783499626.137480 cmdq_next <global>: [bind-key/0x58e4725127e0] (0), flags 0
+1783499626.137482 cmd_find_best_session: 0 sessions to try
+1783499626.137484 cmd_find_current_client: no target, return (nil)
+1783499626.137486 cmd_find_best_session: 0 sessions to try
+1783499626.137488 cmd_find_current_client: no target, return (nil)
+1783499626.137490 cmd_find_best_session: 0 sessions to try
+1783499626.137492 cmd_find_best_session: 0 sessions to try
+1783499626.137496 key_bindings_add: 0x10e1ab Right = send-keys -X cursor-right
+1783499626.137498 cmd_find_best_session: 0 sessions to try
+1783499626.137502 cmdq_next <global>: [bind-key/0x58e472513670] (0), flags 0
+1783499626.137504 cmd_find_best_session: 0 sessions to try
+1783499626.137505 cmd_find_current_client: no target, return (nil)
+1783499626.137507 cmd_find_best_session: 0 sessions to try
+1783499626.137516 cmd_find_current_client: no target, return (nil)
+1783499626.137519 cmd_find_best_session: 0 sessions to try
+1783499626.137520 cmd_find_best_session: 0 sessions to try
+1783499626.137532 key_bindings_add: 0x100000000031 M-1 = command-prompt -N -I 1 -p (repeat) { send-keys -N "%%" }
+1783499626.137537 cmd_find_best_session: 0 sessions to try
+1783499626.137540 cmdq_next <global>: [bind-key/0x58e472513f50] (0), flags 0
+1783499626.137542 cmd_find_best_session: 0 sessions to try
+1783499626.137544 cmd_find_current_client: no target, return (nil)
+1783499626.137546 cmd_find_best_session: 0 sessions to try
+1783499626.137548 cmd_find_current_client: no target, return (nil)
+1783499626.137550 cmd_find_best_session: 0 sessions to try
+1783499626.137551 cmd_find_best_session: 0 sessions to try
+1783499626.137560 key_bindings_add: 0x100000000032 M-2 = command-prompt -N -I 2 -p (repeat) { send-keys -N "%%" }
+1783499626.137562 cmd_find_best_session: 0 sessions to try
+1783499626.137565 cmdq_next <global>: [bind-key/0x58e472514640] (0), flags 0
+1783499626.137567 cmd_find_best_session: 0 sessions to try
+1783499626.137569 cmd_find_current_client: no target, return (nil)
+1783499626.137571 cmd_find_best_session: 0 sessions to try
+1783499626.137573 cmd_find_current_client: no target, return (nil)
+1783499626.137575 cmd_find_best_session: 0 sessions to try
+1783499626.137576 cmd_find_best_session: 0 sessions to try
+1783499626.137584 key_bindings_add: 0x100000000033 M-3 = command-prompt -N -I 3 -p (repeat) { send-keys -N "%%" }
+1783499626.137639 cmd_find_best_session: 0 sessions to try
+1783499626.137646 cmdq_next <global>: [bind-key/0x58e472514dc0] (0), flags 0
+1783499626.137650 cmd_find_best_session: 0 sessions to try
+1783499626.137652 cmd_find_current_client: no target, return (nil)
+1783499626.137654 cmd_find_best_session: 0 sessions to try
+1783499626.137657 cmd_find_current_client: no target, return (nil)
+1783499626.137659 cmd_find_best_session: 0 sessions to try
+1783499626.137661 cmd_find_best_session: 0 sessions to try
+1783499626.137672 key_bindings_add: 0x100000000034 M-4 = command-prompt -N -I 4 -p (repeat) { send-keys -N "%%" }
+1783499626.137674 cmd_find_best_session: 0 sessions to try
+1783499626.137680 cmdq_next <global>: [bind-key/0x58e472515490] (0), flags 0
+1783499626.137685 cmd_find_best_session: 0 sessions to try
+1783499626.137687 cmd_find_current_client: no target, return (nil)
+1783499626.137689 cmd_find_best_session: 0 sessions to try
+1783499626.137691 cmd_find_current_client: no target, return (nil)
+1783499626.137693 cmd_find_best_session: 0 sessions to try
+1783499626.137695 cmd_find_best_session: 0 sessions to try
+1783499626.137704 key_bindings_add: 0x100000000035 M-5 = command-prompt -N -I 5 -p (repeat) { send-keys -N "%%" }
+1783499626.137706 cmd_find_best_session: 0 sessions to try
+1783499626.137709 cmdq_next <global>: [bind-key/0x58e472515cb0] (0), flags 0
+1783499626.137711 cmd_find_best_session: 0 sessions to try
+1783499626.137713 cmd_find_current_client: no target, return (nil)
+1783499626.137715 cmd_find_best_session: 0 sessions to try
+1783499626.137717 cmd_find_current_client: no target, return (nil)
+1783499626.137719 cmd_find_best_session: 0 sessions to try
+1783499626.137721 cmd_find_best_session: 0 sessions to try
+1783499626.137728 key_bindings_add: 0x100000000036 M-6 = command-prompt -N -I 6 -p (repeat) { send-keys -N "%%" }
+1783499626.137730 cmd_find_best_session: 0 sessions to try
+1783499626.137734 cmdq_next <global>: [bind-key/0x58e4725161b0] (0), flags 0
+1783499626.137736 cmd_find_best_session: 0 sessions to try
+1783499626.137738 cmd_find_current_client: no target, return (nil)
+1783499626.137739 cmd_find_best_session: 0 sessions to try
+1783499626.137741 cmd_find_current_client: no target, return (nil)
+1783499626.137743 cmd_find_best_session: 0 sessions to try
+1783499626.137745 cmd_find_best_session: 0 sessions to try
+1783499626.137753 key_bindings_add: 0x100000000037 M-7 = command-prompt -N -I 7 -p (repeat) { send-keys -N "%%" }
+1783499626.137755 cmd_find_best_session: 0 sessions to try
+1783499626.137765 cmdq_next <global>: [bind-key/0x58e4725168a0] (0), flags 0
+1783499626.137767 cmd_find_best_session: 0 sessions to try
+1783499626.137769 cmd_find_current_client: no target, return (nil)
+1783499626.137771 cmd_find_best_session: 0 sessions to try
+1783499626.137773 cmd_find_current_client: no target, return (nil)
+1783499626.137775 cmd_find_best_session: 0 sessions to try
+1783499626.137777 cmd_find_best_session: 0 sessions to try
+1783499626.137785 key_bindings_add: 0x100000000038 M-8 = command-prompt -N -I 8 -p (repeat) { send-keys -N "%%" }
+1783499626.137787 cmd_find_best_session: 0 sessions to try
+1783499626.137790 cmdq_next <global>: [bind-key/0x58e4725159b0] (0), flags 0
+1783499626.137792 cmd_find_best_session: 0 sessions to try
+1783499626.137794 cmd_find_current_client: no target, return (nil)
+1783499626.137796 cmd_find_best_session: 0 sessions to try
+1783499626.137798 cmd_find_current_client: no target, return (nil)
+1783499626.137800 cmd_find_best_session: 0 sessions to try
+1783499626.137801 cmd_find_best_session: 0 sessions to try
+1783499626.137809 key_bindings_add: 0x100000000039 M-9 = command-prompt -N -I 9 -p (repeat) { send-keys -N "%%" }
+1783499626.137811 cmd_find_best_session: 0 sessions to try
+1783499626.137815 cmdq_next <global>: [bind-key/0x58e472516c10] (0), flags 0
+1783499626.137817 cmd_find_best_session: 0 sessions to try
+1783499626.137819 cmd_find_current_client: no target, return (nil)
+1783499626.137820 cmd_find_best_session: 0 sessions to try
+1783499626.137822 cmd_find_current_client: no target, return (nil)
+1783499626.137824 cmd_find_best_session: 0 sessions to try
+1783499626.137826 cmd_find_best_session: 0 sessions to try
+1783499626.137831 key_bindings_add: 0x10000000003c M-< = send-keys -X history-top
+1783499626.137833 cmd_find_best_session: 0 sessions to try
+1783499626.137836 cmdq_next <global>: [bind-key/0x58e472516f00] (0), flags 0
+1783499626.137838 cmd_find_best_session: 0 sessions to try
+1783499626.137840 cmd_find_current_client: no target, return (nil)
+1783499626.137842 cmd_find_best_session: 0 sessions to try
+1783499626.137844 cmd_find_current_client: no target, return (nil)
+1783499626.137846 cmd_find_best_session: 0 sessions to try
+1783499626.137847 cmd_find_best_session: 0 sessions to try
+1783499626.137852 key_bindings_add: 0x10000000003e M-> = send-keys -X history-bottom
+1783499626.137855 cmd_find_best_session: 0 sessions to try
+1783499626.137858 cmdq_next <global>: [bind-key/0x58e4725170a0] (0), flags 0
+1783499626.137859 cmd_find_best_session: 0 sessions to try
+1783499626.137861 cmd_find_current_client: no target, return (nil)
+1783499626.137863 cmd_find_best_session: 0 sessions to try
+1783499626.137865 cmd_find_current_client: no target, return (nil)
+1783499626.137867 cmd_find_best_session: 0 sessions to try
+1783499626.137869 cmd_find_best_session: 0 sessions to try
+1783499626.137874 key_bindings_add: 0x100000000052 M-R = send-keys -X top-line
+1783499626.137876 cmd_find_best_session: 0 sessions to try
+1783499626.137878 cmdq_next <global>: [bind-key/0x58e472517270] (0), flags 0
+1783499626.137880 cmd_find_best_session: 0 sessions to try
+1783499626.137976 cmd_find_current_client: no target, return (nil)
+1783499626.137980 cmd_find_best_session: 0 sessions to try
+1783499626.137983 cmd_find_current_client: no target, return (nil)
+1783499626.137985 cmd_find_best_session: 0 sessions to try
+1783499626.137987 cmd_find_best_session: 0 sessions to try
+1783499626.137996 key_bindings_add: 0x100000000062 M-b = send-keys -X previous-word
+1783499626.137998 cmd_find_best_session: 0 sessions to try
+1783499626.138002 cmdq_next <global>: [bind-key/0x58e472517b10] (0), flags 0
+1783499626.138004 cmd_find_best_session: 0 sessions to try
+1783499626.138006 cmd_find_current_client: no target, return (nil)
+1783499626.138009 cmd_find_best_session: 0 sessions to try
+1783499626.138011 cmd_find_current_client: no target, return (nil)
+1783499626.138013 cmd_find_best_session: 0 sessions to try
+1783499626.138015 cmd_find_best_session: 0 sessions to try
+1783499626.138030 key_bindings_add: 0x100000000002 M-C-b = send-keys -X previous-matching-bracket
+1783499626.138039 cmd_find_best_session: 0 sessions to try
+1783499626.138045 cmdq_next <global>: [bind-key/0x58e472517700] (0), flags 0
+1783499626.138050 cmd_find_best_session: 0 sessions to try
+1783499626.138060 cmd_find_current_client: no target, return (nil)
+1783499626.138062 cmd_find_best_session: 0 sessions to try
+1783499626.138064 cmd_find_current_client: no target, return (nil)
+1783499626.138066 cmd_find_best_session: 0 sessions to try
+1783499626.138068 cmd_find_best_session: 0 sessions to try
+1783499626.138074 key_bindings_add: 0x100000000066 M-f = send-keys -X next-word-end
+1783499626.138076 cmd_find_best_session: 0 sessions to try
+1783499626.138079 cmdq_next <global>: [bind-key/0x58e4725180f0] (0), flags 0
+1783499626.138081 cmd_find_best_session: 0 sessions to try
+1783499626.138084 cmd_find_current_client: no target, return (nil)
+1783499626.138085 cmd_find_best_session: 0 sessions to try
+1783499626.138087 cmd_find_current_client: no target, return (nil)
+1783499626.138089 cmd_find_best_session: 0 sessions to try
+1783499626.138091 cmd_find_best_session: 0 sessions to try
+1783499626.138097 key_bindings_add: 0x100000000006 M-C-f = send-keys -X next-matching-bracket
+1783499626.138099 cmd_find_best_session: 0 sessions to try
+1783499626.138102 cmdq_next <global>: [bind-key/0x58e472518a40] (0), flags 0
+1783499626.138104 cmd_find_best_session: 0 sessions to try
+1783499626.138106 cmd_find_current_client: no target, return (nil)
+1783499626.138108 cmd_find_best_session: 0 sessions to try
+1783499626.138110 cmd_find_current_client: no target, return (nil)
+1783499626.138112 cmd_find_best_session: 0 sessions to try
+1783499626.138114 cmd_find_best_session: 0 sessions to try
+1783499626.138119 key_bindings_add: 0x10000000006d M-m = send-keys -X back-to-indentation
+1783499626.138121 cmd_find_best_session: 0 sessions to try
+1783499626.138124 cmdq_next <global>: [bind-key/0x58e472518bf0] (0), flags 0
+1783499626.138126 cmd_find_best_session: 0 sessions to try
+1783499626.138129 cmd_find_current_client: no target, return (nil)
+1783499626.138130 cmd_find_best_session: 0 sessions to try
+1783499626.138132 cmd_find_current_client: no target, return (nil)
+1783499626.138134 cmd_find_best_session: 0 sessions to try
+1783499626.138136 cmd_find_best_session: 0 sessions to try
+1783499626.138141 key_bindings_add: 0x100000000072 M-r = send-keys -X middle-line
+1783499626.138143 cmd_find_best_session: 0 sessions to try
+1783499626.138147 cmdq_next <global>: [bind-key/0x58e472519140] (0), flags 0
+1783499626.138149 cmd_find_best_session: 0 sessions to try
+1783499626.138151 cmd_find_current_client: no target, return (nil)
+1783499626.138153 cmd_find_best_session: 0 sessions to try
+1783499626.138154 cmd_find_current_client: no target, return (nil)
+1783499626.138156 cmd_find_best_session: 0 sessions to try
+1783499626.138158 cmd_find_best_session: 0 sessions to try
+1783499626.138163 key_bindings_add: 0x100000000076 M-v = send-keys -X page-up
+1783499626.138165 cmd_find_best_session: 0 sessions to try
+1783499626.138168 cmdq_next <global>: [bind-key/0x58e472519b50] (0), flags 0
+1783499626.138170 cmd_find_best_session: 0 sessions to try
+1783499626.138172 cmd_find_current_client: no target, return (nil)
+1783499626.138173 cmd_find_best_session: 0 sessions to try
+1783499626.138175 cmd_find_current_client: no target, return (nil)
+1783499626.138177 cmd_find_best_session: 0 sessions to try
+1783499626.138179 cmd_find_best_session: 0 sessions to try
+1783499626.138184 key_bindings_add: 0x100000000077 M-w = send-keys -X copy-pipe-and-cancel
+1783499626.138186 cmd_find_best_session: 0 sessions to try
+1783499626.138189 cmdq_next <global>: [bind-key/0x58e4725198c0] (0), flags 0
+1783499626.138191 cmd_find_best_session: 0 sessions to try
+1783499626.138193 cmd_find_current_client: no target, return (nil)
+1783499626.138195 cmd_find_best_session: 0 sessions to try
+1783499626.138196 cmd_find_current_client: no target, return (nil)
+1783499626.138198 cmd_find_best_session: 0 sessions to try
+1783499626.138200 cmd_find_best_session: 0 sessions to try
+1783499626.138210 key_bindings_add: 0x100000000078 M-x = send-keys -X jump-to-mark
+1783499626.138212 cmd_find_best_session: 0 sessions to try
+1783499626.138215 cmdq_next <global>: [bind-key/0x58e472519f50] (0), flags 0
+1783499626.138217 cmd_find_best_session: 0 sessions to try
+1783499626.138219 cmd_find_current_client: no target, return (nil)
+1783499626.138221 cmd_find_best_session: 0 sessions to try
+1783499626.138223 cmd_find_current_client: no target, return (nil)
+1783499626.138224 cmd_find_best_session: 0 sessions to try
+1783499626.138226 cmd_find_best_session: 0 sessions to try
+1783499626.138231 key_bindings_add: 0x10000000007b M-{ = send-keys -X previous-paragraph
+1783499626.138233 cmd_find_best_session: 0 sessions to try
+1783499626.138236 cmdq_next <global>: [bind-key/0x58e47251a4a0] (0), flags 0
+1783499626.138238 cmd_find_best_session: 0 sessions to try
+1783499626.138240 cmd_find_current_client: no target, return (nil)
+1783499626.138242 cmd_find_best_session: 0 sessions to try
+1783499626.138266 cmd_find_current_client: no target, return (nil)
+1783499626.138273 cmd_find_best_session: 0 sessions to try
+1783499626.138277 cmd_find_best_session: 0 sessions to try
+1783499626.138284 key_bindings_add: 0x10000000007d M-} = send-keys -X next-paragraph
+1783499626.138287 cmd_find_best_session: 0 sessions to try
+1783499626.138291 cmdq_next <global>: [bind-key/0x58e47251aa10] (0), flags 0
+1783499626.138293 cmd_find_best_session: 0 sessions to try
+1783499626.138295 cmd_find_current_client: no target, return (nil)
+1783499626.138297 cmd_find_best_session: 0 sessions to try
+1783499626.138299 cmd_find_current_client: no target, return (nil)
+1783499626.138303 cmd_find_best_session: 0 sessions to try
+1783499626.138308 cmd_find_best_session: 0 sessions to try
+1783499626.138367 key_bindings_add: 0x10000010e1a8 M-Up = send-keys -X halfpage-up
+1783499626.138373 cmd_find_best_session: 0 sessions to try
+1783499626.138378 cmdq_next <global>: [bind-key/0x58e47251a330] (0), flags 0
+1783499626.138380 cmd_find_best_session: 0 sessions to try
+1783499626.138383 cmd_find_current_client: no target, return (nil)
+1783499626.138385 cmd_find_best_session: 0 sessions to try
+1783499626.138387 cmd_find_current_client: no target, return (nil)
+1783499626.138389 cmd_find_best_session: 0 sessions to try
+1783499626.138391 cmd_find_best_session: 0 sessions to try
+1783499626.138397 key_bindings_add: 0x10000010e1a9 M-Down = send-keys -X halfpage-down
+1783499626.138399 cmd_find_best_session: 0 sessions to try
+1783499626.138402 cmdq_next <global>: [bind-key/0x58e47251b210] (0), flags 0
+1783499626.138404 cmd_find_best_session: 0 sessions to try
+1783499626.138411 cmd_find_current_client: no target, return (nil)
+1783499626.138413 cmd_find_best_session: 0 sessions to try
+1783499626.138415 cmd_find_current_client: no target, return (nil)
+1783499626.138431 cmd_find_best_session: 0 sessions to try
+1783499626.138437 cmd_find_best_session: 0 sessions to try
+1783499626.138444 key_bindings_add: 0x20000010e1a8 C-Up = send-keys -X scroll-up
+1783499626.138446 cmd_find_best_session: 0 sessions to try
+1783499626.138449 cmdq_next <global>: [bind-key/0x58e47251b7f0] (0), flags 0
+1783499626.138451 cmd_find_best_session: 0 sessions to try
+1783499626.138453 cmd_find_current_client: no target, return (nil)
+1783499626.138455 cmd_find_best_session: 0 sessions to try
+1783499626.138457 cmd_find_current_client: no target, return (nil)
+1783499626.138461 cmd_find_best_session: 0 sessions to try
+1783499626.138464 cmd_find_best_session: 0 sessions to try
+1783499626.138470 key_bindings_add: 0x20000010e1a9 C-Down = send-keys -X scroll-down
+1783499626.138472 cmd_find_best_session: 0 sessions to try
+1783499626.138475 cmdq_next <global>: [bind-key/0x58e47251c000] (0), flags 0
+1783499626.138477 cmd_find_best_session: 0 sessions to try
+1783499626.138482 cmd_find_current_client: no target, return (nil)
+1783499626.138485 cmd_find_best_session: 0 sessions to try
+1783499626.138487 cmd_find_current_client: no target, return (nil)
+1783499626.138489 cmd_find_best_session: 0 sessions to try
+1783499626.138505 cmd_find_best_session: 0 sessions to try
+1783499626.138515 key_bindings_add: 0x23 # = send-keys -FX search-backward "#{copy_cursor_word}"
+1783499626.138517 cmd_find_best_session: 0 sessions to try
+1783499626.138520 cmdq_next <global>: [bind-key/0x58e47251c5c0] (0), flags 0
+1783499626.138523 cmd_find_best_session: 0 sessions to try
+1783499626.138536 cmd_find_current_client: no target, return (nil)
+1783499626.138538 cmd_find_best_session: 0 sessions to try
+1783499626.138540 cmd_find_current_client: no target, return (nil)
+1783499626.138542 cmd_find_best_session: 0 sessions to try
+1783499626.138544 cmd_find_best_session: 0 sessions to try
+1783499626.138550 key_bindings_add: 0x2a * = send-keys -FX search-forward "#{copy_cursor_word}"
+1783499626.138552 cmd_find_best_session: 0 sessions to try
+1783499626.138555 cmdq_next <global>: [bind-key/0x58e47251ccf0] (0), flags 0
+1783499626.138561 cmd_find_best_session: 0 sessions to try
+1783499626.138563 cmd_find_current_client: no target, return (nil)
+1783499626.138565 cmd_find_best_session: 0 sessions to try
+1783499626.138567 cmd_find_current_client: no target, return (nil)
+1783499626.138569 cmd_find_best_session: 0 sessions to try
+1783499626.138570 cmd_find_best_session: 0 sessions to try
+1783499626.138575 key_bindings_add: 0x3 C-c = send-keys -X cancel
+1783499626.138577 cmd_find_best_session: 0 sessions to try
+1783499626.138582 cmdq_next <global>: [bind-key/0x58e47251d010] (0), flags 0
+1783499626.138586 cmd_find_best_session: 0 sessions to try
+1783499626.138588 cmd_find_current_client: no target, return (nil)
+1783499626.138590 cmd_find_best_session: 0 sessions to try
+1783499626.138592 cmd_find_current_client: no target, return (nil)
+1783499626.138593 cmd_find_best_session: 0 sessions to try
+1783499626.138595 cmd_find_best_session: 0 sessions to try
+1783499626.138609 key_bindings_add: 0x4 C-d = send-keys -X halfpage-down
+1783499626.138613 cmd_find_best_session: 0 sessions to try
+1783499626.138617 cmdq_next <global>: [bind-key/0x58e47251d400] (0), flags 0
+1783499626.138621 cmd_find_best_session: 0 sessions to try
+1783499626.138623 cmd_find_current_client: no target, return (nil)
+1783499626.138625 cmd_find_best_session: 0 sessions to try
+1783499626.138627 cmd_find_current_client: no target, return (nil)
+1783499626.138629 cmd_find_best_session: 0 sessions to try
+1783499626.138630 cmd_find_best_session: 0 sessions to try
+1783499626.138636 key_bindings_add: 0x5 C-e = send-keys -X scroll-down
+1783499626.138641 cmd_find_best_session: 0 sessions to try
+1783499626.138644 cmdq_next <global>: [bind-key/0x58e47251d730] (0), flags 0
+1783499626.138646 cmd_find_best_session: 0 sessions to try
+1783499626.138648 cmd_find_current_client: no target, return (nil)
+1783499626.138650 cmd_find_best_session: 0 sessions to try
+1783499626.138652 cmd_find_current_client: no target, return (nil)
+1783499626.138654 cmd_find_best_session: 0 sessions to try
+1783499626.138656 cmd_find_best_session: 0 sessions to try
+1783499626.138662 key_bindings_add: 0x2 C-b = send-keys -X page-up
+1783499626.138666 cmd_find_best_session: 0 sessions to try
+1783499626.138671 cmdq_next <global>: [bind-key/0x58e47251de10] (0), flags 0
+1783499626.138674 cmd_find_best_session: 0 sessions to try
+1783499626.138676 cmd_find_current_client: no target, return (nil)
+1783499626.138678 cmd_find_best_session: 0 sessions to try
+1783499626.138680 cmd_find_current_client: no target, return (nil)
+1783499626.138686 cmd_find_best_session: 0 sessions to try
+1783499626.138688 cmd_find_best_session: 0 sessions to try
+1783499626.138692 key_bindings_add: 0x6 C-f = send-keys -X page-down
+1783499626.138695 cmd_find_best_session: 0 sessions to try
+1783499626.138699 cmdq_next <global>: [bind-key/0x58e47251e260] (0), flags 0
+1783499626.138703 cmd_find_best_session: 0 sessions to try
+1783499626.138705 cmd_find_current_client: no target, return (nil)
+1783499626.138707 cmd_find_best_session: 0 sessions to try
+1783499626.138709 cmd_find_current_client: no target, return (nil)
+1783499626.138711 cmd_find_best_session: 0 sessions to try
+1783499626.138714 cmd_find_best_session: 0 sessions to try
+1783499626.138725 key_bindings_add: 0x8 C-h = send-keys -X cursor-left
+1783499626.138727 cmd_find_best_session: 0 sessions to try
+1783499626.138732 cmdq_next <global>: [bind-key/0x58e47251eba0] (0), flags 0
+1783499626.138736 cmd_find_best_session: 0 sessions to try
+1783499626.138740 cmd_find_current_client: no target, return (nil)
+1783499626.138743 cmd_find_best_session: 0 sessions to try
+1783499626.138745 cmd_find_current_client: no target, return (nil)
+1783499626.138747 cmd_find_best_session: 0 sessions to try
+1783499626.138749 cmd_find_best_session: 0 sessions to try
+1783499626.138754 key_bindings_add: 0xa C-j = send-keys -X copy-pipe-and-cancel
+1783499626.138808 cmd_find_best_session: 0 sessions to try
+1783499626.138819 cmdq_next <global>: [bind-key/0x58e47251edb0] (0), flags 0
+1783499626.138824 cmd_find_best_session: 0 sessions to try
+1783499626.138827 cmd_find_current_client: no target, return (nil)
+1783499626.138829 cmd_find_best_session: 0 sessions to try
+1783499626.138833 cmd_find_current_client: no target, return (nil)
+1783499626.138837 cmd_find_best_session: 0 sessions to try
+1783499626.138840 cmd_find_best_session: 0 sessions to try
+1783499626.138847 key_bindings_add: 0xd Enter = send-keys -X copy-pipe-and-cancel
+1783499626.138849 cmd_find_best_session: 0 sessions to try
+1783499626.138853 cmdq_next <global>: [bind-key/0x58e47251f000] (0), flags 0
+1783499626.138859 cmd_find_best_session: 0 sessions to try
+1783499626.138864 cmd_find_current_client: no target, return (nil)
+1783499626.138867 cmd_find_best_session: 0 sessions to try
+1783499626.138869 cmd_find_current_client: no target, return (nil)
+1783499626.138871 cmd_find_best_session: 0 sessions to try
+1783499626.138873 cmd_find_best_session: 0 sessions to try
+1783499626.138878 key_bindings_add: 0x15 C-u = send-keys -X halfpage-up
+1783499626.138881 cmd_find_best_session: 0 sessions to try
+1783499626.138884 cmdq_next <global>: [bind-key/0x58e47251f620] (0), flags 0
+1783499626.138886 cmd_find_best_session: 0 sessions to try
+1783499626.138888 cmd_find_current_client: no target, return (nil)
+1783499626.138890 cmd_find_best_session: 0 sessions to try
+1783499626.138892 cmd_find_current_client: no target, return (nil)
+1783499626.138894 cmd_find_best_session: 0 sessions to try
+1783499626.138896 cmd_find_best_session: 0 sessions to try
+1783499626.138901 key_bindings_add: 0x16 C-v = send-keys -X rectangle-toggle
+1783499626.138903 cmd_find_best_session: 0 sessions to try
+1783499626.138910 cmdq_next <global>: [bind-key/0x58e47251f8b0] (0), flags 0
+1783499626.138912 cmd_find_best_session: 0 sessions to try
+1783499626.138914 cmd_find_current_client: no target, return (nil)
+1783499626.138916 cmd_find_best_session: 0 sessions to try
+1783499626.138918 cmd_find_current_client: no target, return (nil)
+1783499626.138920 cmd_find_best_session: 0 sessions to try
+1783499626.138922 cmd_find_best_session: 0 sessions to try
+1783499626.139100 key_bindings_add: 0x19 C-y = send-keys -X scroll-up
+1783499626.139109 cmd_find_best_session: 0 sessions to try
+1783499626.139117 cmdq_next <global>: [bind-key/0x58e472520420] (0), flags 0
+1783499626.139122 cmd_find_best_session: 0 sessions to try
+1783499626.139124 cmd_find_current_client: no target, return (nil)
+1783499626.139127 cmd_find_best_session: 0 sessions to try
+1783499626.139129 cmd_find_current_client: no target, return (nil)
+1783499626.139131 cmd_find_best_session: 0 sessions to try
+1783499626.139133 cmd_find_best_session: 0 sessions to try
+1783499626.139143 key_bindings_add: 0x1b Escape = send-keys -X clear-selection
+1783499626.139147 cmd_find_best_session: 0 sessions to try
+1783499626.139151 cmdq_next <global>: [bind-key/0x58e47251fb00] (0), flags 0
+1783499626.139153 cmd_find_best_session: 0 sessions to try
+1783499626.139155 cmd_find_current_client: no target, return (nil)
+1783499626.139157 cmd_find_best_session: 0 sessions to try
+1783499626.139159 cmd_find_current_client: no target, return (nil)
+1783499626.139161 cmd_find_best_session: 0 sessions to try
+1783499626.139163 cmd_find_best_session: 0 sessions to try
+1783499626.139176 key_bindings_add: 0x20 Space = send-keys -X begin-selection
+1783499626.139178 cmd_find_best_session: 0 sessions to try
+1783499626.139181 cmdq_next <global>: [bind-key/0x58e472520760] (0), flags 0
+1783499626.139183 cmd_find_best_session: 0 sessions to try
+1783499626.139185 cmd_find_current_client: no target, return (nil)
+1783499626.139187 cmd_find_best_session: 0 sessions to try
+1783499626.139189 cmd_find_current_client: no target, return (nil)
+1783499626.139191 cmd_find_best_session: 0 sessions to try
+1783499626.139193 cmd_find_best_session: 0 sessions to try
+1783499626.139198 key_bindings_add: 0x24 $ = send-keys -X end-of-line
+1783499626.139202 cmd_find_best_session: 0 sessions to try
+1783499626.139208 cmdq_next <global>: [bind-key/0x58e472520ec0] (0), flags 0
+1783499626.139210 cmd_find_best_session: 0 sessions to try
+1783499626.139212 cmd_find_current_client: no target, return (nil)
+1783499626.139214 cmd_find_best_session: 0 sessions to try
+1783499626.139216 cmd_find_current_client: no target, return (nil)
+1783499626.139218 cmd_find_best_session: 0 sessions to try
+1783499626.139220 cmd_find_best_session: 0 sessions to try
+1783499626.139225 key_bindings_add: 0x2c , = send-keys -X jump-reverse
+1783499626.139227 cmd_find_best_session: 0 sessions to try
+1783499626.139230 cmdq_next <global>: [bind-key/0x58e472522000] (0), flags 0
+1783499626.139232 cmd_find_best_session: 0 sessions to try
+1783499626.139237 cmd_find_current_client: no target, return (nil)
+1783499626.139240 cmd_find_best_session: 0 sessions to try
+1783499626.139242 cmd_find_current_client: no target, return (nil)
+1783499626.139244 cmd_find_best_session: 0 sessions to try
+1783499626.139246 cmd_find_best_session: 0 sessions to try
+1783499626.139255 key_bindings_add: 0x2f / = command-prompt -T search -p "(search down)" { send-keys -X search-forward "%%" }
+1783499626.139258 cmd_find_best_session: 0 sessions to try
+1783499626.139261 cmdq_next <global>: [bind-key/0x58e472521b30] (0), flags 0
+1783499626.139263 cmd_find_best_session: 0 sessions to try
+1783499626.139265 cmd_find_current_client: no target, return (nil)
+1783499626.139267 cmd_find_best_session: 0 sessions to try
+1783499626.139269 cmd_find_current_client: no target, return (nil)
+1783499626.139274 cmd_find_best_session: 0 sessions to try
+1783499626.139277 cmd_find_best_session: 0 sessions to try
+1783499626.139282 key_bindings_add: 0x30 0 = send-keys -X start-of-line
+1783499626.139284 cmd_find_best_session: 0 sessions to try
+1783499626.139287 cmdq_next <global>: [bind-key/0x58e472522b80] (0), flags 0
+1783499626.139289 cmd_find_best_session: 0 sessions to try
+1783499626.139291 cmd_find_current_client: no target, return (nil)
+1783499626.139293 cmd_find_best_session: 0 sessions to try
+1783499626.139294 cmd_find_current_client: no target, return (nil)
+1783499626.139296 cmd_find_best_session: 0 sessions to try
+1783499626.139298 cmd_find_best_session: 0 sessions to try
+1783499626.139306 key_bindings_add: 0x31 1 = command-prompt -N -I 1 -p (repeat) { send-keys -N "%%" }
+1783499626.139309 cmd_find_best_session: 0 sessions to try
+1783499626.139311 cmdq_next <global>: [bind-key/0x58e472521d10] (0), flags 0
+1783499626.139313 cmd_find_best_session: 0 sessions to try
+1783499626.139315 cmd_find_current_client: no target, return (nil)
+1783499626.139317 cmd_find_best_session: 0 sessions to try
+1783499626.139319 cmd_find_current_client: no target, return (nil)
+1783499626.139321 cmd_find_best_session: 0 sessions to try
+1783499626.139323 cmd_find_best_session: 0 sessions to try
+1783499626.139330 key_bindings_add: 0x32 2 = command-prompt -N -I 2 -p (repeat) { send-keys -N "%%" }
+1783499626.139332 cmd_find_best_session: 0 sessions to try
+1783499626.139335 cmdq_next <global>: [bind-key/0x58e472523bc0] (0), flags 0
+1783499626.139337 cmd_find_best_session: 0 sessions to try
+1783499626.139339 cmd_find_current_client: no target, return (nil)
+1783499626.139340 cmd_find_best_session: 0 sessions to try
+1783499626.139342 cmd_find_current_client: no target, return (nil)
+1783499626.139344 cmd_find_best_session: 0 sessions to try
+1783499626.139351 cmd_find_best_session: 0 sessions to try
+1783499626.139358 key_bindings_add: 0x33 3 = command-prompt -N -I 3 -p (repeat) { send-keys -N "%%" }
+1783499626.139361 cmd_find_best_session: 0 sessions to try
+1783499626.139363 cmdq_next <global>: [bind-key/0x58e472523d20] (0), flags 0
+1783499626.139365 cmd_find_best_session: 0 sessions to try
+1783499626.139367 cmd_find_current_client: no target, return (nil)
+1783499626.139369 cmd_find_best_session: 0 sessions to try
+1783499626.139371 cmd_find_current_client: no target, return (nil)
+1783499626.139372 cmd_find_best_session: 0 sessions to try
+1783499626.139374 cmd_find_best_session: 0 sessions to try
+1783499626.139382 key_bindings_add: 0x34 4 = command-prompt -N -I 4 -p (repeat) { send-keys -N "%%" }
+1783499626.139384 cmd_find_best_session: 0 sessions to try
+1783499626.139387 cmdq_next <global>: [bind-key/0x58e472523e90] (0), flags 0
+1783499626.139389 cmd_find_best_session: 0 sessions to try
+1783499626.139391 cmd_find_current_client: no target, return (nil)
+1783499626.139392 cmd_find_best_session: 0 sessions to try
+1783499626.139394 cmd_find_current_client: no target, return (nil)
+1783499626.139396 cmd_find_best_session: 0 sessions to try
+1783499626.139398 cmd_find_best_session: 0 sessions to try
+1783499626.139408 key_bindings_add: 0x35 5 = command-prompt -N -I 5 -p (repeat) { send-keys -N "%%" }
+1783499626.139413 cmd_find_best_session: 0 sessions to try
+1783499626.139416 cmdq_next <global>: [bind-key/0x58e472525470] (0), flags 0
+1783499626.139419 cmd_find_best_session: 0 sessions to try
+1783499626.139420 cmd_find_current_client: no target, return (nil)
+1783499626.139422 cmd_find_best_session: 0 sessions to try
+1783499626.139424 cmd_find_current_client: no target, return (nil)
+1783499626.139426 cmd_find_best_session: 0 sessions to try
+1783499626.139428 cmd_find_best_session: 0 sessions to try
+1783499626.139435 key_bindings_add: 0x36 6 = command-prompt -N -I 6 -p (repeat) { send-keys -N "%%" }
+1783499626.139437 cmd_find_best_session: 0 sessions to try
+1783499626.139440 cmdq_next <global>: [bind-key/0x58e472525c10] (0), flags 0
+1783499626.139442 cmd_find_best_session: 0 sessions to try
+1783499626.139444 cmd_find_current_client: no target, return (nil)
+1783499626.139446 cmd_find_best_session: 0 sessions to try
+1783499626.139447 cmd_find_current_client: no target, return (nil)
+1783499626.139662 cmd_find_best_session: 0 sessions to try
+1783499626.139703 cmd_find_best_session: 0 sessions to try
+1783499626.139719 key_bindings_add: 0x37 7 = command-prompt -N -I 7 -p (repeat) { send-keys -N "%%" }
+1783499626.139722 cmd_find_best_session: 0 sessions to try
+1783499626.139726 cmdq_next <global>: [bind-key/0x58e472525220] (0), flags 0
+1783499626.139728 cmd_find_best_session: 0 sessions to try
+1783499626.139731 cmd_find_current_client: no target, return (nil)
+1783499626.139733 cmd_find_best_session: 0 sessions to try
+1783499626.139735 cmd_find_current_client: no target, return (nil)
+1783499626.139737 cmd_find_best_session: 0 sessions to try
+1783499626.139739 cmd_find_best_session: 0 sessions to try
+1783499626.139746 key_bindings_add: 0x38 8 = command-prompt -N -I 8 -p (repeat) { send-keys -N "%%" }
+1783499626.139749 cmd_find_best_session: 0 sessions to try
+1783499626.139752 cmdq_next <global>: [bind-key/0x58e472525eb0] (0), flags 0
+1783499626.139754 cmd_find_best_session: 0 sessions to try
+1783499626.139756 cmd_find_current_client: no target, return (nil)
+1783499626.139758 cmd_find_best_session: 0 sessions to try
+1783499626.139760 cmd_find_current_client: no target, return (nil)
+1783499626.139762 cmd_find_best_session: 0 sessions to try
+1783499626.139764 cmd_find_best_session: 0 sessions to try
+1783499626.139771 key_bindings_add: 0x39 9 = command-prompt -N -I 9 -p (repeat) { send-keys -N "%%" }
+1783499626.139773 cmd_find_best_session: 0 sessions to try
+1783499626.139776 cmdq_next <global>: [bind-key/0x58e472526510] (0), flags 0
+1783499626.139778 cmd_find_best_session: 0 sessions to try
+1783499626.139780 cmd_find_current_client: no target, return (nil)
+1783499626.139789 cmd_find_best_session: 0 sessions to try
+1783499626.139791 cmd_find_current_client: no target, return (nil)
+1783499626.139874 cmd_find_best_session: 0 sessions to try
+1783499626.139881 cmd_find_best_session: 0 sessions to try
+1783499626.139894 key_bindings_add: 0x3a : = command-prompt -p "(goto line)" { send-keys -X goto-line "%%" }
+1783499626.139897 cmd_find_best_session: 0 sessions to try
+1783499626.139901 cmdq_next <global>: [bind-key/0x58e472526d60] (0), flags 0
+1783499626.139904 cmd_find_best_session: 0 sessions to try
+1783499626.139906 cmd_find_current_client: no target, return (nil)
+1783499626.139908 cmd_find_best_session: 0 sessions to try
+1783499626.139910 cmd_find_current_client: no target, return (nil)
+1783499626.139913 cmd_find_best_session: 0 sessions to try
+1783499626.139914 cmd_find_best_session: 0 sessions to try
+1783499626.139920 key_bindings_add: 0x3b ; = send-keys -X jump-again
+1783499626.139922 cmd_find_best_session: 0 sessions to try
+1783499626.139925 cmdq_next <global>: [bind-key/0x58e4725288d0] (0), flags 0
+1783499626.139928 cmd_find_best_session: 0 sessions to try
+1783499626.139930 cmd_find_current_client: no target, return (nil)
+1783499626.139932 cmd_find_best_session: 0 sessions to try
+1783499626.139934 cmd_find_current_client: no target, return (nil)
+1783499626.139936 cmd_find_best_session: 0 sessions to try
+1783499626.139938 cmd_find_best_session: 0 sessions to try
+1783499626.139948 key_bindings_add: 0x3f ? = command-prompt -T search -p "(search up)" { send-keys -X search-backward "%%" }
+1783499626.139950 cmd_find_best_session: 0 sessions to try
+1783499626.139953 cmdq_next <global>: [bind-key/0x58e472526fe0] (0), flags 0
+1783499626.139955 cmd_find_best_session: 0 sessions to try
+1783499626.139957 cmd_find_current_client: no target, return (nil)
+1783499626.139959 cmd_find_best_session: 0 sessions to try
+1783499626.139961 cmd_find_current_client: no target, return (nil)
+1783499626.139963 cmd_find_best_session: 0 sessions to try
+1783499626.139965 cmd_find_best_session: 0 sessions to try
+1783499626.139970 key_bindings_add: 0x41 A = send-keys -X append-selection-and-cancel
+1783499626.139972 cmd_find_best_session: 0 sessions to try
+1783499626.139975 cmdq_next <global>: [bind-key/0x58e472527540] (0), flags 0
+1783499626.139978 cmd_find_best_session: 0 sessions to try
+1783499626.139980 cmd_find_current_client: no target, return (nil)
+1783499626.139981 cmd_find_best_session: 0 sessions to try
+1783499626.140031 cmd_find_current_client: no target, return (nil)
+1783499626.140045 cmd_find_best_session: 0 sessions to try
+1783499626.140048 cmd_find_best_session: 0 sessions to try
+1783499626.140056 key_bindings_add: 0x42 B = send-keys -X previous-space
+1783499626.140059 cmd_find_best_session: 0 sessions to try
+1783499626.140063 cmdq_next <global>: [bind-key/0x58e472528aa0] (0), flags 0
+1783499626.140065 cmd_find_best_session: 0 sessions to try
+1783499626.140067 cmd_find_current_client: no target, return (nil)
+1783499626.140070 cmd_find_best_session: 0 sessions to try
+1783499626.140072 cmd_find_current_client: no target, return (nil)
+1783499626.140074 cmd_find_best_session: 0 sessions to try
+1783499626.140076 cmd_find_best_session: 0 sessions to try
+1783499626.140083 key_bindings_add: 0x44 D = send-keys -X copy-pipe-end-of-line-and-cancel
+1783499626.140085 cmd_find_best_session: 0 sessions to try
+1783499626.140089 cmdq_next <global>: [bind-key/0x58e472529100] (0), flags 0
+1783499626.140110 cmd_find_best_session: 0 sessions to try
+1783499626.140168 cmd_find_current_client: no target, return (nil)
+1783499626.140173 cmd_find_best_session: 0 sessions to try
+1783499626.140177 cmd_find_current_client: no target, return (nil)
+1783499626.140180 cmd_find_best_session: 0 sessions to try
+1783499626.140182 cmd_find_best_session: 0 sessions to try
+1783499626.140189 key_bindings_add: 0x45 E = send-keys -X next-space-end
+1783499626.140192 cmd_find_best_session: 0 sessions to try
+1783499626.140316 cmdq_next <global>: [bind-key/0x58e47252a340] (0), flags 0
+1783499626.140322 cmd_find_best_session: 0 sessions to try
+1783499626.140333 cmd_find_current_client: no target, return (nil)
+1783499626.140335 cmd_find_best_session: 0 sessions to try
+1783499626.140338 cmd_find_current_client: no target, return (nil)
+1783499626.140340 cmd_find_best_session: 0 sessions to try
+1783499626.140342 cmd_find_best_session: 0 sessions to try
+1783499626.140354 key_bindings_add: 0x46 F = command-prompt -1 -p "(jump backward)" { send-keys -X jump-backward "%%" }
+1783499626.140356 cmd_find_best_session: 0 sessions to try
+1783499626.140360 cmdq_next <global>: [bind-key/0x58e472529410] (0), flags 0
+1783499626.140362 cmd_find_best_session: 0 sessions to try
+1783499626.140364 cmd_find_current_client: no target, return (nil)
+1783499626.140366 cmd_find_best_session: 0 sessions to try
+1783499626.140368 cmd_find_current_client: no target, return (nil)
+1783499626.140370 cmd_find_best_session: 0 sessions to try
+1783499626.140372 cmd_find_best_session: 0 sessions to try
+1783499626.140377 key_bindings_add: 0x47 G = send-keys -X history-bottom
+1783499626.140379 cmd_find_best_session: 0 sessions to try
+1783499626.140383 cmdq_next <global>: [bind-key/0x58e47252a620] (0), flags 0
+1783499626.140385 cmd_find_best_session: 0 sessions to try
+1783499626.140387 cmd_find_current_client: no target, return (nil)
+1783499626.140389 cmd_find_best_session: 0 sessions to try
+1783499626.140391 cmd_find_current_client: no target, return (nil)
+1783499626.140393 cmd_find_best_session: 0 sessions to try
+1783499626.140395 cmd_find_best_session: 0 sessions to try
+1783499626.140400 key_bindings_add: 0x48 H = send-keys -X top-line
+1783499626.140402 cmd_find_best_session: 0 sessions to try
+1783499626.140405 cmdq_next <global>: [bind-key/0x58e47252acd0] (0), flags 0
+1783499626.140407 cmd_find_best_session: 0 sessions to try
+1783499626.140409 cmd_find_current_client: no target, return (nil)
+1783499626.140411 cmd_find_best_session: 0 sessions to try
+1783499626.140413 cmd_find_current_client: no target, return (nil)
+1783499626.140415 cmd_find_best_session: 0 sessions to try
+1783499626.140417 cmd_find_best_session: 0 sessions to try
+1783499626.140423 key_bindings_add: 0x4a J = send-keys -X scroll-down
+1783499626.140425 cmd_find_best_session: 0 sessions to try
+1783499626.140428 cmdq_next <global>: [bind-key/0x58e47252b290] (0), flags 0
+1783499626.140430 cmd_find_best_session: 0 sessions to try
+1783499626.140432 cmd_find_current_client: no target, return (nil)
+1783499626.140434 cmd_find_best_session: 0 sessions to try
+1783499626.140436 cmd_find_current_client: no target, return (nil)
+1783499626.140438 cmd_find_best_session: 0 sessions to try
+1783499626.140439 cmd_find_best_session: 0 sessions to try
+1783499626.140444 key_bindings_add: 0x4b K = send-keys -X scroll-up
+1783499626.140446 cmd_find_best_session: 0 sessions to try
+1783499626.140449 cmdq_next <global>: [bind-key/0x58e47252b800] (0), flags 0
+1783499626.140451 cmd_find_best_session: 0 sessions to try
+1783499626.140453 cmd_find_current_client: no target, return (nil)
+1783499626.140455 cmd_find_best_session: 0 sessions to try
+1783499626.140457 cmd_find_current_client: no target, return (nil)
+1783499626.140459 cmd_find_best_session: 0 sessions to try
+1783499626.140461 cmd_find_best_session: 0 sessions to try
+1783499626.140466 key_bindings_add: 0x4c L = send-keys -X bottom-line
+1783499626.140468 cmd_find_best_session: 0 sessions to try
+1783499626.140470 cmdq_next <global>: [bind-key/0x58e47252bdb0] (0), flags 0
+1783499626.140473 cmd_find_best_session: 0 sessions to try
+1783499626.140475 cmd_find_current_client: no target, return (nil)
+1783499626.140476 cmd_find_best_session: 0 sessions to try
+1783499626.140478 cmd_find_current_client: no target, return (nil)
+1783499626.140480 cmd_find_best_session: 0 sessions to try
+1783499626.140482 cmd_find_best_session: 0 sessions to try
+1783499626.140487 key_bindings_add: 0x4d M = send-keys -X middle-line
+1783499626.140489 cmd_find_best_session: 0 sessions to try
+1783499626.140492 cmdq_next <global>: [bind-key/0x58e47252c390] (0), flags 0
+1783499626.140494 cmd_find_best_session: 0 sessions to try
+1783499626.140500 cmd_find_current_client: no target, return (nil)
+1783499626.140619 cmd_find_best_session: 0 sessions to try
+1783499626.140628 cmd_find_current_client: no target, return (nil)
+1783499626.140631 cmd_find_best_session: 0 sessions to try
+1783499626.140634 cmd_find_best_session: 0 sessions to try
+1783499626.140693 key_bindings_add: 0x4e N = send-keys -X search-reverse
+1783499626.140701 cmd_find_best_session: 0 sessions to try
+1783499626.140706 cmdq_next <global>: [bind-key/0x58e47252c970] (0), flags 0
+1783499626.140709 cmd_find_best_session: 0 sessions to try
+1783499626.140711 cmd_find_current_client: no target, return (nil)
+1783499626.140713 cmd_find_best_session: 0 sessions to try
+1783499626.140715 cmd_find_current_client: no target, return (nil)
+1783499626.140717 cmd_find_best_session: 0 sessions to try
+1783499626.140719 cmd_find_best_session: 0 sessions to try
+1783499626.140725 key_bindings_add: 0x50 P = send-keys -X toggle-position
+1783499626.140728 cmd_find_best_session: 0 sessions to try
+1783499626.140731 cmdq_next <global>: [bind-key/0x58e47252d8c0] (0), flags 0
+1783499626.140733 cmd_find_best_session: 0 sessions to try
+1783499626.140735 cmd_find_current_client: no target, return (nil)
+1783499626.140737 cmd_find_best_session: 0 sessions to try
+1783499626.140739 cmd_find_current_client: no target, return (nil)
+1783499626.140741 cmd_find_best_session: 0 sessions to try
+1783499626.140743 cmd_find_best_session: 0 sessions to try
+1783499626.140754 key_bindings_add: 0x54 T = command-prompt -1 -p "(jump to backward)" { send-keys -X jump-to-backward "%%" }
+1783499626.140756 cmd_find_best_session: 0 sessions to try
+1783499626.140760 cmdq_next <global>: [bind-key/0x58e47252cc50] (0), flags 0
+1783499626.140762 cmd_find_best_session: 0 sessions to try
+1783499626.140764 cmd_find_current_client: no target, return (nil)
+1783499626.140766 cmd_find_best_session: 0 sessions to try
+1783499626.140768 cmd_find_current_client: no target, return (nil)
+1783499626.140770 cmd_find_best_session: 0 sessions to try
+1783499626.140771 cmd_find_best_session: 0 sessions to try
+1783499626.140777 key_bindings_add: 0x56 V = send-keys -X select-line
+1783499626.140779 cmd_find_best_session: 0 sessions to try
+1783499626.140782 cmdq_next <global>: [bind-key/0x58e47252ddd0] (0), flags 0
+1783499626.140784 cmd_find_best_session: 0 sessions to try
+1783499626.140786 cmd_find_current_client: no target, return (nil)
+1783499626.140788 cmd_find_best_session: 0 sessions to try
+1783499626.140790 cmd_find_current_client: no target, return (nil)
+1783499626.140792 cmd_find_best_session: 0 sessions to try
+1783499626.140794 cmd_find_best_session: 0 sessions to try
+1783499626.140799 key_bindings_add: 0x57 W = send-keys -X next-space
+1783499626.140801 cmd_find_best_session: 0 sessions to try
+1783499626.140804 cmdq_next <global>: [bind-key/0x58e47252e140] (0), flags 0
+1783499626.140806 cmd_find_best_session: 0 sessions to try
+1783499626.140808 cmd_find_current_client: no target, return (nil)
+1783499626.140810 cmd_find_best_session: 0 sessions to try
+1783499626.140812 cmd_find_current_client: no target, return (nil)
+1783499626.140814 cmd_find_best_session: 0 sessions to try
+1783499626.140816 cmd_find_best_session: 0 sessions to try
+1783499626.140820 key_bindings_add: 0x58 X = send-keys -X set-mark
+1783499626.140822 cmd_find_best_session: 0 sessions to try
+1783499626.140826 cmdq_next <global>: [bind-key/0x58e47252e520] (0), flags 0
+1783499626.140828 cmd_find_best_session: 0 sessions to try
+1783499626.140830 cmd_find_current_client: no target, return (nil)
+1783499626.140832 cmd_find_best_session: 0 sessions to try
+1783499626.140833 cmd_find_current_client: no target, return (nil)
+1783499626.140835 cmd_find_best_session: 0 sessions to try
+1783499626.140837 cmd_find_best_session: 0 sessions to try
+1783499626.140842 key_bindings_add: 0x5e ^ = send-keys -X back-to-indentation
+1783499626.140844 cmd_find_best_session: 0 sessions to try
+1783499626.140847 cmdq_next <global>: [bind-key/0x58e47252ea90] (0), flags 0
+1783499626.140849 cmd_find_best_session: 0 sessions to try
+1783499626.140857 cmd_find_current_client: no target, return (nil)
+1783499626.140860 cmd_find_best_session: 0 sessions to try
+1783499626.140861 cmd_find_current_client: no target, return (nil)
+1783499626.140863 cmd_find_best_session: 0 sessions to try
+1783499626.140865 cmd_find_best_session: 0 sessions to try
+1783499626.140870 key_bindings_add: 0x62 b = send-keys -X previous-word
+1783499626.140872 cmd_find_best_session: 0 sessions to try
+1783499626.140875 cmdq_next <global>: [bind-key/0x58e47252f260] (0), flags 0
+1783499626.140877 cmd_find_best_session: 0 sessions to try
+1783499626.140879 cmd_find_current_client: no target, return (nil)
+1783499626.140881 cmd_find_best_session: 0 sessions to try
+1783499626.140883 cmd_find_current_client: no target, return (nil)
+1783499626.140885 cmd_find_best_session: 0 sessions to try
+1783499626.140887 cmd_find_best_session: 0 sessions to try
+1783499626.140892 key_bindings_add: 0x65 e = send-keys -X next-word-end
+1783499626.140894 cmd_find_best_session: 0 sessions to try
+1783499626.140897 cmdq_next <global>: [bind-key/0x58e4725307d0] (0), flags 0
+1783499626.140899 cmd_find_best_session: 0 sessions to try
+1783499626.140901 cmd_find_current_client: no target, return (nil)
+1783499626.140902 cmd_find_best_session: 0 sessions to try
+1783499626.140904 cmd_find_current_client: no target, return (nil)
+1783499626.140906 cmd_find_best_session: 0 sessions to try
+1783499626.140908 cmd_find_best_session: 0 sessions to try
+1783499626.141007 key_bindings_add: 0x66 f = command-prompt -1 -p "(jump forward)" { send-keys -X jump-forward "%%" }
+1783499626.141014 cmd_find_best_session: 0 sessions to try
+1783499626.141019 cmdq_next <global>: [bind-key/0x58e47252f660] (0), flags 0
+1783499626.141022 cmd_find_best_session: 0 sessions to try
+1783499626.141024 cmd_find_current_client: no target, return (nil)
+1783499626.141027 cmd_find_best_session: 0 sessions to try
+1783499626.141029 cmd_find_current_client: no target, return (nil)
+1783499626.141031 cmd_find_best_session: 0 sessions to try
+1783499626.141033 cmd_find_best_session: 0 sessions to try
+1783499626.141039 key_bindings_add: 0x67 g = send-keys -X history-top
+1783499626.141042 cmd_find_best_session: 0 sessions to try
+1783499626.141045 cmdq_next <global>: [bind-key/0x58e472530930] (0), flags 0
+1783499626.141047 cmd_find_best_session: 0 sessions to try
+1783499626.141049 cmd_find_current_client: no target, return (nil)
+1783499626.141051 cmd_find_best_session: 0 sessions to try
+1783499626.141054 cmd_find_current_client: no target, return (nil)
+1783499626.141056 cmd_find_best_session: 0 sessions to try
+1783499626.141058 cmd_find_best_session: 0 sessions to try
+1783499626.141062 key_bindings_add: 0x68 h = send-keys -X cursor-left
+1783499626.141065 cmd_find_best_session: 0 sessions to try
+1783499626.141068 cmdq_next <global>: [bind-key/0x58e472530d00] (0), flags 0
+1783499626.141070 cmd_find_best_session: 0 sessions to try
+1783499626.141072 cmd_find_current_client: no target, return (nil)
+1783499626.141074 cmd_find_best_session: 0 sessions to try
+1783499626.141076 cmd_find_current_client: no target, return (nil)
+1783499626.141078 cmd_find_best_session: 0 sessions to try
+1783499626.141079 cmd_find_best_session: 0 sessions to try
+1783499626.141084 key_bindings_add: 0x6a j = send-keys -X cursor-down
+1783499626.141086 cmd_find_best_session: 0 sessions to try
+1783499626.141089 cmdq_next <global>: [bind-key/0x58e472531210] (0), flags 0
+1783499626.141091 cmd_find_best_session: 0 sessions to try
+1783499626.141094 cmd_find_current_client: no target, return (nil)
+1783499626.141095 cmd_find_best_session: 0 sessions to try
+1783499626.141097 cmd_find_current_client: no target, return (nil)
+1783499626.141099 cmd_find_best_session: 0 sessions to try
+1783499626.141101 cmd_find_best_session: 0 sessions to try
+1783499626.141106 key_bindings_add: 0x6b k = send-keys -X cursor-up
+1783499626.141108 cmd_find_best_session: 0 sessions to try
+1783499626.141111 cmdq_next <global>: [bind-key/0x58e472531780] (0), flags 0
+1783499626.141113 cmd_find_best_session: 0 sessions to try
+1783499626.141115 cmd_find_current_client: no target, return (nil)
+1783499626.141244 cmd_find_best_session: 0 sessions to try
+1783499626.141269 cmd_find_current_client: no target, return (nil)
+1783499626.141285 cmd_find_best_session: 0 sessions to try
+1783499626.141291 cmd_find_best_session: 0 sessions to try
+1783499626.141447 key_bindings_add: 0x7a z = send-keys -X scroll-middle
+1783499626.141463 cmd_find_best_session: 0 sessions to try
+1783499626.141471 cmdq_next <global>: [bind-key/0x58e472531cf0] (0), flags 0
+1783499626.141474 cmd_find_best_session: 0 sessions to try
+1783499626.141477 cmd_find_current_client: no target, return (nil)
+1783499626.141480 cmd_find_best_session: 0 sessions to try
+1783499626.141483 cmd_find_current_client: no target, return (nil)
+1783499626.141486 cmd_find_best_session: 0 sessions to try
+1783499626.141488 cmd_find_best_session: 0 sessions to try
+1783499626.141499 key_bindings_add: 0x6c l = send-keys -X cursor-right
+1783499626.141502 cmd_find_best_session: 0 sessions to try
+1783499626.141506 cmdq_next <global>: [bind-key/0x58e472532400] (0), flags 0
+1783499626.141509 cmd_find_best_session: 0 sessions to try
+1783499626.141512 cmd_find_current_client: no target, return (nil)
+1783499626.141515 cmd_find_best_session: 0 sessions to try
+1783499626.141517 cmd_find_current_client: no target, return (nil)
+1783499626.141520 cmd_find_best_session: 0 sessions to try
+1783499626.141522 cmd_find_best_session: 0 sessions to try
+1783499626.141529 key_bindings_add: 0x6e n = send-keys -X search-again
+1783499626.141532 cmd_find_best_session: 0 sessions to try
+1783499626.141536 cmdq_next <global>: [bind-key/0x58e472532ae0] (0), flags 0
+1783499626.141538 cmd_find_best_session: 0 sessions to try
+1783499626.141541 cmd_find_current_client: no target, return (nil)
+1783499626.141544 cmd_find_best_session: 0 sessions to try
+1783499626.141546 cmd_find_current_client: no target, return (nil)
+1783499626.141549 cmd_find_best_session: 0 sessions to try
+1783499626.141552 cmd_find_best_session: 0 sessions to try
+1783499626.141558 key_bindings_add: 0x6f o = send-keys -X other-end
+1783499626.141561 cmd_find_best_session: 0 sessions to try
+1783499626.141565 cmdq_next <global>: [bind-key/0x58e472532f20] (0), flags 0
+1783499626.141567 cmd_find_best_session: 0 sessions to try
+1783499626.141570 cmd_find_current_client: no target, return (nil)
+1783499626.141572 cmd_find_best_session: 0 sessions to try
+1783499626.141575 cmd_find_current_client: no target, return (nil)
+1783499626.141577 cmd_find_best_session: 0 sessions to try
+1783499626.141579 cmd_find_best_session: 0 sessions to try
+1783499626.141586 key_bindings_add: 0x71 q = send-keys -X cancel
+1783499626.141588 cmd_find_best_session: 0 sessions to try
+1783499626.141592 cmdq_next <global>: [bind-key/0x58e4725332a0] (0), flags 0
+1783499626.141595 cmd_find_best_session: 0 sessions to try
+1783499626.141597 cmd_find_current_client: no target, return (nil)
+1783499626.141600 cmd_find_best_session: 0 sessions to try
+1783499626.141602 cmd_find_current_client: no target, return (nil)
+1783499626.141605 cmd_find_best_session: 0 sessions to try
+1783499626.141607 cmd_find_best_session: 0 sessions to try
+1783499626.141614 key_bindings_add: 0x72 r = send-keys -X refresh-from-pane
+1783499626.141623 cmd_find_best_session: 0 sessions to try
+1783499626.141630 cmdq_next <global>: [bind-key/0x58e472534670] (0), flags 0
+1783499626.141633 cmd_find_best_session: 0 sessions to try
+1783499626.141694 cmd_find_current_client: no target, return (nil)
+1783499626.141700 cmd_find_best_session: 0 sessions to try
+1783499626.141703 cmd_find_current_client: no target, return (nil)
+1783499626.141705 cmd_find_best_session: 0 sessions to try
+1783499626.141707 cmd_find_best_session: 0 sessions to try
+1783499626.141721 key_bindings_add: 0x74 t = command-prompt -1 -p "(jump to forward)" { send-keys -X jump-to-forward "%%" }
+1783499626.141724 cmd_find_best_session: 0 sessions to try
+1783499626.141794 cmdq_next <global>: [bind-key/0x58e472533640] (0), flags 0
+1783499626.141798 cmd_find_best_session: 0 sessions to try
+1783499626.141802 cmd_find_current_client: no target, return (nil)
+1783499626.141815 cmd_find_best_session: 0 sessions to try
+1783499626.141818 cmd_find_current_client: no target, return (nil)
+1783499626.141821 cmd_find_best_session: 0 sessions to try
+1783499626.141824 cmd_find_best_session: 0 sessions to try
+1783499626.141886 key_bindings_add: 0x76 v = send-keys -X rectangle-toggle
+1783499626.141938 cmd_find_best_session: 0 sessions to try
+1783499626.141944 cmdq_next <global>: [bind-key/0x58e4725349e0] (0), flags 0
+1783499626.141947 cmd_find_best_session: 0 sessions to try
+1783499626.141951 cmd_find_current_client: no target, return (nil)
+1783499626.141953 cmd_find_best_session: 0 sessions to try
+1783499626.141956 cmd_find_current_client: no target, return (nil)
+1783499626.141959 cmd_find_best_session: 0 sessions to try
+1783499626.141962 cmd_find_best_session: 0 sessions to try
+1783499626.141969 key_bindings_add: 0x77 w = send-keys -X next-word
+1783499626.141971 cmd_find_best_session: 0 sessions to try
+1783499626.141974 cmdq_next <global>: [bind-key/0x58e472534e30] (0), flags 0
+1783499626.141976 cmd_find_best_session: 0 sessions to try
+1783499626.141978 cmd_find_current_client: no target, return (nil)
+1783499626.141980 cmd_find_best_session: 0 sessions to try
+1783499626.141982 cmd_find_current_client: no target, return (nil)
+1783499626.141984 cmd_find_best_session: 0 sessions to try
+1783499626.141985 cmd_find_best_session: 0 sessions to try
+1783499626.141991 key_bindings_add: 0x7b { = send-keys -X previous-paragraph
+1783499626.141992 cmd_find_best_session: 0 sessions to try
+1783499626.141995 cmdq_next <global>: [bind-key/0x58e472535410] (0), flags 0
+1783499626.141997 cmd_find_best_session: 0 sessions to try
+1783499626.141999 cmd_find_current_client: no target, return (nil)
+1783499626.142000 cmd_find_best_session: 0 sessions to try
+1783499626.142002 cmd_find_current_client: no target, return (nil)
+1783499626.142004 cmd_find_best_session: 0 sessions to try
+1783499626.142005 cmd_find_best_session: 0 sessions to try
+1783499626.142010 key_bindings_add: 0x7d } = send-keys -X next-paragraph
+1783499626.142011 cmd_find_best_session: 0 sessions to try
+1783499626.142014 cmdq_next <global>: [bind-key/0x58e472535b20] (0), flags 0
+1783499626.142016 cmd_find_best_session: 0 sessions to try
+1783499626.142018 cmd_find_current_client: no target, return (nil)
+1783499626.142019 cmd_find_best_session: 0 sessions to try
+1783499626.142021 cmd_find_current_client: no target, return (nil)
+1783499626.142023 cmd_find_best_session: 0 sessions to try
+1783499626.142024 cmd_find_best_session: 0 sessions to try
+1783499626.142029 key_bindings_add: 0x25 % = send-keys -X next-matching-bracket
+1783499626.142031 cmd_find_best_session: 0 sessions to try
+1783499626.142034 cmdq_next <global>: [bind-key/0x58e4725361a0] (0), flags 0
+1783499626.142035 cmd_find_best_session: 0 sessions to try
+1783499626.142037 cmd_find_current_client: no target, return (nil)
+1783499626.142039 cmd_find_best_session: 0 sessions to try
+1783499626.142040 cmd_find_current_client: no target, return (nil)
+1783499626.142042 cmd_find_best_session: 0 sessions to try
+1783499626.142044 cmd_find_best_session: 0 sessions to try
+1783499626.142049 key_bindings_add: 0x10e1a3 Home = send-keys -X start-of-line
+1783499626.142052 cmd_find_best_session: 0 sessions to try
+1783499626.142055 cmdq_next <global>: [bind-key/0x58e4725368a0] (0), flags 0
+1783499626.142058 cmd_find_best_session: 0 sessions to try
+1783499626.142060 cmd_find_current_client: no target, return (nil)
+1783499626.142063 cmd_find_best_session: 0 sessions to try
+1783499626.142065 cmd_find_current_client: no target, return (nil)
+1783499626.142067 cmd_find_best_session: 0 sessions to try
+1783499626.142069 cmd_find_best_session: 0 sessions to try
+1783499626.142075 key_bindings_add: 0x10e1a4 End = send-keys -X end-of-line
+1783499626.142077 cmd_find_best_session: 0 sessions to try
+1783499626.142081 cmdq_next <global>: [bind-key/0x58e472535a20] (0), flags 0
+1783499626.142083 cmd_find_best_session: 0 sessions to try
+1783499626.142086 cmd_find_current_client: no target, return (nil)
+1783499626.142096 cmd_find_best_session: 0 sessions to try
+1783499626.142099 cmd_find_current_client: no target, return (nil)
+1783499626.142101 cmd_find_best_session: 0 sessions to try
+1783499626.142103 cmd_find_best_session: 0 sessions to try
+1783499626.142108 key_bindings_add: 0x10e00e MouseDown1Pane = select-pane
+1783499626.142110 cmd_find_best_session: 0 sessions to try
+1783499626.142112 cmdq_next <global>: [bind-key/0x58e472535510] (0), flags 0
+1783499626.142114 cmd_find_best_session: 0 sessions to try
+1783499626.142115 cmd_find_current_client: no target, return (nil)
+1783499626.142117 cmd_find_best_session: 0 sessions to try
+1783499626.142119 cmd_find_current_client: no target, return (nil)
+1783499626.142120 cmd_find_best_session: 0 sessions to try
+1783499626.142122 cmd_find_best_session: 0 sessions to try
+1783499626.142128 key_bindings_add: 0x10e07a MouseDrag1Pane = select-pane ; send-keys -X begin-selection
+1783499626.142130 cmd_find_best_session: 0 sessions to try
+1783499626.142133 cmdq_next <global>: [bind-key/0x58e472536ba0] (0), flags 0
+1783499626.142134 cmd_find_best_session: 0 sessions to try
+1783499626.142406 cmd_find_current_client: no target, return (nil)
+1783499626.142412 cmd_find_best_session: 0 sessions to try
+1783499626.142415 cmd_find_current_client: no target, return (nil)
+1783499626.142417 cmd_find_best_session: 0 sessions to try
+1783499626.142419 cmd_find_best_session: 0 sessions to try
+1783499626.142432 key_bindings_add: 0x10e0b0 MouseDragEnd1Pane = send-keys -X copy-pipe-and-cancel
+1783499626.142434 cmd_find_best_session: 0 sessions to try
+1783499626.142437 cmdq_next <global>: [bind-key/0x58e472537030] (0), flags 0
+1783499626.142439 cmd_find_best_session: 0 sessions to try
+1783499626.142441 cmd_find_current_client: no target, return (nil)
+1783499626.142443 cmd_find_best_session: 0 sessions to try
+1783499626.142445 cmd_find_current_client: no target, return (nil)
+1783499626.142447 cmd_find_best_session: 0 sessions to try
+1783499626.142448 cmd_find_best_session: 0 sessions to try
+1783499626.142458 key_bindings_add: 0x10e0e6 WheelUpPane = select-pane ; send-keys -X -N 5 scroll-up
+1783499626.142460 cmd_find_best_session: 0 sessions to try
+1783499626.142462 cmdq_next <global>: [bind-key/0x58e4725371b0] (0), flags 0
+1783499626.142464 cmd_find_best_session: 0 sessions to try
+1783499626.142466 cmd_find_current_client: no target, return (nil)
+1783499626.142467 cmd_find_best_session: 0 sessions to try
+1783499626.142469 cmd_find_current_client: no target, return (nil)
+1783499626.142471 cmd_find_best_session: 0 sessions to try
+1783499626.142505 cmd_find_best_session: 0 sessions to try
+1783499626.142517 key_bindings_add: 0x10e0ec WheelDownPane = select-pane ; send-keys -X -N 5 scroll-down
+1783499626.142520 cmd_find_best_session: 0 sessions to try
+1783499626.142524 cmdq_next <global>: [bind-key/0x58e4725380d0] (0), flags 0
+1783499626.142526 cmd_find_best_session: 0 sessions to try
+1783499626.142528 cmd_find_current_client: no target, return (nil)
+1783499626.142531 cmd_find_best_session: 0 sessions to try
+1783499626.142533 cmd_find_current_client: no target, return (nil)
+1783499626.142535 cmd_find_best_session: 0 sessions to try
+1783499626.142536 cmd_find_best_session: 0 sessions to try
+1783499626.142795 key_bindings_add: 0x10e128 DoubleClick1Pane = select-pane ; send-keys -X select-word ; run-shell -d 0.3 ; send-keys -X copy-pipe-and-cancel
+1783499626.142827 cmd_find_best_session: 0 sessions to try
+1783499626.143111 cmdq_next <global>: [bind-key/0x58e472537d10] (0), flags 0
+1783499626.143119 cmd_find_best_session: 0 sessions to try
+1783499626.143124 cmd_find_current_client: no target, return (nil)
+1783499626.143129 cmd_find_best_session: 0 sessions to try
+1783499626.143580 cmd_find_current_client: no target, return (nil)
+1783499626.143587 cmd_find_best_session: 0 sessions to try
+1783499626.143591 cmd_find_best_session: 0 sessions to try
+1783499626.144158 key_bindings_add: 0x10e15e TripleClick1Pane = select-pane ; send-keys -X select-line ; run-shell -d 0.3 ; send-keys -X copy-pipe-and-cancel
+1783499626.144192 cmd_find_best_session: 0 sessions to try
+1783499626.144695 cmdq_next <global>: [bind-key/0x58e4725386f0] (0), flags 0
+1783499626.144709 cmd_find_best_session: 0 sessions to try
+1783499626.144712 cmd_find_current_client: no target, return (nil)
+1783499626.144714 cmd_find_best_session: 0 sessions to try
+1783499626.144716 cmd_find_current_client: no target, return (nil)
+1783499626.144718 cmd_find_best_session: 0 sessions to try
+1783499626.144719 cmd_find_best_session: 0 sessions to try
+1783499626.144763 key_bindings_add: 0x10e194 BSpace = send-keys -X cursor-left
+1783499626.144767 cmd_find_best_session: 0 sessions to try
+1783499626.144771 cmdq_next <global>: [bind-key/0x58e472538ff0] (0), flags 0
+1783499626.144773 cmd_find_best_session: 0 sessions to try
+1783499626.144774 cmd_find_current_client: no target, return (nil)
+1783499626.144776 cmd_find_best_session: 0 sessions to try
+1783499626.144777 cmd_find_current_client: no target, return (nil)
+1783499626.144779 cmd_find_best_session: 0 sessions to try
+1783499626.144780 cmd_find_best_session: 0 sessions to try
+1783499626.144785 key_bindings_add: 0x10e1a5 NPage = send-keys -X page-down
+1783499626.144786 cmd_find_best_session: 0 sessions to try
+1783499626.144789 cmdq_next <global>: [bind-key/0x58e4725397a0] (0), flags 0
+1783499626.144790 cmd_find_best_session: 0 sessions to try
+1783499626.144792 cmd_find_current_client: no target, return (nil)
+1783499626.144794 cmd_find_best_session: 0 sessions to try
+1783499626.144795 cmd_find_current_client: no target, return (nil)
+1783499626.144797 cmd_find_best_session: 0 sessions to try
+1783499626.144799 cmd_find_best_session: 0 sessions to try
+1783499626.144803 key_bindings_add: 0x10e1a6 PPage = send-keys -X page-up
+1783499626.144805 cmd_find_best_session: 0 sessions to try
+1783499626.144807 cmdq_next <global>: [bind-key/0x58e472539b90] (0), flags 0
+1783499626.144809 cmd_find_best_session: 0 sessions to try
+1783499626.144810 cmd_find_current_client: no target, return (nil)
+1783499626.144812 cmd_find_best_session: 0 sessions to try
+1783499626.144813 cmd_find_current_client: no target, return (nil)
+1783499626.144816 cmd_find_best_session: 0 sessions to try
+1783499626.144817 cmd_find_best_session: 0 sessions to try
+1783499626.144821 key_bindings_add: 0x10e1a8 Up = send-keys -X cursor-up
+1783499626.144823 cmd_find_best_session: 0 sessions to try
+1783499626.144825 cmdq_next <global>: [bind-key/0x58e472539fd0] (0), flags 0
+1783499626.144827 cmd_find_best_session: 0 sessions to try
+1783499626.144828 cmd_find_current_client: no target, return (nil)
+1783499626.144830 cmd_find_best_session: 0 sessions to try
+1783499626.144832 cmd_find_current_client: no target, return (nil)
+1783499626.144833 cmd_find_best_session: 0 sessions to try
+1783499626.144835 cmd_find_best_session: 0 sessions to try
+1783499626.144841 key_bindings_add: 0x10e1a9 Down = send-keys -X cursor-down
+1783499626.144842 cmd_find_best_session: 0 sessions to try
+1783499626.144849 cmdq_next <global>: [bind-key/0x58e47253a330] (0), flags 0
+1783499626.144850 cmd_find_best_session: 0 sessions to try
+1783499626.144852 cmd_find_current_client: no target, return (nil)
+1783499626.144853 cmd_find_best_session: 0 sessions to try
+1783499626.144855 cmd_find_current_client: no target, return (nil)
+1783499626.144856 cmd_find_best_session: 0 sessions to try
+1783499626.144857 cmd_find_best_session: 0 sessions to try
+1783499626.144862 key_bindings_add: 0x10e1aa Left = send-keys -X cursor-left
+1783499626.144863 cmd_find_best_session: 0 sessions to try
+1783499626.144883 cmdq_next <global>: [bind-key/0x58e47253a770] (0), flags 0
+1783499626.144885 cmd_find_best_session: 0 sessions to try
+1783499626.144886 cmd_find_current_client: no target, return (nil)
+1783499626.144888 cmd_find_best_session: 0 sessions to try
+1783499626.144889 cmd_find_current_client: no target, return (nil)
+1783499626.144890 cmd_find_best_session: 0 sessions to try
+1783499626.144892 cmd_find_best_session: 0 sessions to try
+1783499626.144895 key_bindings_add: 0x10e1ab Right = send-keys -X cursor-right
+1783499626.144897 cmd_find_best_session: 0 sessions to try
+1783499626.144908 cmdq_next <global>: [bind-key/0x58e47253ab40] (0), flags 0
+1783499626.144910 cmd_find_best_session: 0 sessions to try
+1783499626.144911 cmd_find_current_client: no target, return (nil)
+1783499626.144913 cmd_find_best_session: 0 sessions to try
+1783499626.144914 cmd_find_current_client: no target, return (nil)
+1783499626.144916 cmd_find_best_session: 0 sessions to try
+1783499626.144917 cmd_find_best_session: 0 sessions to try
+1783499626.144965 key_bindings_add: 0x100000000078 M-x = send-keys -X jump-to-mark
+1783499626.144969 cmd_find_best_session: 0 sessions to try
+1783499626.144973 cmdq_next <global>: [bind-key/0x58e47253b200] (0), flags 0
+1783499626.144975 cmd_find_best_session: 0 sessions to try
+1783499626.144977 cmd_find_current_client: no target, return (nil)
+1783499626.144978 cmd_find_best_session: 0 sessions to try
+1783499626.144980 cmd_find_current_client: no target, return (nil)
+1783499626.144981 cmd_find_best_session: 0 sessions to try
+1783499626.144983 cmd_find_best_session: 0 sessions to try
+1783499626.144988 key_bindings_add: 0x20000010e1a8 C-Up = send-keys -X scroll-up
+1783499626.144990 cmd_find_best_session: 0 sessions to try
+1783499626.144993 cmdq_next <global>: [bind-key/0x58e47253b6f0] (0), flags 0
+1783499626.144994 cmd_find_best_session: 0 sessions to try
+1783499626.144996 cmd_find_current_client: no target, return (nil)
+1783499626.144997 cmd_find_best_session: 0 sessions to try
+1783499626.144999 cmd_find_current_client: no target, return (nil)
+1783499626.145000 cmd_find_best_session: 0 sessions to try
+1783499626.145021 cmd_find_best_session: 0 sessions to try
+1783499626.145027 key_bindings_add: 0x20000010e1a9 C-Down = send-keys -X scroll-down
+1783499626.145029 cmd_find_best_session: 0 sessions to try
+1783499626.145032 cmdq_next <global>: [key_bindings_init_done/0x58e47253bc70] (1), flags 0
+1783499626.145156 cmdq_next <global>: exit (empty)
+1783499626.145168 cmdq_next <global>: empty
+1783499626.145612 peer 0x58e47253c880 message 110
+1783499626.145758 client 0x58e47253bd70 IDENTIFY_STDOUT 9
+1783499626.145763 peer 0x58e47253c880 message 107
+1783499626.145766 client 0x58e47253bd70 IDENTIFY_CLIENTPID 988175
+1783499626.145768 peer 0x58e47253c880 message 105
+1783499626.145772 client 0x58e47253bd70 IDENTIFY_ENVIRON AI_AGENT=claude-code_2-1-202_agent
+1783499626.145774 peer 0x58e47253c880 message 105
+1783499626.145777 client 0x58e47253bd70 IDENTIFY_ENVIRON ATUIN_HISTORY_ID=019f3bfa64c07042852c4ee73bfa28b6
+1783499626.145779 peer 0x58e47253c880 message 105
+1783499626.145781 client 0x58e47253bd70 IDENTIFY_ENVIRON ATUIN_PREEXEC_BACKEND=1:bash-preexec
+1783499626.145783 peer 0x58e47253c880 message 105
+1783499626.145785 client 0x58e47253bd70 IDENTIFY_ENVIRON ATUIN_SESSION=019f3bc1efe674b1ba1d6f13652ff073
+1783499626.145787 peer 0x58e47253c880 message 105
+1783499626.145789 client 0x58e47253bd70 IDENTIFY_ENVIRON ATUIN_SHLVL=1
+1783499626.145791 peer 0x58e47253c880 message 105
+1783499626.145793 client 0x58e47253bd70 IDENTIFY_ENVIRON ATUIN_TMUX_POPUP=false
+1783499626.145795 peer 0x58e47253c880 message 105
+1783499626.145797 client 0x58e47253bd70 IDENTIFY_ENVIRON BUN_INSTALL=/home/sme/.bun
+1783499626.145799 peer 0x58e47253c880 message 105
+1783499626.145801 client 0x58e47253bd70 IDENTIFY_ENVIRON CLAUDECODE=1
+1783499626.145803 peer 0x58e47253c880 message 105
+1783499626.145805 client 0x58e47253bd70 IDENTIFY_ENVIRON CLAUDE_CODE_BRIDGE_SESSION_ID=session_01VEv9fSfxTg7qXtFjw9Rp63
+1783499626.145806 peer 0x58e47253c880 message 105
+1783499626.145808 client 0x58e47253bd70 IDENTIFY_ENVIRON CLAUDE_CODE_CHILD_SESSION=1
+1783499626.145810 peer 0x58e47253c880 message 105
+1783499626.145812 client 0x58e47253bd70 IDENTIFY_ENVIRON CLAUDE_CODE_ENTRYPOINT=cli
+1783499626.145814 peer 0x58e47253c880 message 105
+1783499626.145817 client 0x58e47253bd70 IDENTIFY_ENVIRON CLAUDE_CODE_EXECPATH=/home/sme/.local/share/claude/versions/2.1.202
+1783499626.145819 peer 0x58e47253c880 message 105
+1783499626.145822 client 0x58e47253bd70 IDENTIFY_ENVIRON CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
+1783499626.145824 peer 0x58e47253c880 message 105
+1783499626.145833 client 0x58e47253bd70 IDENTIFY_ENVIRON CLAUDE_CODE_SESSION_ID=c1b29522-1a31-472b-a2ee-a6ee3ae1a9d6
+1783499626.145835 peer 0x58e47253c880 message 105
+1783499626.145837 client 0x58e47253bd70 IDENTIFY_ENVIRON CLAUDE_CODE_TEAMMATE_MODE=tmux
+1783499626.145839 peer 0x58e47253c880 message 105
+1783499626.145841 client 0x58e47253bd70 IDENTIFY_ENVIRON CLAUDE_EFFORT=high
+1783499626.145843 peer 0x58e47253c880 message 105
+1783499626.145844 client 0x58e47253bd70 IDENTIFY_ENVIRON CLI_AUDIT_JSON=1
+1783499626.145846 peer 0x58e47253c880 message 105
+1783499626.145848 client 0x58e47253bd70 IDENTIFY_ENVIRON COREPACK_ENABLE_AUTO_PIN=0
+1783499626.145850 peer 0x58e47253c880 message 105
+1783499626.145904 client 0x58e47253bd70 IDENTIFY_ENVIRON DIRENV_DIFF=eJx00D2TojAAxvHvkloWFFc9uyjZiLC8GaJnkwGNiEcCGEBlx-9-s8XNzhX2z-8p_l-gAvMvQO2IxNBlyKNgDvRzKbiuBNffOi47pR95B54DIL-nlh0hjzLLjsAcaD_TSj-Ux1xmLMm4bNihyFlTloXiDRj8Qx-2i_77f430Ny676-HHbiFZrtAGzAFf31Wvhs7dgiH0F-Yjleod85TIq-mssp2zD9ZTKwm9xkU0sk7mrtt_sMvYlIxiRmkfXrdtJgzCIWmdZGbe-eTxa7xzpaya_W-x2kwewe19m5l1U_OjN8Q3EZjCvaXFojv1f4ZVm2gMFafZJ9GoXcdjPDJyHM7y1RRO8ljLjJGPFRrF4c5JsH-poMI93zvTgI5nI5Qvhe_jQhhbadCJd9kEU7zIaLBOo_PRq0-bM2MwhJAx7UDiNgUDEET-Gi0J8-Dnd8CXpZ_PvwEAAP__tMuaXw==
+1783499626.145912 peer 0x58e47253c880 message 105
+1783499626.145916 client 0x58e47253bd70 IDENTIFY_ENVIRON DIRENV_DIR=-/home/sme/p/coding_agent_cli_toolset
+1783499626.145918 peer 0x58e47253c880 message 105
+1783499626.145921 client 0x58e47253bd70 IDENTIFY_ENVIRON DIRENV_FILE=/home/sme/p/coding_agent_cli_toolset/.envrc
+1783499626.145923 peer 0x58e47253c880 message 105
+1783499626.145928 client 0x58e47253bd70 IDENTIFY_ENVIRON DIRENV_WATCHES=eJxszs1KxDAQAOB3ybns5GebTnr3KHgXKZPJ7DaQNtLEVRDf3XvZF_j43n_VG_VVzQrWugm0TeATuKa83xe6y94XLnnptZYmHS6yPw5Wg3qtqedN1GwmP3mLwblBvfzk1pua-_Elf8MT-VIqU4G20iGQ8iH7A6iU-g02OGsE2UQXKaGOjpAsGzeZK7PV482EiCmOOGlm0Wn0V6NjSP7GBgVPJbRhdNqfSh__AQAA__-cTUub
+1783499626.145931 peer 0x58e47253c880 message 105
+1783499626.145980 client 0x58e47253bd70 IDENTIFY_ENVIRON DISPLAY=:0
+1783499626.146011 peer 0x58e47253c880 message 105
+1783499626.146147 client 0x58e47253bd70 IDENTIFY_ENVIRON EDITOR=vim
+1783499626.146152 peer 0x58e47253c880 message 105
+1783499626.146156 client 0x58e47253bd70 IDENTIFY_ENVIRON GITLAB_HOST=git.netresearch.de
+1783499626.146158 peer 0x58e47253c880 message 105
+1783499626.146161 client 0x58e47253bd70 IDENTIFY_ENVIRON GIT_EDITOR=true
+1783499626.146163 peer 0x58e47253c880 message 105
+1783499626.146165 client 0x58e47253bd70 IDENTIFY_ENVIRON HISTCONTROL=ignoredups:
+1783499626.146167 peer 0x58e47253c880 message 105
+1783499626.146169 client 0x58e47253bd70 IDENTIFY_ENVIRON HOME=/home/sme
+1783499626.146172 peer 0x58e47253c880 message 105
+1783499626.146174 client 0x58e47253bd70 IDENTIFY_ENVIRON HOMEBREW_CELLAR=/home/linuxbrew/.linuxbrew/Cellar
+1783499626.146176 peer 0x58e47253c880 message 105
+1783499626.146179 client 0x58e47253bd70 IDENTIFY_ENVIRON HOMEBREW_PREFIX=/home/linuxbrew/.linuxbrew
+1783499626.146181 peer 0x58e47253c880 message 105
+1783499626.146183 client 0x58e47253bd70 IDENTIFY_ENVIRON HOMEBREW_REPOSITORY=/home/linuxbrew/.linuxbrew/Homebrew
+1783499626.146185 peer 0x58e47253c880 message 105
+1783499626.146187 client 0x58e47253bd70 IDENTIFY_ENVIRON HOSTTYPE=x86_64
+1783499626.146189 peer 0x58e47253c880 message 105
+1783499626.146191 client 0x58e47253bd70 IDENTIFY_ENVIRON INFOPATH=/home/linuxbrew/.linuxbrew/share/info:
+1783499626.146240 peer 0x58e47253c880 message 105
+1783499626.146246 client 0x58e47253bd70 IDENTIFY_ENVIRON LANG=C.UTF-8
+1783499626.146248 peer 0x58e47253c880 message 105
+1783499626.146251 client 0x58e47253bd70 IDENTIFY_ENVIRON LESSCLOSE=/usr/bin/lesspipe %s %s
+1783499626.146253 peer 0x58e47253c880 message 105
+1783499626.146255 client 0x58e47253bd70 IDENTIFY_ENVIRON LESSOPEN=| /usr/bin/lesspipe %s
+1783499626.146258 peer 0x58e47253c880 message 105
+1783499626.146260 client 0x58e47253bd70 IDENTIFY_ENVIRON LOGNAME=sme
+1783499626.146263 peer 0x58e47253c880 message 105
+1783499626.146281 client 0x58e47253bd70 IDENTIFY_ENVIRON LS_COLORS=rs=0:di=01;34:ln=01;36:mh=00:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=40;31;01:mi=00:su=37;41:sg=30;43:ca=00:tw=30;42:ow=34;42:st=37;44:ex=01;32:*.tar=01;31:*.tgz=01;31:*.arc=01;31:*.arj=01;31:*.taz=01;31:*.lha=01;31:*.lz4=01;31:*.lzh=01;31:*.lzma=01;31:*.tlz=01;31:*.txz=01;31:*.tzo=01;31:*.t7z=01;31:*.zip=01;31:*.z=01;31:*.dz=01;31:*.gz=01;31:*.lrz=01;31:*.lz=01;31:*.lzo=01;31:*.xz=01;31:*.zst=01;31:*.tzst=01;31:*.bz2=01;31:*.bz=01;31:*.tbz=01;31:*.tbz2=01;31:*.tz=01;31:*.deb=01;31:*.rpm=01;31:*.jar=01;31:*.war=01;31:*.ear=01;31:*.sar=01;31:*.rar=01;31:*.alz=01;31:*.ace=01;31:*.zoo=01;31:*.cpio=01;31:*.7z=01;31:*.rz=01;31:*.cab=01;31:*.wim=01;31:*.swm=01;31:*.dwm=01;31:*.esd=01;31:*.avif=01;35:*.jpg=01;35:*.jpeg=01;35:*.mjpg=01;35:*.mjpeg=01;35:*.gif=01;35:*.bmp=01;35:*.pbm=01;35:*.pgm=01;35:*.ppm=01;35:*.tga=01;35:*.xbm=01;35:*.xpm=01;35:*.tif=01;35:*.tiff=01;35:*.png=01;35:*.svg=01;35:*.svgz=01;35:*.mng=01;35:*.pcx=01;35:*.mov=01;35:*.mpg=01;35:*.mpeg=01;35:*.m2v=01;35:*.mkv=01;35:*.webm=01;35:*.webp=01;35:*.ogm=01;35:*.mp4=01;35:*.m4v=01;35:*.mp4v=01;35:*.vob=01;35:*.qt=01;35:*.nuv=01;35:*.wmv=01;35:*.asf=01;35:*.rm=01;35:*.rmvb=01;35:*.flc=01;35:*.avi=01;35:*.fli=01;35:*.flv=01;35:*.gl=01;35:*.dl=01;35:*.xcf=01;35:*.xwd=01;35:*.yuv=01;35:*.cgm=01;35:*.emf=01;35:*.ogv=01;35:*.ogx=01;35:*.aac=00;36:*.au=00;36:*.flac=00;36:*.m4a=00;36:*.mid=00;36:*.midi=00;36:*.mka=00;36:*.mp3=00;36:*.mpc=00;36:*.ogg=00;36:*.ra=00;36:*.wav=00;36:*.oga=00;36:*.opus=00;36:*.spx=00;36:*.xspf=00;36:*~=00;90:*#=00;90:*.bak=00;90:*.crdownload=00;90:*.dpkg-dist=00;90:*.dpkg-new=00;90:*.dpkg-old=00;90:*.dpkg-tmp=00;90:*.old=00;90:*.orig=00;90:*.part=00;90:*.rej=00;90:*.rpmnew=00;90:*.rpmorig=00;90:*.rpmsave=00;90:*.swp=00;90:*.tmp=00;90:*.ucf-dist=00;90:*.ucf-new=00;90:*.ucf-old=00;90:
+1783499626.146291 peer 0x58e47253c880 message 105
+1783499626.146294 client 0x58e47253bd70 IDENTIFY_ENVIRON NAME=iot-563-win
+1783499626.146296 peer 0x58e47253c880 message 105
+1783499626.146299 client 0x58e47253bd70 IDENTIFY_ENVIRON NVM_BIN=/home/sme/.nvm/versions/node/v25.9.0/bin
+1783499626.146301 peer 0x58e47253c880 message 105
+1783499626.146303 client 0x58e47253bd70 IDENTIFY_ENVIRON NVM_CD_FLAGS=
+1783499626.146305 peer 0x58e47253c880 message 105
+1783499626.146307 client 0x58e47253bd70 IDENTIFY_ENVIRON NVM_DIR=/home/sme/.nvm
+1783499626.146309 peer 0x58e47253c880 message 105
+1783499626.146311 client 0x58e47253bd70 IDENTIFY_ENVIRON NVM_INC=/home/sme/.nvm/versions/node/v25.9.0/include/node
+1783499626.146313 peer 0x58e47253c880 message 105
+1783499626.146315 client 0x58e47253bd70 IDENTIFY_ENVIRON NoDefaultCurrentDirectoryInExePath=1
+1783499626.146318 peer 0x58e47253c880 message 105
+1783499626.146320 client 0x58e47253bd70 IDENTIFY_ENVIRON OLDPWD=/home/sme/p/coding_agent_cli_toolset
+1783499626.146323 peer 0x58e47253c880 message 105
+1783499626.146653 client 0x58e47253bd70 IDENTIFY_ENVIRON PATH=/home/sme/p/coding_agent_cli_toolset/.venv/bin:/home/sme/.local/bin:/home/sme/.bun/bin:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:/home/sme/go/bin:/home/sme/.local/bin:/home/sme/.rbenv/shims:/home/sme/.rbenv/bin:/home/sme/.local/bin:/home/sme/.venvs/dev/bin:/home/sme/.cargo/bin:/home/sme/.nvm/versions/node/v25.9.0/bin:/home/sme/.local/share/pnpm:/home/sme/.config/herd-lite/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/lib/wsl/lib:/mnt/c/WINDOWS/system32:/mnt/c/WINDOWS:/mnt/c/WINDOWS/System32/Wbem:/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/:/mnt/c/WINDOWS/System32/OpenSSH/:/mnt/c/Program Files/WireGuard/:/mnt/c/Program Files/dotnet/:/mnt/c/ProgramData/chocolatey/bin:/mnt/c/Users/sebastian.mendel/AppData/Local/Programs/cursor/resources/app/bin:/mnt/c/WINDOWS/system32:/mnt/c/WINDOWS:/mnt/c/WINDOWS/System32/Wbem:/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/:/mnt/c/WINDOWS/System32/OpenSSH/:/mnt/c/Program Files/PowerShell/7/:/mnt/c/Program Files/PyManager/:/mnt/c/Program Files/PuTTY/:/mnt/c/Program Files/Go/bin:/mnt/c/Program Files/Docker/Docker/resources/bin:/mnt/c/Program Files/nodejs/:/mnt/c/Program Files/PowerToys/DSCModules/:/mnt/c/Program Files/WSL/:/mnt/c/Program Files/Git/cmd:/mnt/c/Program Files/GitHub CLI/:/mnt/c/Users/sebastian.mendel/AppData/Local/Programs/Python/Python314/Scripts/:/mnt/c/Users/sebastian.mendel/AppData/Local/Programs/Python/Python314/:/mnt/c/Users/sebastian.mendel/AppData/Local/Programs/Python/Launcher/:/mnt/c/Users/sebastian.mendel/AppData/Local/Microsoft/WindowsApps:/mnt/c/Users/sebastian.mendel/AppData/Local/Programs/Microsoft VS Code/bin:/mnt/c/Users/sebastian.mendel/AppData/Local/GitHubDesktop/bin:/mnt/c/Users/sebastian.mendel/AppData/Local/Microsoft/WinGet/Packages/Microsoft.AIShell_Microsoft.Winget.Source_8wekyb3d8bbwe:/mnt/c/Users/sebastian.mendel/AppData/Local/Programs/AIShell:/mnt/c/Users/sebastian.mendel/go/bin:/mnt/c/Users/sebastian.mendel/AppData/Roaming/Cursor/User/globalStorage/ms-vscode-remote.remote-containers/cli-bin:/mnt/c/Users/sebastian.mendel/AppData/Local/Programs/cursor/resources/app/bin:/mnt/c/Users/sebastian.mendel/AppData/Local/Microsoft/WindowsApps:/mnt/c/Users/sebastian.mendel/AppData/Local/Microsoft/WinGet/Links:/mnt/c/Users/sebastian.mendel/AppData/Local/Programs/glab:/mnt/c/Users/sebastian.mendel/go/bin:/mnt/c/Users/sebastian.mendel/AppData/Roaming/npm:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/cli-tools/1.8.1/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/coach/2.5.3/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/enterprise-readiness/4.15.0/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/git-workflow/1.18.4/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/github-project/2.15.6/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/go-development/1.13.1/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/jira-integration/3.19.0/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/netresearch-branding/2.9.2/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/php-modernization/1.20.0/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/security-audit/2.10.4/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/skill-repo/1.25.2/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/typo3-ckeditor5/1.8.0/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/typo3-conformance/2.15.1/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/typo3-core-contributions/1.11.0/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/typo3-ddev/1.21.0/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/typo3-docs/2.14.1/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/typo3-extension-upgrade/3.9.0/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/typo3-testing/5.18.2/bin:/home/sme/.claude/plugins/cache/netresearch-marketplace/netresearch-gitlab/1.3.3/bin:/home/sme/.claude/plugins/cache/netresearch-marketplace/netresearch-jira/2.7.2/bin:/home/sme/.claude/plugins/cache/netresearch-marketplace/typo3-project-evaluator/1.0.3/bin:/home/sme/.claude/plugins/cache/netresearch-marketplace/typo3-upgrade-estimator/2.1.0/bin:/home/sme/.claude/plugins/cache/claude-plugins-official/pyright-lsp/1.0.0/bin:/home/sme/.claude/plugins/cache/claude-plugins-official/gopls-lsp/1.0.0/bin:/home/sme/.claude/plugins/cache/claude-plugins-official/rust-analyzer-lsp/1.0.0/bin:/home/sme/.claude/plugins/cache/claude-plugins-official/php-lsp/1.0.0/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/concourse-ci/1.9.0/bin:/home/sme/.claude/plugins/cache/claude-plugins-official/code-review/unknown/bin:/home/sme/.claude/plugins/cache/claude-plugins-official/feature-dev/unknown/bin:/home/sme/.claude/plugins/cache/claude-plugins-official/frontend-design/unknown/bin:/home/sme/.claude/plugins/cache/claude-plugins-official/pr-review-toolkit/unknown/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/docker-development/1.10.0/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/matrix-communication/1.25.3/bin:/home/sme/.claude/plugins/cache/claude-plugins-official/commit-commands/unknown/bin:/home/sme/.claude/plugins/cache/claude-plugins-official/playwright/unknown/bin:/home/sme/.claude/plugins/cache/claude-plugins-official/superpowers/6.1.1/bin:/home/sme/.claude/plugins/cache/claude-plugins-official/typescript-lsp/1.0.0/bin:/home/sme/.claude/plugins/cache/claude-plugins-official/serena/unknown/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/automated-assessment/2.10.1/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/data-tools/1.6.2/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/file-search/1.6.1/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/typo3-project-upgrade/1.3.0/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/agent-harness/1.6.0/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/agent-rules/3.13.1/bin:/home/sme/.claude/plugins/cache/netresearch-marketplace/netresearch-maintenance/1.9.2/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/typo3-typoscript-ref/1.4.0/bin:/home/sme/.claude/plugins/cache/netresearch-marketplace/typo3-update-issues/1.2.4/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/github-release/0.8.3/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/typo3-a11y/1.2.0/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/typo3-frontend-patterns/1.2.0/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/typo3-vite/1.5.0/bin:/home/sme/.claude/plugins/cache/netresearch-marketplace/activity-detective/1.0.2/bin:/home/sme/.claude/plugins/cache/netresearch-marketplace/dxp-frontend/2.3.0/bin:/home/sme/.claude/plugins/cache/netresearch-marketplace/dxp-local/1.5.5/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/german-technical-writing/1.2.2/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/peer-qa-review/0.5.2/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/retro/1.0.1/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/typo3-upgrade-effort-model/1.2.1/bin:/home/sme/.claude/plugins/cache/netresearch-marketplace/netresearch-evaluation/0.1.0/bin:/home/sme/.claude/plugins/cache/netresearch-marketplace/netresearch-onboarding/1.0.1/bin:/home/sme/.claude/plugins/cache/netresearch-claude-code-marketplace/jujutsu-workflow/0.1.0/bin:/home/sme/.claude/plugins/cache/addy-agent-skills/agent-skills/70b7506ce90e/bin:/home/sme/.claude/plugins/cache/anticipating-shadow-points/anticipating-shadow-points/1.0.0/bin:/home/sme/.claude/plugins/cache/ui-ux-pro-max-skill/ui-ux-pro-max/2.6.2/bin:/home/sme/.claude/plugins/cache/netresearch-marketplace/netresearch-offboarding/0.4.5/bin
+1783499626.146686 peer 0x58e47253c880 message 105
+1783499626.146693 client 0x58e47253bd70 IDENTIFY_ENVIRON PHP_INI_SCAN_DIR=/home/sme/.config/herd-lite/bin:
+1783499626.146695 peer 0x58e47253c880 message 105
+1783499626.146699 client 0x58e47253bd70 IDENTIFY_ENVIRON PNPM_HOME=/home/sme/.local/share/pnpm
+1783499626.146701 peer 0x58e47253c880 message 105
+1783499626.146752 client 0x58e47253bd70 IDENTIFY_ENVIRON PROJECT_NAME=coding_agent_cli_toolset
+1783499626.146757 peer 0x58e47253c880 message 105
+1783499626.146761 client 0x58e47253bd70 IDENTIFY_ENVIRON PULSE_SERVER=unix:/mnt/wslg/PulseServer
+1783499626.146764 peer 0x58e47253c880 message 105
+1783499626.146775 client 0x58e47253bd70 IDENTIFY_ENVIRON PWD=/home/sme/p/coding_agent_cli_toolset
+1783499626.146778 peer 0x58e47253c880 message 105
+1783499626.146781 client 0x58e47253bd70 IDENTIFY_ENVIRON RBENV_SHELL=bash
+1783499626.146783 peer 0x58e47253c880 message 105
+1783499626.146786 client 0x58e47253bd70 IDENTIFY_ENVIRON SHELL=/bin/bash
+1783499626.146788 peer 0x58e47253c880 message 105
+1783499626.146791 client 0x58e47253bd70 IDENTIFY_ENVIRON SHLVL=2
+1783499626.146793 peer 0x58e47253c880 message 105
+1783499626.146817 client 0x58e47253bd70 IDENTIFY_ENVIRON SSH_AGENT_PID=857
+1783499626.146820 peer 0x58e47253c880 message 105
+1783499626.146824 client 0x58e47253bd70 IDENTIFY_ENVIRON SSH_AUTH_SOCK=/tmp/ssh-cLEMaBGKLcXE/agent.855
+1783499626.146826 peer 0x58e47253c880 message 105
+1783499626.146829 client 0x58e47253bd70 IDENTIFY_ENVIRON STARSHIP_SESSION_KEY=2974114123020747
+1783499626.146831 peer 0x58e47253c880 message 105
+1783499626.146834 client 0x58e47253bd70 IDENTIFY_ENVIRON STARSHIP_SHELL=bash
+1783499626.146836 peer 0x58e47253c880 message 105
+1783499626.146838 client 0x58e47253bd70 IDENTIFY_ENVIRON TERM=dumb
+1783499626.146840 peer 0x58e47253c880 message 105
+1783499626.146843 client 0x58e47253bd70 IDENTIFY_ENVIRON USER=sme
+1783499626.146845 peer 0x58e47253c880 message 105
+1783499626.146848 client 0x58e47253bd70 IDENTIFY_ENVIRON UV=/home/sme/.local/bin/uv
+1783499626.146850 peer 0x58e47253c880 message 105
+1783499626.146852 client 0x58e47253bd70 IDENTIFY_ENVIRON UV_RUN_RECURSION_DEPTH=1
+1783499626.146855 peer 0x58e47253c880 message 105
+1783499626.146858 client 0x58e47253bd70 IDENTIFY_ENVIRON VIRTUAL_ENV=/home/sme/p/coding_agent_cli_toolset/.venv
+1783499626.146861 peer 0x58e47253c880 message 105
+1783499626.146864 client 0x58e47253bd70 IDENTIFY_ENVIRON VIRTUAL_ENV_PROMPT=dev
+1783499626.146866 peer 0x58e47253c880 message 105
+1783499626.146868 client 0x58e47253bd70 IDENTIFY_ENVIRON VISUAL=vim
+1783499626.146870 peer 0x58e47253c880 message 105
+1783499626.146873 client 0x58e47253bd70 IDENTIFY_ENVIRON WAYLAND_DISPLAY=wayland-0
+1783499626.146875 peer 0x58e47253c880 message 105
+1783499626.146877 client 0x58e47253bd70 IDENTIFY_ENVIRON WSL2_GUI_APPS_ENABLED=1
+1783499626.146879 peer 0x58e47253c880 message 105
+1783499626.146882 client 0x58e47253bd70 IDENTIFY_ENVIRON WSLENV=WT_SESSION:WT_PROFILE_ID:
+1783499626.146884 peer 0x58e47253c880 message 105
+1783499626.146887 client 0x58e47253bd70 IDENTIFY_ENVIRON WSL_DISTRO_NAME=Ubuntu
+1783499626.146889 peer 0x58e47253c880 message 105
+1783499626.146892 client 0x58e47253bd70 IDENTIFY_ENVIRON WSL_INTEROP=/run/WSL/130160_interop
+1783499626.146894 peer 0x58e47253c880 message 105
+1783499626.146898 client 0x58e47253bd70 IDENTIFY_ENVIRON WT_PROFILE_ID={2c4de342-38b7-51cf-b940-2309a097f518}
+1783499626.146900 peer 0x58e47253c880 message 105
+1783499626.146903 client 0x58e47253bd70 IDENTIFY_ENVIRON WT_SESSION=da3e4bf6-74df-479a-bb3c-107b19587e4f
+1783499626.146905 peer 0x58e47253c880 message 105
+1783499626.146908 client 0x58e47253bd70 IDENTIFY_ENVIRON XDG_RUNTIME_DIR=/mnt/wslg/runtime-dir
+1783499626.146910 peer 0x58e47253c880 message 105
+1783499626.146913 client 0x58e47253bd70 IDENTIFY_ENVIRON _=/usr/bin/timeout
+1783499626.146915 peer 0x58e47253c880 message 106
+1783499626.146918 client 0x58e47253bd70 name is client-988175
+1783499626.146935 cmdq_append <client-988175>: [cfg_client_done/0x58e472534e30]
+1783499626.146942 loading /home/sme/.tmux.conf
+1783499626.147913 yylex_token: end at WS
+1783499626.147923 yylex_token: set
+1783499626.147927 yylex_token: end at WS
+1783499626.147928 yylex_token: -g
+1783499626.147930 yylex_token: end at WS
+1783499626.147932 yylex_token: mouse
+1783499626.147934 yylex_token: end at EOL
+1783499626.147935 yylex_token: on
+1783499626.147942 cmd_parse_build_commands 0:0: set
+1783499626.147944 cmd_parse_build_commands 0:1: -g
+1783499626.147945 cmd_parse_build_commands 0:2: mouse
+1783499626.147947 cmd_parse_build_commands 0:3: on
+1783499626.147959 args_parse_flags: next -g
+1783499626.147960 args_parse_flags: -g
+1783499626.147962 args_parse_flags: next mouse
+1783499626.147963 args_parse: flags end at 2 of 4
+1783499626.147965 args_parse: 2 = mouse (type STRING)
+1783499626.147967 args_parse: 3 = on (type STRING)
+1783499626.147975 cmd_parse_build_commands: set-option -g mouse on
+1783499626.148079 cmdq_get_command: [set-option/0x58e472536a20] group 2709
+1783499626.148088 cmdq_append <global>: [set-option/0x58e472536a20]
+1783499626.148091 cmdq_append <global>: [cfg_done/0x58e4725372d0]
+1783499626.148099 cmdq_next <global>: enter
+1783499626.148103 cmdq_next <global>: [set-option/0x58e472536a20] (0), flags 0
+1783499626.148114 cmd_find_best_session: 0 sessions to try
+1783499626.148117 cmd_find_current_client: no target, return (nil)
+1783499626.148119 cmd_find_best_session: 0 sessions to try
+1783499626.148120 cmd_find_current_client: no target, return (nil)
+1783499626.148123 cmd_find_best_session: 0 sessions to try
+1783499626.148216 cmd_find_target: target none, type pane, item 0x58e472536a20, flags QUIET,CANFAIL
+1783499626.148227 cmd_find_best_session: 0 sessions to try
+1783499626.148230 cmd_find_target: error
+1783499626.148374 format_defaults: c=none
+1783499626.148383 format_defaults: s=none
+1783499626.148385 format_defaults: wl=none
+1783499626.148387 format_defaults: wp=none
+1783499626.148544 format_expand1: expanding format: mouse
+1783499626.148589 format_expand1: result is: mouse
+1783499626.148705 options_push_changes: mouse
+1783499626.148715 cmd_find_best_session: 0 sessions to try
+1783499626.148722 cmdq_next <global>: [cfg_done/0x58e4725372d0] (1), flags 0
+1783499626.148807 cmdq_next <global>: exit (empty)
+1783499626.148816 cmdq_next <client-988175>: enter
+1783499626.148821 cmdq_next <client-988175>: [cfg_client_done/0x58e472534e30] (1), flags 0
+1783499626.148824 unref client 0x58e47253bd70 (2 references)
+1783499626.148828 cmdq_next <client-988175>: exit (empty)
+1783499626.148829 cmdq_next <global>: empty
+1783499626.148831 cmdq_next <client-988175>: empty
+1783499626.148910 peer 0x58e47253c880 message 200
+1783499626.148916 cmd_parse_build_commands 0:0: new-session
+1783499626.148925 args_parse: flags end at 1 of 1
+1783499626.148928 cmd_parse_build_commands: new-session
+1783499626.148932 cmdq_get_command: [new-session/0x58e4725372d0] group 2713
+1783499626.148935 cmdq_append <client-988175>: [new-session/0x58e4725372d0]
+1783499626.148939 cmdq_append <client-988175>: [server_client_command_done/0x58e472515a00]
+1783499626.148943 cmdq_next <global>: empty
+1783499626.148945 cmdq_next <client-988175>: enter
+1783499626.148948 cmdq_next <client-988175>: [new-session/0x58e4725372d0] (0), flags 0
+1783499626.149008 message: client-988175 command: new-session
+1783499626.149056 cmd_find_best_session: 0 sessions to try
+1783499626.149064 cmd_find_current_client: no target, return (nil)
+1783499626.149067 cmd_find_best_session: 0 sessions to try
+1783499626.149072 cmd_find_target: target none, type session, item 0x58e4725372d0, flags QUIET,CANFAIL
+1783499626.149074 cmd_find_best_session: 0 sessions to try
+1783499626.149076 cmd_find_target: error
+1783499626.149286 cmdq_error: open terminal failed: not a terminal
+1783499626.149310 message: client-988175 message: open terminal failed: not a terminal
+1783499626.149597 sending message 303 to peer 0x58e47253c880 (12 bytes)
+1783499626.149611 unref client 0x58e47253bd70 (4 references)
+1783499626.149617 cmdq_next <client-988175>: [server_client_command_done/0x58e472515a00] (1), flags 0
+1783499626.149676 unref client 0x58e47253bd70 (3 references)
+1783499626.149685 cmdq_next <client-988175>: exit (empty)
+1783499626.149688 cmdq_next <global>: empty
+1783499626.149691 cmdq_next <client-988175>: empty
+1783499626.149777 cmdq_next <global>: empty
+1783499626.149785 cmdq_next <client-988175>: empty
+1783499626.150464 peer 0x58e47253c880 message 305
+1783499626.150475 sending message 304 to peer 0x58e47253c880 (41 bytes)
+1783499626.150520 file 2 sent 37, left 0
+1783499626.150530 cmdq_next <global>: empty
+1783499626.150534 cmdq_next <client-988175>: empty
+1783499626.150537 sending message 203 to peer 0x58e47253c880 (4 bytes)
+1783499626.150581 cmdq_next <global>: empty
+1783499626.150587 cmdq_next <client-988175>: empty
+1783499626.151687 lost client 0x58e47253bd70
+1783499626.151858 remove peer 0x58e47253c880
+1783499626.151895 unref client 0x58e47253bd70 (2 references)
+1783499626.151978 unref client 0x58e47253bd70 (1 references)
+1783499626.151991 free client 0x58e47253bd70 (0 references)
+1783499626.152002 cmdq_next <global>: empty
+1783499626.152010 server loop exit


### PR DESCRIPTION
Closes the gap where `make upgrade` warns about duplicate installs but offers no
way to act, and where the existing bulk-upgrade commands are undiscoverable.
Design: `docs/superpowers/specs/2026-07-08-reconcile-and-upgrade-discoverability-design.md`.

## What changed

**`audit.py --reconcile` (new CLI over the existing `reconcile.py` engine)**
- `--reconcile <tool>` reports the plan: per-install **version**, which install
  is **active** on PATH (the default when called without a path), and which is
  **preferred** (kept). `--apply` removes the non-preferred duplicates
  (aggressive mode, honoring the system-tool safelist). `--all` sweeps the full
  catalog. JSON via `CLI_AUDIT_JSON=1`.
- Fixes `reconcile_tool` to resolve catalog candidates when a caller omits them,
  so alternate-named duplicates (pip/pip3, fd/fdfind) are caught in bulk sweeps.
  Previously `bulk_reconcile` only looked at `config.tools` (5 tools); the sweep
  now finds all of them (37 on the author's machine).

**Guide (`scripts/guide.sh`)**
- The `⚠️ Multiple installations` listing now shows version + `→ active` +
  `✓ keep` per install, and notes when cleanup would change which binary runs.
- New inline `c = clean up duplicates` action (confirms, then applies).

**Make targets**
- `make reconcile-all` (confirm-each) and `make reconcile-all-dry-run` (plan only).

**Discoverability + safety**
- Audit readiness line and guide summary hint at `make reconcile-all` (when
  duplicates exist) and `make upgrade-managed`.
- `auto_update.sh` warns that native manager upgrades bypass cli-audit pins and
  project lockfiles before running (skipped on dry-run / `FORCE=1`).

## Example

```
⚠️  Multiple installations detected (2):
   • 4.44.3  manual  /home/sme/.local/bin/yq   → active  ✓ keep
   • 4.40.1  manual  /usr/local/bin/yq
```

## Verification

- `pytest`: **644 passed, 1 skipped** (+10 new reconcile-CLI tests; +1 shell
  guard test that the dry-run target never passes `--apply`).
- Gating flake8 (`E9,F63,F7,F82`): clean. Smoke: pass. mypy: no new errors.
- `test_guide_multi_install.sh`: unchanged (same 3 pre-existing failures on
  `main`; no regression).
- `make reconcile-all-dry-run` verified non-destructive; `--all` sweep + render
  markers verified against real duplicates.

Safety model: confirm-each + dry-run; nothing removed without explicit yes;
critical-tools protect list honored; removing the active install gets an extra
heads-up. No version bump / CHANGELOG (feature branch).