### PR TITLE
feat(catalog): add HashiCorp Vault

### DIFF
--- a/catalog/COVERAGE.md
+++ b/catalog/COVERAGE.md
@@ -2,7 +2,7 @@
 
 This file documents which tools have catalog entries and which use dedicated install scripts.
 
-## Tools with Catalog Entries (56)
+## Tools with Catalog Entries (57)
 
 These tools use the catalog-based installation system with generic installers:
 
@@ -11,7 +11,7 @@ These tools use the catalog-based installation system with generic installers:
 - git-branchless, git-lfs, gitleaks, glab, golangci-lint, httpie, isort, just
 - kubectl, ninja, npm, opengrep, parallel, pip, pipx, pnpm, poetry, pre-commit
 - prettier, rga, ripgrep, ruff, sd, semgrep, shellcheck, shfmt, sponge, terraform
-- tfsec, trivy, watchexec, xsv, yarn, yq
+- tfsec, trivy, vault, watchexec, xsv, yarn, yq
 
 ## Tools with Dedicated Install Scripts
 
@@ -49,16 +49,16 @@ Most now in catalog, one dedicated script:
 - **github_release_binary**: 32 tools
 - **uv_tool**: 8 tools (Python CLI tools)
 - **package_manager**: 10 tools (pip, pipx, poetry, npm, pnpm, yarn, gem, composer, sponge, entr)
-- **hashicorp_zip**: 1 tool (terraform)
+- **hashicorp_zip**: 2 tools (terraform, vault)
 - **aws_installer**: 1 tool (aws)
 - **npm_global**: 1 tool (prettier)
 - **script**: 1 tool (parallel)
 - **dedicated_script**: 10 tools (runtimes: go, rust, python, node; special: uv, docker, git, ctags, gam)
 - **system_package**: 2 tools (cscope, rename variants)
 
-## Total: 71 tools tracked
+## Total: 72 tools tracked
 
-- **56 tools** have catalog entries
+- **57 tools** have catalog entries
 - **10 tools** use dedicated scripts (runtimes + special cases)
 - **5 tools** are system packages only
 
@@ -101,7 +101,7 @@ direnv, dust, entr, eslint, flake8, gam, gem, gemini, gh-aw-firewall, git,
 git-branchless, git-filter-repo, go, google-workspace-cli, gosec, httpie,
 hyperfine, isort, jq, ninja, opengrep, php, pre-commit, prename, prettier,
 python, qsv, rename.ul, ruby, ruby-build, sd, semgrep, shellcheck, shfmt,
-sponge, templ, terraform, tfsec, tmux, tokei, tree, wslu, xsv, yarn
+sponge, templ, terraform, tfsec, tmux, tokei, tree, vault, wslu, xsv, yarn
 
 (`git` and `docker` already ship completions via the distro `bash-completion`
 package; `docker` is still declared so the generated script matches the

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -71,7 +71,7 @@ Install tools via system package managers (apt, brew, dnf, pacman).
 2. The tool will automatically be available via `make install-<tool>`, `make upgrade-<tool>`, `make uninstall-<tool>`, and `make reconcile-<tool>`
 3. No need to create a custom install script!
 
-Currently **98 tools** are cataloged.
+Currently **100 tools** are cataloged.
 
 ## Environment Variables
 
@@ -96,6 +96,6 @@ make upgrade
 
 ## Architecture
 
-All 98 tools have catalog entries. The generic installer (`scripts/install_tool.sh`) reads a tool's catalog JSON and delegates to the appropriate method-specific installer under `scripts/installers/`. Tools with complex installation needs (python, node, docker, rust, etc.) use `install_method: "dedicated_script"` to route to their existing bespoke scripts.
+All 100 tools have catalog entries. The generic installer (`scripts/install_tool.sh`) reads a tool's catalog JSON and delegates to the appropriate method-specific installer under `scripts/installers/`. Tools with complex installation needs (python, node, docker, rust, etc.) use `install_method: "dedicated_script"` to route to their existing bespoke scripts.
 
 See [ADR-007](../docs/adr/ADR-007-generic-tool-installation-architecture.md) for the full architectural decision record.

--- a/catalog/vault.json
+++ b/catalog/vault.json
@@ -1,0 +1,19 @@
+{
+  "name": "vault",
+  "category": "devops",
+  "install_method": "hashicorp_zip",
+  "description": "Secrets management tool",
+  "homepage": "https://www.vaultproject.io/",
+  "github_repo": "hashicorp/vault",
+  "product_name": "vault",
+  "binary_name": "vault",
+  "arch_map": {
+    "x86_64": "amd64",
+    "aarch64": "arm64"
+  },
+  "guide": {
+    "display_name": "Vault",
+    "install_action": "install",
+    "order": 205
+  }
+}

--- a/upstream_versions.json
+++ b/upstream_versions.json
@@ -51,17 +51,17 @@
       "latest_tag": "2.0.76",
       "latest_url": "https://www.npmjs.com/package/@anthropic-ai/claude-code",
       "latest_version": "2.0.76",
+      "npm_package": "@anthropic-ai/claude-code",
       "tool_url": "https://www.npmjs.com/package/@anthropic-ai/claude-code",
-      "upstream_method": "npm",
-      "npm_package": "@anthropic-ai/claude-code"
+      "upstream_method": "npm"
     },
     "codex": {
       "latest_tag": "rust-v0.101.0",
       "latest_url": "https://github.com/openai/codex/releases/tag/rust-v0.101.0",
       "latest_version": "0.101.0",
+      "npm_package": "@openai/codex",
       "tool_url": "https://www.npmjs.com/package/@openai/codex",
-      "upstream_method": "npm",
-      "npm_package": "@openai/codex"
+      "upstream_method": "npm"
     },
     "compose": {
       "latest_tag": "5.0.1",
@@ -186,9 +186,9 @@
       "latest_tag": "v0.28.2",
       "latest_url": "https://github.com/google-gemini/gemini-cli/releases/tag/v0.28.2",
       "latest_version": "0.28.2",
+      "npm_package": "@google/gemini-cli",
       "tool_url": "https://www.npmjs.com/package/@google/gemini-cli",
-      "upstream_method": "npm",
-      "npm_package": "@google/gemini-cli"
+      "upstream_method": "npm"
     },
     "gh": {
       "latest_tag": "2.83.2",
@@ -517,6 +517,13 @@
       "latest_url": "https://github.com/astral-sh/uv/releases/tag/0.9.18",
       "latest_version": "0.9.18",
       "tool_url": "https://github.com/astral-sh/uv",
+      "upstream_method": "gh"
+    },
+    "vault": {
+      "latest_tag": "v2.0.3",
+      "latest_url": "https://github.com/hashicorp/vault/releases/tag/v2.0.3",
+      "latest_version": "2.0.3",
+      "tool_url": "https://github.com/hashicorp/vault",
       "upstream_method": "gh"
     },
     "watchexec": {


### PR DESCRIPTION
## Summary

Adds `vault` to the tool catalog as the second `hashicorp_zip` tool (after terraform).

- `catalog/vault.json` — modeled on `terraform.json` (`product_name`/`binary_name` `vault`, guide order 205, amd64/arm64 arch map)
- `upstream_versions.json` — vault 2.0.3 added to the committed baseline (merged additively; two npm entries got key-sorted to match the canonical `sort_keys=True` writer output)
- `catalog/COVERAGE.md`, `catalog/README.md` — coverage lists and counts updated; the cataloged-tool count was already stale at 98 vs. 99 actual JSON entries, now corrected to 100

No `bash_completion` declared: `vault completion bash` prints usage text (which the completion validator rejects); vault's actual mechanism is `vault -autocomplete-install`, which edits rc files directly instead of emitting a script.

## Verification

- `https://releases.hashicorp.com/vault/2.0.3/vault_2.0.3_linux_amd64.zip` → HTTP 200
- `make install-vault` → installs `Vault v2.0.3` to `~/.local/bin/vault`, snapshot refreshed
- `uv run python audit.py vault` → ✅ 2.0.3 / 2.0.3
- 738 passed, 1 skipped; smoke test OK; flake8 findings are pre-existing (no Python touched)

## Note

`audit.py --update-baseline <tool>` with a single tool argument **replaces** the whole `upstream_versions.json` instead of merging — it dropped the other ~95 entries when run for vault (restored, then merged manually). Worth a follow-up issue.