### PR TITLE
ci: route shell tests through the shared python-ci reusable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,7 @@ on:
     branches: [main, develop]
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   # Gold-standard meta-reusable pilot. python-app-ci composes lint /
@@ -59,18 +58,25 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
 
+  # The bash suites are driven through python-ci's test step (it runs the
+  # command with `bash -c` from the repo root), so no step-level action is
+  # needed here. test_reconcile_dryrun.sh invokes `python3 audit.py`, which
+  # needs the runtime deps declared in pyproject (packaging, PyYAML) — hence
+  # the editable install and Python 3.14 (pyproject requires-python >=3.14).
   shell-tests:
     name: Shell Tests
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Run shell test suites
-        run: |
-          bash tests/test_guide_multi_install.sh
-          bash tests/test_reconcile_dryrun.sh
+    uses: netresearch/.github/.github/workflows/python-ci.yml@main
+    permissions:
+      contents: read
+    with:
+      python-versions: '["3.14"]'
+      install-cmd: "python -m pip install --upgrade pip && pip install -e ."
+      run-lint: false
+      run-type-check: false
+      run-tests: true
+      test-cmd: >-
+        bash tests/test_guide_multi_install.sh &&
+        bash tests/test_reconcile_dryrun.sh
 
   docs:
     name: Documentation Check


### PR DESCRIPTION
## What

`ci.yml` now contains **zero step-level action uses** — every job is a call to a shared reusable workflow in [netresearch/.github](https://github.com/netresearch/.github). The only job left with inline steps was `shell-tests` (`actions/checkout` + a `run:` block); it now calls [`python-ci.yml`](https://github.com/netresearch/.github/blob/main/.github/workflows/python-ci.yml), whose test step executes the caller-supplied command with `bash -c` from the repo root.

`app-ci`, `docs` and `integration-e2e` were already reusable calls and are untouched.

## Behaviour comparison — `shell-tests`

| Behaviour | Before (inline job) | After (`python-ci.yml@main`) | Verdict |
|---|---|---|---|
| Runner | `runs-on: ubuntu-latest` | `os-versions` default `'["ubuntu-latest"]'` | identical |
| Checkout | `actions/checkout@3d3c42e` (v7) | `actions/checkout@3d3c42e` (v7), same SHA, plus `persist-credentials: false` | identical + hardened (the suites use no git credentials) |
| Commands | `bash tests/test_guide_multi_install.sh` then `bash tests/test_reconcile_dryrun.sh` in one `run: |` block | `test-cmd: bash tests/test_guide_multi_install.sh && bash tests/test_reconcile_dryrun.sh` | identical — GitHub runs `run:` with `bash -e`, so the second script was already skipped when the first failed; `&&` reproduces that exactly |
| Working directory | repo root | `working-directory` default `.` | identical |
| Shell | `bash -e` | `defaults.run.shell: bash`, command run via `bash -c` | identical |
| Lint / type-check | none | `run-lint: false`, `run-type-check: false` | identical (nothing added) |
| Python interpreter | runner system `python3` (3.12 on `ubuntu-24.04`) | `actions/setup-python` 3.14 + `pip install -e .` | see delta 1 |
| Job permissions | inherited workflow default `contents: read` | job-level `contents: read`, reusable job declares `contents: read` | identical effective token |
| Job timeout | none (6 h platform default) | `timeout-minutes` default 15 | see delta 2 |
| Artefacts / coverage | none | `upload-coverage-*` default `false` | identical |
| Job gate (`if:`) | none | reusable skips only when every feature is off; `run-tests: true` keeps it running | identical |

`python-ci.yml`'s `workflow_call` inputs, `secrets`, per-job `permissions` (`contents: read`) and steps were read from source on `main` before mapping. No input needed by this job is missing, and nothing the old job did is dropped.

## Accepted, intentional deltas

1. **Python 3.14 + editable install instead of the runner's system Python.** `test_reconcile_dryrun.sh` runs `python3 audit.py --help` and greps the output. `cli_audit` imports `packaging` and `PyYAML`, which happened to be present in the runner's system interpreter; a `setup-python` interpreter is clean, so the caller installs the project explicitly. 3.14 is used because `pyproject.toml` declares `requires-python = ">=3.14"` (and the rest of this workflow already tests 3.14). This makes the environment deterministic rather than dependent on runner image contents — strictly stronger than before.
2. **15-minute job timeout** (reusable default) where the job previously had none. The job completes in well under a minute (verified in [run 29914321738](https://github.com/netresearch/coding_agent_cli_toolset/actions/runs/29914321738)).
3. **Added hardening from the reusable**: `step-security/harden-runner` (egress-policy `audit`) and `persist-credentials: false` on checkout.
4. **Workflow-level `permissions: {}`** replaces `contents: read`. Every job in this file declares its own `permissions:` block, so the effective token per job is unchanged; this matches the caller pattern already used in `dependency-review.yml` and `auto-merge-deps.yml`.
5. **Check name** changes from `Shell Tests` to `Shell Tests / Python 3.14 (ubuntu-latest)`. `main` has no required status checks configured, so no branch-protection update is needed.

## Deliberately NOT migrated

- **`release.yml`** — out of scope for this PR. Migrating it needs extensions to `python-release.yml` that do not exist yet; migrating it now would drop behaviour.
- **`dependency-review.yml`, `auto-merge-deps.yml`** — already pure reusable callers with no step-level actions.

## Validation

- `actionlint .github/workflows/ci.yml` — clean.
- `grep "uses:" .github/workflows/ci.yml` returns only the four `netresearch/.github/.github/workflows/*.yml@main` reusable calls; no step-level `uses:` remains.
