### PR TITLE
fix(audit): fall back to cached version when version probe times out

### DIFF
--- a/audit.py
+++ b/audit.py
@@ -33,7 +33,7 @@ from cli_audit.collectors import (  # noqa: E402
     get_gitlab_rate_limit,
     is_wsl,
 )
-from cli_audit.detection import audit_tool_installation, detect_multi_versions  # noqa: E402
+from cli_audit.detection import VERSION_PROBE_TIMEOUT, audit_tool_installation, detect_multi_versions  # noqa: E402
 from cli_audit.local_state import (  # noqa: E402
     LocalInstallation,
     LocalState,
@@ -265,6 +265,32 @@ def audit_multi_version_tool(
     return results
 
 
+def _apply_probe_timeout_fallback(
+    tool_name: str,
+    version_num: str,
+    version_line: str,
+    path: str,
+    install_method: str,
+) -> tuple[str, str, str, str]:
+    """Fall back to the last known local_state version when the probe timed out.
+
+    A timeout means the binary exists but answered too slowly (slow binaries
+    like opengrep need ~2.5s and can exceed the probe timeout under parallel
+    collection load) — reporting it as not installed would be wrong.
+    """
+    if version_line != VERSION_PROBE_TIMEOUT:
+        return version_num, version_line, path, install_method
+
+    prev = load_local_state().tools.get(tool_name)
+    if prev and prev.installed_version:
+        version = prev.installed_version
+        line = f"{tool_name} {version} (cached; version probe timed out)"
+        return version, line, path or prev.installed_path, install_method or prev.installed_method
+
+    # No cached version to fall back to: keep prior "no version" behavior.
+    return "", "", path, install_method
+
+
 def audit_tool(tool: Tool, offline_cache: dict[str, tuple[str, str]] | None = None) -> dict[str, str]:
     """Audit a single tool.
 
@@ -290,6 +316,9 @@ def audit_tool(tool: Tool, offline_cache: dict[str, tuple[str, str]] | None = No
     deep_scan = tool.name in {"node", "python", "semgrep", "pre-commit", "bandit", "black", "flake8", "isort"}
     version_num, version_line, path, install_method = audit_tool_installation(
         tool.name, tool.candidates, deep=deep_scan, version_flag=version_flag, version_command=version_command
+    )
+    version_num, version_line, path, install_method = _apply_probe_timeout_fallback(
+        tool.name, version_num, version_line, path, install_method
     )
 
     installed = version_num if version_num else (version_line if version_line != "X" else "")
@@ -1142,6 +1171,9 @@ def _detect_local_only(tool: Tool) -> LocalInstallation:
     deep_scan = tool.name in {"node", "python", "semgrep", "pre-commit", "bandit", "black", "flake8", "isort"}
     version_num, version_line, path, install_method = audit_tool_installation(
         tool.name, tool.candidates, deep=deep_scan, version_flag=version_flag, version_command=version_command
+    )
+    version_num, version_line, path, install_method = _apply_probe_timeout_fallback(
+        tool.name, version_num, version_line, path, install_method
     )
 
     installed = version_num if version_num else (version_line if version_line != "X" else "")

--- a/audit.py
+++ b/audit.py
@@ -271,24 +271,29 @@ def _apply_probe_timeout_fallback(
     version_line: str,
     path: str,
     install_method: str,
-) -> tuple[str, str, str, str]:
+) -> tuple[str, str, str, str, bool]:
     """Fall back to the last known local_state version when the probe timed out.
 
     A timeout means the binary exists but answered too slowly (slow binaries
     like opengrep need ~2.5s and can exceed the probe timeout under parallel
     collection load) — reporting it as not installed would be wrong.
+
+    Returns:
+        Tuple of (version_num, version_line, path, install_method, from_cache).
+        from_cache is True only when the cached version was substituted; callers
+        must surface that in classification_reason so the fallback is not silent.
     """
     if version_line != VERSION_PROBE_TIMEOUT:
-        return version_num, version_line, path, install_method
+        return version_num, version_line, path, install_method, False
 
     prev = load_local_state().tools.get(tool_name)
     if prev and prev.installed_version:
         version = prev.installed_version
         line = f"{tool_name} {version} (cached; version probe timed out)"
-        return version, line, path or prev.installed_path, install_method or prev.installed_method
+        return version, line, path or prev.installed_path, install_method or prev.installed_method, True
 
     # No cached version to fall back to: keep prior "no version" behavior.
-    return "", "", path, install_method
+    return "", "", path, install_method, False
 
 
 def audit_tool(tool: Tool, offline_cache: dict[str, tuple[str, str]] | None = None) -> dict[str, str]:
@@ -317,7 +322,7 @@ def audit_tool(tool: Tool, offline_cache: dict[str, tuple[str, str]] | None = No
     version_num, version_line, path, install_method = audit_tool_installation(
         tool.name, tool.candidates, deep=deep_scan, version_flag=version_flag, version_command=version_command
     )
-    version_num, version_line, path, install_method = _apply_probe_timeout_fallback(
+    version_num, version_line, path, install_method, from_cache = _apply_probe_timeout_fallback(
         tool.name, version_num, version_line, path, install_method
     )
 
@@ -346,7 +351,9 @@ def audit_tool(tool: Tool, offline_cache: dict[str, tuple[str, str]] | None = No
     latest_url = latest_target_url(tool, latest_tag, latest_num)
 
     # Generate classification reason
-    if install_method:
+    if from_cache:
+        classification_reason = "Cached version (probe timed out); last known method: " + (install_method or "unknown")
+    elif install_method:
         classification_reason = f"Detected via path analysis: {install_method}"
     else:
         classification_reason = "No installation detected"
@@ -1172,13 +1179,15 @@ def _detect_local_only(tool: Tool) -> LocalInstallation:
     version_num, version_line, path, install_method = audit_tool_installation(
         tool.name, tool.candidates, deep=deep_scan, version_flag=version_flag, version_command=version_command
     )
-    version_num, version_line, path, install_method = _apply_probe_timeout_fallback(
+    version_num, version_line, path, install_method, from_cache = _apply_probe_timeout_fallback(
         tool.name, version_num, version_line, path, install_method
     )
 
     installed = version_num if version_num else (version_line if version_line != "X" else "")
 
-    if install_method:
+    if from_cache:
+        classification_reason = "Cached version (probe timed out); last known method: " + (install_method or "unknown")
+    elif install_method:
         classification_reason = f"Detected via path analysis: {install_method}"
     else:
         classification_reason = "No installation detected"

--- a/audit.py
+++ b/audit.py
@@ -25,25 +25,38 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 # Add current directory to path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-# Import modules
-from cli_audit.tools import Tool, all_tools, filter_tools, tool_homepage_url, latest_target_url  # noqa: E402
-from cli_audit.detection import audit_tool_installation, detect_multi_versions  # noqa: E402
-from cli_audit.snapshot import load_snapshot, write_snapshot, render_from_snapshot, get_snapshot_path  # noqa: E402
-from cli_audit.render import render_table, print_summary, status_icon, osc8  # noqa: E402
-from cli_audit.pins import lookup_pin, should_skip as _pin_should_skip  # noqa: E402
-from cli_audit.collectors import get_github_rate_limit, get_github_rate_limit_help, get_gitlab_rate_limit, is_wsl, collect_endoflife  # noqa: E402
 from cli_audit import collectors  # noqa: E402
+from cli_audit.collectors import (  # noqa: E402
+    collect_endoflife,
+    get_github_rate_limit,
+    get_github_rate_limit_help,
+    get_gitlab_rate_limit,
+    is_wsl,
+)
+from cli_audit.detection import audit_tool_installation, detect_multi_versions  # noqa: E402
+from cli_audit.local_state import (  # noqa: E402
+    LocalInstallation,
+    LocalState,
+    build_legacy_snapshot,
+    get_local_state_path,
+    load_local_state,
+    write_local_state,
+)
 from cli_audit.logging_config import setup_logging  # noqa: E402
+from cli_audit.pins import lookup_pin  # noqa: E402
+from cli_audit.pins import should_skip as _pin_should_skip  # noqa: E402
+from cli_audit.render import osc8, print_summary, render_table, status_icon  # noqa: E402
+from cli_audit.snapshot import get_snapshot_path, load_snapshot, render_from_snapshot, write_snapshot  # noqa: E402
+
+# Import modules
+from cli_audit.tools import Tool, all_tools, filter_tools, latest_target_url, tool_homepage_url  # noqa: E402
+
 # Split file support (Phase 2.1)
 from cli_audit.upstream_cache import (  # noqa: E402
     UpstreamVersion,
-    load_upstream_cache, write_upstream_cache, get_upstream_cache_path,
-    update_cached_upstream,
-)
-from cli_audit.local_state import (  # noqa: E402
-    LocalInstallation, LocalState,
-    load_local_state, write_local_state, get_local_state_path,
-    update_local_installation, merge_for_display, build_legacy_snapshot,
+    get_upstream_cache_path,
+    load_upstream_cache,
+    write_upstream_cache,
 )
 
 # Strip control characters from externally-sourced strings (e.g. GitHub tags)
@@ -87,23 +100,23 @@ def normalize_version(version: str) -> str:
         return version
 
     # Remove 'v' prefix
-    version = version.lstrip('v')
+    version = version.lstrip("v")
 
     # Split into parts and remove trailing zeros from each part
-    parts = version.split('.')
+    parts = version.split(".")
     normalized_parts = []
 
     for i, part in enumerate(parts):
         # For numeric parts, strip trailing zeros but keep at least one digit
         if part.isdigit():
             # Keep at least one zero if the part is all zeros
-            normalized = part.lstrip('0') or '0'
+            normalized = part.lstrip("0") or "0"
             normalized_parts.append(normalized)
         else:
             # Non-numeric parts (e.g., "rc1", "beta") - keep as is
             normalized_parts.append(part)
 
-    return '.'.join(normalized_parts)
+    return ".".join(normalized_parts)
 
 
 def compute_status(installed: str, latest: str) -> str:
@@ -120,6 +133,7 @@ def compute_status(installed: str, latest: str) -> str:
     if not latest:
         return "UNKNOWN"
     from cli_audit.upgrade import compare_versions
+
     if compare_versions(normalize_version(installed), normalize_version(latest)) < 0:
         return "OUTDATED"
     return "UP-TO-DATE"
@@ -224,27 +238,29 @@ def audit_multi_version_tool(
         # canned "check your package manager" line adds no value).
         hint = catalog_data.get("hint", "")
 
-        results.append({
-            "tool": versioned_name,
-            "category": catalog_data.get("category", tool_name),
-            "installed": installed or "",
-            "installed_method": method,
-            "installed_version": installed or "",
-            "installed_path_selected": path,
-            "classification_reason_selected": classification_reason,
-            "latest_upstream": latest,
-            "latest_version": latest,
-            "upstream_method": "endoflife",
-            "status": status,
-            "tool_url": catalog_data.get("homepage", ""),
-            "latest_url": f"https://endoflife.date/{product}",
-            "hint": hint,
-            # Extra fields for multi-version
-            "is_multi_version": True,
-            "base_tool": tool_name,
-            "version_cycle": cycle,
-            "lifecycle_status": status_lifecycle,  # active, security, eol
-        })
+        results.append(
+            {
+                "tool": versioned_name,
+                "category": catalog_data.get("category", tool_name),
+                "installed": installed or "",
+                "installed_method": method,
+                "installed_version": installed or "",
+                "installed_path_selected": path,
+                "classification_reason_selected": classification_reason,
+                "latest_upstream": latest,
+                "latest_version": latest,
+                "upstream_method": "endoflife",
+                "status": status,
+                "tool_url": catalog_data.get("homepage", ""),
+                "latest_url": f"https://endoflife.date/{product}",
+                "hint": hint,
+                # Extra fields for multi-version
+                "is_multi_version": True,
+                "base_tool": tool_name,
+                "version_cycle": cycle,
+                "lifecycle_status": status_lifecycle,  # active, security, eol
+            }
+        )
 
     return results
 
@@ -261,6 +277,7 @@ def audit_tool(tool: Tool, offline_cache: dict[str, tuple[str, str]] | None = No
     """
     # Load catalog metadata for version detection
     from cli_audit.catalog import ToolCatalog
+
     catalog = ToolCatalog()
     version_flag = None
     version_command = None
@@ -340,6 +357,7 @@ def cmd_audit(args: argparse.Namespace) -> int:
 
         # Separate multi-version tools from regular tools
         from cli_audit.catalog import ToolCatalog
+
         catalog = ToolCatalog()
         regular_tools = []
         mv_tools = {}  # tool_name -> (catalog_data, mv_config)
@@ -416,7 +434,7 @@ def cmd_audit(args: argparse.Namespace) -> int:
             enriched["state_icon"] = status_icon(status, installed)
 
             # Add is_up_to_date boolean field
-            enriched["is_up_to_date"] = (status == "UP-TO-DATE")  # type: ignore[assignment]
+            enriched["is_up_to_date"] = status == "UP-TO-DATE"  # type: ignore[assignment]
 
             # Add path and classification fields (for backward compatibility with old snapshots)
             if "installed_path_selected" not in enriched:
@@ -447,6 +465,7 @@ def cmd_audit(args: argparse.Namespace) -> int:
     if created_at and created_at != "cached":
         try:
             from datetime import datetime
+
             created_dt = datetime.fromisoformat(created_at)
             now = datetime.now(created_dt.tzinfo)
             age_seconds = (now - created_dt).total_seconds()
@@ -474,6 +493,7 @@ def cmd_audit(args: argparse.Namespace) -> int:
 
     # Suggest package manager upgrades
     from cli_audit.catalog import suggest_package_manager_upgrades
+
     suggest_package_manager_upgrades()
 
     return 0
@@ -540,9 +560,17 @@ def cmd_update(args: argparse.Namespace) -> int:
                 gl_auth_info = " (via GITLAB_TOKEN)"
 
         if gl_remaining < gl_limit * 0.2:
-            print(f"⚠️  GitLab rate limit ({gl_host}): {gl_remaining}/{gl_limit} remaining{gl_auth_info}", file=sys.stderr, flush=True)
+            print(
+                f"⚠️  GitLab rate limit ({gl_host}): {gl_remaining}/{gl_limit} remaining{gl_auth_info}",
+                file=sys.stderr,
+                flush=True,
+            )
         else:
-            print(f"✓ GitLab rate limit ({gl_host}): {gl_remaining}/{gl_limit} remaining{gl_auth_info}", file=sys.stderr, flush=True)
+            print(
+                f"✓ GitLab rate limit ({gl_host}): {gl_remaining}/{gl_limit} remaining{gl_auth_info}",
+                file=sys.stderr,
+                flush=True,
+            )
 
     print(f"# Collecting fresh data for {total} tools...", file=sys.stderr)
     est_time = int((total / MAX_WORKERS) * 3 * 1.5)
@@ -551,6 +579,7 @@ def cmd_update(args: argparse.Namespace) -> int:
 
     # Identify multi-version tools
     from cli_audit.catalog import ToolCatalog
+
     catalog = ToolCatalog()
     multi_version_tools = {}  # tool_name -> (catalog_data, mv_config)
     regular_tools = []
@@ -565,7 +594,8 @@ def cmd_update(args: argparse.Namespace) -> int:
         regular_tools.append(tool)
 
     # Group regular tools by category for organized output
-    from cli_audit.render import CATEGORY_ORDER, CATEGORY_ICON, CATEGORY_DESC
+    from cli_audit.render import CATEGORY_DESC, CATEGORY_ICON, CATEGORY_ORDER
+
     categorized: dict[str, list] = {}
     for tool in regular_tools:
         cat = tool.category or "general"
@@ -646,7 +676,10 @@ def cmd_update(args: argparse.Namespace) -> int:
                             latest_link = result.get("latest_url", "")
                             if latest_link and latest_display != "n/a":
                                 latest_fmt = osc8(latest_link, latest_fmt)
-                            msg = f"# [{completed}/{total}] [{cat}] {tool.name} (installed: {inst_fmt} {op} latest: {latest_fmt}){marker_str}"
+                            msg = (
+                                f"# [{completed}/{total}] [{cat}] {tool.name} "
+                                f"(installed: {inst_fmt} {op} latest: {latest_fmt}){marker_str}"
+                            )
 
                             print(msg, file=sys.stderr, flush=True)
 
@@ -655,22 +688,24 @@ def cmd_update(args: argparse.Namespace) -> int:
                             print(f"# [{completed}/{total}] {tool.name} (failed: {e})", file=sys.stderr, flush=True)
 
                             # Add failure entry
-                            results.append({
-                                "tool": tool.name,
-                                "category": tool.category,
-                                "installed": "",
-                                "installed_method": "",
-                                "installed_version": "",
-                                "installed_path_selected": "",
-                                "classification_reason_selected": "Detection failed",
-                                "latest_upstream": "",
-                                "latest_version": "",
-                                "upstream_method": tool.source_kind,
-                                "status": "UNKNOWN",
-                                "tool_url": tool_homepage_url(tool),
-                                "latest_url": "",
-                                "hint": "",
-                            })
+                            results.append(
+                                {
+                                    "tool": tool.name,
+                                    "category": tool.category,
+                                    "installed": "",
+                                    "installed_method": "",
+                                    "installed_version": "",
+                                    "installed_path_selected": "",
+                                    "classification_reason_selected": "Detection failed",
+                                    "latest_upstream": "",
+                                    "latest_version": "",
+                                    "upstream_method": tool.source_kind,
+                                    "status": "UNKNOWN",
+                                    "tool_url": tool_homepage_url(tool),
+                                    "latest_url": "",
+                                    "hint": "",
+                                }
+                            )
                 except KeyboardInterrupt:
                     executor.shutdown(wait=False, cancel_futures=True)
                     raise
@@ -682,7 +717,7 @@ def cmd_update(args: argparse.Namespace) -> int:
             if cat in status_counts:
                 status_counts[cat][r.get("status")] += 1
 
-        print(f"\n# Summary by category:", file=sys.stderr)
+        print("\n# Summary by category:", file=sys.stderr)
         for category in sorted_cats:
             icon = CATEGORY_ICON.get(category, "📦")
             desc = CATEGORY_DESC.get(category, category)
@@ -743,6 +778,7 @@ def cmd_update(args: argparse.Namespace) -> int:
         sys.stderr.flush()
         # Exit immediately to avoid shutdown deadlocks
         import os
+
         os._exit(130)
 
     # Write snapshot
@@ -779,6 +815,7 @@ def cmd_update(args: argparse.Namespace) -> int:
 
         # Suggest package manager upgrades
         from cli_audit.catalog import suggest_package_manager_upgrades
+
         suggest_package_manager_upgrades()
 
         # Reset terminal state (reset colors + ensure echo mode)
@@ -838,9 +875,7 @@ def cmd_update_local(args: argparse.Namespace) -> int:
                 # Determine status using cached upstream
                 cached = upstream_cache.versions.get(tool.name)
                 if cached and installation.installed_version:
-                    installation.status = compute_status(
-                        installation.installed_version, cached.latest_version
-                    )
+                    installation.status = compute_status(installation.installed_version, cached.latest_version)
                 elif not installation.installed_version:
                     installation.status = STATUS_NOT_INSTALLED
                 else:
@@ -848,7 +883,10 @@ def cmd_update_local(args: argparse.Namespace) -> int:
 
                 local_state.tools[tool.name] = installation
                 completed += 1
-                print(f"# [{completed}/{total}] {tool.name}: {installation.installed_version or 'not installed'}", file=sys.stderr)
+                print(
+                    f"# [{completed}/{total}] {tool.name}: {installation.installed_version or 'not installed'}",
+                    file=sys.stderr,
+                )
             except Exception as e:
                 completed += 1
                 print(f"# [{completed}/{total}] {tool.name}: failed ({e})", file=sys.stderr)
@@ -888,6 +926,7 @@ def cmd_update_local(args: argparse.Namespace) -> int:
         # installs as "version unchanged" in the guide.
         try:
             from cli_audit.catalog import ToolCatalog
+
             _catalog = ToolCatalog()
         except Exception:
             _catalog = None
@@ -905,15 +944,17 @@ def cmd_update_local(args: argparse.Namespace) -> int:
                 supported: list[dict] = []
                 for t in existing_tools:
                     if t.get("base_tool") == tool.name and t.get("version_cycle"):
-                        supported.append({
-                            "cycle": t["version_cycle"],
-                            "latest": t.get("latest_upstream", ""),
-                            "status": t.get("lifecycle_status", "unknown"),
-                            "eol": None,
-                            "support": None,
-                            "release_date": None,
-                            "lts": False,
-                        })
+                        supported.append(
+                            {
+                                "cycle": t["version_cycle"],
+                                "latest": t.get("latest_upstream", ""),
+                                "status": t.get("lifecycle_status", "unknown"),
+                                "eol": None,
+                                "support": None,
+                                "release_date": None,
+                                "lts": False,
+                            }
+                        )
                 if not supported:
                     continue
                 detected = detect_multi_versions(tool.name, mv_config, supported)
@@ -932,25 +973,26 @@ def cmd_update_local(args: argparse.Namespace) -> int:
                     method = info.get("install_method")
                     versioned = f"{tool.name}@{cycle}"
                     entry = dict(tools_by_name.get(versioned, {}))
-                    entry.update({
-                        "tool": versioned,
-                        "category": catalog_data.get("category", tool.name),
-                        "installed": installed_v or "",
-                        "installed_method": method,
-                        "installed_version": installed_v or "",
-                        "installed_path_selected": info.get("path"),
-                        "classification_reason_selected": (
-                            f"Detected via path analysis: {method}" if method
-                            else "No installation detected"
-                        ),
-                        "latest_upstream": latest_v,
-                        "latest_version": latest_v,
-                        "status": status_v,
-                        "is_multi_version": True,
-                        "base_tool": tool.name,
-                        "version_cycle": cycle,
-                        "lifecycle_status": info.get("status", "unknown"),
-                    })
+                    entry.update(
+                        {
+                            "tool": versioned,
+                            "category": catalog_data.get("category", tool.name),
+                            "installed": installed_v or "",
+                            "installed_method": method,
+                            "installed_version": installed_v or "",
+                            "installed_path_selected": info.get("path"),
+                            "classification_reason_selected": (
+                                f"Detected via path analysis: {method}" if method else "No installation detected"
+                            ),
+                            "latest_upstream": latest_v,
+                            "latest_version": latest_v,
+                            "status": status_v,
+                            "is_multi_version": True,
+                            "base_tool": tool.name,
+                            "version_cycle": cycle,
+                            "lifecycle_status": info.get("status", "unknown"),
+                        }
+                    )
                     # Hint stays empty for generic multi-version runtimes;
                     # the tool name + state already tell the user what to do.
                     entry["hint"] = ""
@@ -1088,6 +1130,7 @@ def cmd_update_baseline(args: argparse.Namespace) -> int:
 def _detect_local_only(tool: Tool) -> LocalInstallation:
     """Detect local installation without collecting upstream version."""
     from cli_audit.catalog import ToolCatalog
+
     catalog = ToolCatalog()
     version_flag = None
     version_command = None
@@ -1169,10 +1212,7 @@ def cmd_versions(args: argparse.Namespace) -> int:
     # Filter to specific tools if requested
     if args.tools:
         requested = set(args.tools)
-        multi_version_tools = [
-            (name, data, config) for name, data, config in multi_version_tools
-            if name in requested
-        ]
+        multi_version_tools = [(name, data, config) for name, data, config in multi_version_tools if name in requested]
 
     # Collect all runtime data
     runtimes_data = []
@@ -1208,17 +1248,19 @@ def cmd_versions(args: argparse.Namespace) -> int:
         for version_info in detected:
             installed = version_info.get("installed")
             latest = version_info.get("latest_upstream", "")
-            runtime_info["versions"].append({
-                "cycle": version_info.get("cycle", ""),
-                "latest_upstream": latest,
-                "installed": installed,
-                "is_installed": bool(installed),
-                "is_up_to_date": installed == latest if installed else False,
-                "needs_upgrade": bool(installed and installed != latest),
-                "path": version_info.get("path", ""),
-                "install_method": version_info.get("install_method", ""),
-                "status": version_info.get("status", "unknown"),
-            })
+            runtime_info["versions"].append(
+                {
+                    "cycle": version_info.get("cycle", ""),
+                    "latest_upstream": latest,
+                    "installed": installed,
+                    "is_installed": bool(installed),
+                    "is_up_to_date": installed == latest if installed else False,
+                    "needs_upgrade": bool(installed and installed != latest),
+                    "path": version_info.get("path", ""),
+                    "install_method": version_info.get("install_method", ""),
+                    "status": version_info.get("status", "unknown"),
+                }
+            )
 
         runtimes_data.append(runtime_info)
 
@@ -1303,10 +1345,7 @@ def _shape_reconcile_plan(tool, installs, preferred, active, protected):
         "protected": protected,
         "preferred": preferred.to_dict() if preferred else None,
         "active": active.to_dict() if active else None,
-        "installations": [
-            {**i.to_dict(), "preferred": bool(pref_path and i.path == pref_path)}
-            for i in installs
-        ],
+        "installations": [{**i.to_dict(), "preferred": bool(pref_path and i.path == pref_path)} for i in installs],
     }
 
 
@@ -1372,40 +1411,50 @@ def cmd_reconcile(args: argparse.Namespace) -> int:
         all_tools = list(catalog.all_tools())
         if apply:
             result = bulk_reconcile(
-                mode="explicit", tool_names=all_tools, reconcile_mode="aggressive",
-                force=force, verbose=args.verbose,
+                mode="explicit",
+                tool_names=all_tools,
+                reconcile_mode="aggressive",
+                force=force,
+                verbose=args.verbose,
             )
             # Report only tools that actually had duplicates — the explicit
             # sweep visits every catalog entry, but --all is about conflicts.
             conflicts = [r for r in result.results if len(r.installations) > 1]
             if JSON_MODE:
-                print(json.dumps({
-                    "tools_checked": result.tools_checked,
-                    "conflicts_found": result.conflicts_found,
-                    "conflicts_resolved": result.conflicts_resolved,
-                    "results": [r.to_dict() for r in conflicts],
-                    "duration_seconds": result.duration_seconds,
-                }))
+                print(
+                    json.dumps(
+                        {
+                            "tools_checked": result.tools_checked,
+                            "conflicts_found": result.conflicts_found,
+                            "conflicts_resolved": result.conflicts_resolved,
+                            "results": [r.to_dict() for r in conflicts],
+                            "duration_seconds": result.duration_seconds,
+                        }
+                    )
+                )
             else:
                 print(result.summary(), file=sys.stderr)
             # Fail only on real removal errors — not on protected tools (blocked)
             # or tools the user declined (aborted), which are expected outcomes.
-            failures = [
-                r for r in conflicts
-                if not r.success and r.action_taken not in ("blocked", "aborted", "none")
-            ]
+            failures = [r for r in conflicts if not r.success and r.action_taken not in ("blocked", "aborted", "none")]
             return 1 if failures else 0
         # Plan-only sweep (parallel detection, no removal)
         result = bulk_reconcile(
-            mode="explicit", tool_names=all_tools, reconcile_mode="parallel",
+            mode="explicit",
+            tool_names=all_tools,
+            reconcile_mode="parallel",
             verbose=args.verbose,
         )
         plans = [
             _shape_reconcile_plan(
-                r.tool, list(r.installations), r.preferred, r.active,
+                r.tool,
+                list(r.installations),
+                r.preferred,
+                r.active,
                 r.tool in SYSTEM_TOOL_SAFELIST,
             )
-            for r in result.results if len(r.installations) > 1
+            for r in result.results
+            if len(r.installations) > 1
         ]
         if JSON_MODE:
             print(json.dumps({"results": plans, "total": len(plans)}))
@@ -1422,10 +1471,15 @@ def cmd_reconcile(args: argparse.Namespace) -> int:
     if apply:
         results = []
         for tool in tools:
-            results.append(reconcile_tool(
-                tool, mode="aggressive", candidates=_candidates(tool),
-                force=force, verbose=args.verbose,
-            ))
+            results.append(
+                reconcile_tool(
+                    tool,
+                    mode="aggressive",
+                    candidates=_candidates(tool),
+                    force=force,
+                    verbose=args.verbose,
+                )
+            )
         if JSON_MODE:
             print(json.dumps({"results": [r.to_dict() for r in results]}))
         else:
@@ -1500,7 +1554,8 @@ def main() -> int:
         help="With --reconcile --apply: skip confirmation prompts (honors safelist)",
     )
     parser.add_argument(
-        "--verbose", "-v",
+        "--verbose",
+        "-v",
         action="store_true",
         help="Verbose output",
     )
@@ -1529,10 +1584,10 @@ def main() -> int:
     elif args.update:
         # Explicit --update flag: full update of all tools
         return cmd_update(args)
-    elif getattr(args, 'update_local', False) or UPDATE_LOCAL_ONLY:
+    elif getattr(args, "update_local", False) or UPDATE_LOCAL_ONLY:
         # Update only local state (fast, no network)
         return cmd_update_local(args)
-    elif getattr(args, 'update_baseline', False) or UPDATE_BASELINE_ONLY:
+    elif getattr(args, "update_baseline", False) or UPDATE_BASELINE_ONLY:
         # Update only upstream baseline cache
         return cmd_update_baseline(args)
     elif args.install:

--- a/cli_audit/detection.py
+++ b/cli_audit/detection.py
@@ -34,6 +34,10 @@ VERSION_FLAG_SETS = (
 # fall back to the last known version instead of reporting "not installed".
 VERSION_PROBE_TIMEOUT = "<probe-timeout>"
 
+# Pseudo-path recorded when a version was detected via a standalone
+# catalog version_command instead of a binary on disk.
+VERSION_COMMAND_PATH = "<version_command>"
+
 
 def find_paths(command_name: str, deep: bool = False) -> list[str]:
     """Find all paths for a command.
@@ -350,9 +354,9 @@ def audit_tool_installation(
         line = get_version_line("", tool_name, version_flag, version_command)
         if line:
             num = extract_version_number(line)
-            tuples.append((num, line, "<version_command>"))
+            tuples.append((num, line, VERSION_COMMAND_PATH))
         elif line is None:
-            timed_out_paths.append("<version_command>")
+            timed_out_paths.append(VERSION_COMMAND_PATH)
 
     if not tuples:
         # A probe ran but timed out: signal the timeout so callers can fall
@@ -360,7 +364,7 @@ def audit_tool_installation(
         # as not installed.
         if timed_out_paths:
             path = timed_out_paths[0]
-            if path == "<version_command>":
+            if path == VERSION_COMMAND_PATH:
                 return ("", VERSION_PROBE_TIMEOUT, path, "version_command")
             return ("", VERSION_PROBE_TIMEOUT, path, detect_install_method(path, tool_name))
         return ("", "X", "", "")
@@ -372,7 +376,7 @@ def audit_tool_installation(
     version_num, version_line, path = chosen
 
     # Handle version_command detection (no physical path)
-    if path == "<version_command>":
+    if path == VERSION_COMMAND_PATH:
         install_method = "version_command"
     else:
         install_method = detect_install_method(path, tool_name)

--- a/cli_audit/detection.py
+++ b/cli_audit/detection.py
@@ -351,13 +351,17 @@ def audit_tool_installation(
         if line:
             num = extract_version_number(line)
             tuples.append((num, line, "<version_command>"))
+        elif line is None:
+            timed_out_paths.append("<version_command>")
 
     if not tuples:
-        # Binary exists but every version probe timed out: signal the timeout
-        # so callers can fall back to the last known version instead of
-        # misreporting the tool as not installed.
+        # A probe ran but timed out: signal the timeout so callers can fall
+        # back to the last known version instead of misreporting the tool
+        # as not installed.
         if timed_out_paths:
             path = timed_out_paths[0]
+            if path == "<version_command>":
+                return ("", VERSION_PROBE_TIMEOUT, path, "version_command")
             return ("", VERSION_PROBE_TIMEOUT, path, detect_install_method(path, tool_name))
         return ("", "X", "", "")
 

--- a/cli_audit/detection.py
+++ b/cli_audit/detection.py
@@ -19,7 +19,7 @@ CARGO_BIN = os.path.join(HOME, ".cargo", "bin")
 
 VERSION_RE = re.compile(r"(\d+(?:\.\d+)+)")
 DATE_VERSION_RE = re.compile(r"\b(\d{8})\b")
-ANSI_ESCAPE_RE = re.compile(r'\x1b\[[0-9;]*m|\033\[[0-9;]*m')
+ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m|\033\[[0-9;]*m")
 
 VERSION_FLAG_SETS = (
     ("-v",),
@@ -27,6 +27,12 @@ VERSION_FLAG_SETS = (
     ("-V",),
     ("version",),
 )
+
+# Marker returned by audit_tool_installation when the binary exists on disk
+# but every version probe timed out (slow binaries like opengrep need ~2.5s
+# and can exceed TIMEOUT_SECONDS under parallel collection load). Callers
+# fall back to the last known version instead of reporting "not installed".
+VERSION_PROBE_TIMEOUT = "<probe-timeout>"
 
 
 def find_paths(command_name: str, deep: bool = False) -> list[str]:
@@ -76,7 +82,7 @@ def find_paths(command_name: str, deep: bool = False) -> list[str]:
     return paths
 
 
-def run_with_timeout(args: Sequence[str], timeout: float | None = None, capture_stderr: bool = True) -> str:
+def run_with_timeout(args: Sequence[str], timeout: float | None = None, capture_stderr: bool = True) -> str | None:
     """Run command with timeout and return output with version info.
 
     Args:
@@ -85,7 +91,8 @@ def run_with_timeout(args: Sequence[str], timeout: float | None = None, capture_
         capture_stderr: If True, merge stderr into stdout
 
     Returns:
-        Line containing version, or first line if no version found
+        Line containing version, or first line if no version found.
+        None if the command timed out (distinct from "" for other failures).
     """
     try:
         proc = subprocess.run(
@@ -107,7 +114,7 @@ def run_with_timeout(args: Sequence[str], timeout: float | None = None, capture_
             return ""
 
         # Strip ANSI escape sequences from all lines
-        cleaned_lines = [ANSI_ESCAPE_RE.sub('', line.strip()) for line in lines]
+        cleaned_lines = [ANSI_ESCAPE_RE.sub("", line.strip()) for line in lines]
 
         # Search for line containing version number (prefer this over first line)
         for line in cleaned_lines:
@@ -120,6 +127,8 @@ def run_with_timeout(args: Sequence[str], timeout: float | None = None, capture_
                 return line
 
         return ""
+    except subprocess.TimeoutExpired:
+        return None
     except Exception:
         return ""
 
@@ -146,7 +155,9 @@ def extract_version_number(s: str) -> str:
     return m2.group(1) if m2 else ""
 
 
-def get_version_line(path: str, tool_name: str, version_flag: str | None = None, version_command: str | None = None) -> str:
+def get_version_line(
+    path: str, tool_name: str, version_flag: str | None = None, version_command: str | None = None
+) -> str | None:
     """Get version string for installed tool.
 
     Args:
@@ -156,8 +167,12 @@ def get_version_line(path: str, tool_name: str, version_flag: str | None = None,
         version_command: Custom shell command from catalog (ignores path)
 
     Returns:
-        Version line string or empty string
+        Version line string, or empty string if no probe produced output.
+        None if at least one probe timed out and none produced a version.
     """
+    timed_out = False
+    line: str | None
+
     # Priority 1: If catalog specifies custom shell command, run it directly.
     # version_command comes from trusted catalog JSON (committed in-repo), never
     # from user input — e.g. `uv python list --only-installed | grep … | sed …`.
@@ -178,6 +193,8 @@ def get_version_line(path: str, tool_name: str, version_flag: str | None = None,
             line = (proc.stdout or "").strip()
             if line:
                 return line
+        except subprocess.TimeoutExpired:
+            timed_out = True
         except Exception:
             pass
 
@@ -186,6 +203,8 @@ def get_version_line(path: str, tool_name: str, version_flag: str | None = None,
         line = run_with_timeout([path, version_flag])
         if line:
             return line
+        if line is None:
+            timed_out = True
 
     # Priority 3: Special cases (only truly complex cases that can't be handled by catalog)
     if tool_name == "sponge":
@@ -195,17 +214,15 @@ def get_version_line(path: str, tool_name: str, version_flag: str | None = None,
     # Generic version flags
     for flags in VERSION_FLAG_SETS:
         line = run_with_timeout([path, *flags])
+        if line is None:
+            timed_out = True
+            continue
         if not line:
             continue
 
         # Skip error messages
         lcline = line.lower()
-        if (
-            lcline.startswith("error:")
-            or lcline.startswith("usage")
-            or "unknown option" in lcline
-            or "try --help" in lcline
-        ):
+        if lcline.startswith("error:") or lcline.startswith("usage") or "unknown option" in lcline or "try --help" in lcline:
             continue
 
         # Return if contains version
@@ -221,6 +238,7 @@ def get_version_line(path: str, tool_name: str, version_flag: str | None = None,
             if os.path.isfile(pkg_json):
                 try:
                     import json
+
                     with open(pkg_json) as f:
                         data = json.load(f)
                         version = data.get("version", "")
@@ -230,7 +248,7 @@ def get_version_line(path: str, tool_name: str, version_flag: str | None = None,
                     pass
         return "installed"
 
-    return ""
+    return None if timed_out else ""
 
 
 def detect_install_method(path: str, tool_name: str) -> str:
@@ -316,6 +334,7 @@ def audit_tool_installation(
         Tuple of (version_num, version_line, path, install_method)
     """
     tuples: list[tuple[str, str, str]] = []
+    timed_out_paths: list[str] = []
 
     for cand in candidates:
         for path in find_paths(cand, deep=deep):
@@ -323,6 +342,8 @@ def audit_tool_installation(
             if line:
                 num = extract_version_number(line)
                 tuples.append((num, line, path))
+            elif line is None:
+                timed_out_paths.append(path)
 
     # If no paths found but version_command exists, try standalone version detection
     if not tuples and version_command:
@@ -332,6 +353,12 @@ def audit_tool_installation(
             tuples.append((num, line, "<version_command>"))
 
     if not tuples:
+        # Binary exists but every version probe timed out: signal the timeout
+        # so callers can fall back to the last known version instead of
+        # misreporting the tool as not installed.
+        if timed_out_paths:
+            path = timed_out_paths[0]
+            return ("", VERSION_PROBE_TIMEOUT, path, detect_install_method(path, tool_name))
         return ("", "X", "", "")
 
     chosen = choose_highest(tuples)
@@ -379,7 +406,7 @@ def scan_version_manager_dir(
         # Get version string (strip prefix if present)
         version = version_dir
         if version_prefix and version.startswith(version_prefix):
-            version = version[len(version_prefix):]
+            version = version[len(version_prefix) :]
 
         # Find the binary
         if binary_name:
@@ -438,9 +465,7 @@ def detect_multi_versions(
         binary_subpath = multi_version_config.get("binary_subpath", "bin")
         binary_name = multi_version_config.get("binary_name", tool_name)
 
-        installed_versions = scan_version_manager_dir(
-            version_manager_dir, version_prefix, binary_subpath, binary_name
-        )
+        installed_versions = scan_version_manager_dir(version_manager_dir, version_prefix, binary_subpath, binary_name)
 
         # Create a lookup map: major.minor -> (full_version, path)
         installed_map: dict[str, tuple[str, str]] = {}
@@ -493,7 +518,7 @@ def detect_multi_versions(
             default_go = shutil.which("go")
             if default_go:
                 version_line = get_version_line(default_go, "go", version_flag="version")
-                default_version = extract_version_number(version_line)
+                default_version = extract_version_number(version_line or "")
                 if default_version:
                     parts = default_version.split(".")
                     if len(parts) >= 2:
@@ -529,7 +554,7 @@ def detect_multi_versions(
                 if found_path:
                     # Get version info
                     version_line = get_version_line(found_path, tool_name)
-                    installed_version = extract_version_number(version_line)
+                    installed_version = extract_version_number(version_line or "")
                     break
 
             # Go fallback: if no version-specific binary found, check if default

--- a/tests/test_probe_timeout_fallback.py
+++ b/tests/test_probe_timeout_fallback.py
@@ -86,6 +86,14 @@ class TestGetVersionLine:
         monkeypatch.setattr(detection, "TIMEOUT_SECONDS", 1)
         assert detection.get_version_line(str(script), "quiettool") == ""
 
+    @skip_on_windows
+    def test_returns_none_on_timeout_with_version_command(self, monkeypatch):
+        """The shell version_command path must also signal a timeout as None."""
+        import cli_audit.detection as detection
+
+        monkeypatch.setattr(detection, "TIMEOUT_SECONDS", 0.1)
+        assert detection.get_version_line("", "slowtool", version_command="sleep 2") is None
+
 
 # ===========================================================================
 # 3. audit_tool_installation returns the timeout marker
@@ -113,6 +121,20 @@ class TestAuditToolInstallationTimeout:
         monkeypatch.setattr(detection, "find_paths", lambda cand, deep=False: [])
         result = detection.audit_tool_installation("ghosttool", ("ghosttool",))
         assert result == ("", "X", "", "")
+
+    def test_timeout_marker_for_standalone_version_command(self, monkeypatch):
+        """A timed-out standalone version_command probe must not read as not-installed."""
+        import cli_audit.detection as detection
+
+        monkeypatch.setattr(detection, "find_paths", lambda cand, deep=False: [])
+        monkeypatch.setattr(
+            detection,
+            "get_version_line",
+            lambda path, tool_name, version_flag=None, version_command=None: None,
+        )
+
+        result = detection.audit_tool_installation("slowtool", ("slowtool",), version_command="slow-pipeline")
+        assert result == ("", detection.VERSION_PROBE_TIMEOUT, "<version_command>", "version_command")
 
 
 # ===========================================================================
@@ -150,13 +172,14 @@ class TestTimeoutFallback:
         import audit
         from cli_audit.detection import VERSION_PROBE_TIMEOUT
 
-        version_num, version_line, path, method = audit._apply_probe_timeout_fallback(
+        version_num, version_line, path, method, from_cache = audit._apply_probe_timeout_fallback(
             "slowtool", "", VERSION_PROBE_TIMEOUT, "/fake/bin/slowtool", "manual"
         )
         assert version_num == "1.26.0"
         assert "1.26.0" in version_line
         assert path == "/fake/bin/slowtool"
         assert method == "manual"
+        assert from_cache is True
 
     def test_no_cached_version_reports_unknown(self, tmp_path, monkeypatch):
         import audit
@@ -166,15 +189,53 @@ class TestTimeoutFallback:
         state_file.write_text(json.dumps({"__meta__": {"schema_version": 2}, "tools": {}}))
         monkeypatch.setenv("CLI_AUDIT_LOCAL_FILE", str(state_file))
 
-        version_num, version_line, path, method = audit._apply_probe_timeout_fallback(
+        version_num, version_line, path, method, from_cache = audit._apply_probe_timeout_fallback(
             "slowtool", "", VERSION_PROBE_TIMEOUT, "/fake/bin/slowtool", "manual"
         )
         assert version_num == ""
         assert version_line == ""
         assert path == "/fake/bin/slowtool"
+        assert from_cache is False
 
     def test_passthrough_when_no_timeout(self, local_state_file):
         import audit
 
         result = audit._apply_probe_timeout_fallback("slowtool", "2.0.0", "slowtool 2.0.0", "/usr/bin/slowtool", "apt")
-        assert result == ("2.0.0", "slowtool 2.0.0", "/usr/bin/slowtool", "apt")
+        assert result == ("2.0.0", "slowtool 2.0.0", "/usr/bin/slowtool", "apt", False)
+
+    def test_fallback_is_surfaced_in_classification_reason(self, tmp_path, monkeypatch):
+        """The cached substitution must be visible in the audit record, not silent."""
+        import audit
+        from cli_audit.detection import VERSION_PROBE_TIMEOUT
+        from cli_audit.tools import filter_tools
+
+        tool = filter_tools(["ripgrep"])[0]
+        state_file = tmp_path / "local_state.json"
+        state_file.write_text(
+            json.dumps(
+                {
+                    "__meta__": {"schema_version": 2},
+                    "tools": {
+                        tool.name: {
+                            "installed_version": "15.1.0",
+                            "installed_path": "/home/user/.cargo/bin/rg",
+                            "installed_method": "cargo",
+                            "status": "UP-TO-DATE",
+                            "classification_reason": "Detected via path analysis: cargo",
+                            "category": "general",
+                            "hint": "",
+                        }
+                    },
+                }
+            )
+        )
+        monkeypatch.setenv("CLI_AUDIT_LOCAL_FILE", str(state_file))
+        monkeypatch.setattr(
+            audit,
+            "audit_tool_installation",
+            lambda *a, **k: ("", VERSION_PROBE_TIMEOUT, "/fake/bin/rg", "cargo"),
+        )
+
+        inst = audit._detect_local_only(tool)
+        assert inst.installed_version == "15.1.0"
+        assert "probe timed out" in inst.classification_reason

--- a/tests/test_probe_timeout_fallback.py
+++ b/tests/test_probe_timeout_fallback.py
@@ -1,0 +1,180 @@
+"""
+Regression tests for version-probe timeout fallback.
+
+A slow binary (e.g. opengrep, ~2.5s for --version) can exceed the probe
+timeout under parallel `make update` load. That must NOT be reported as
+"not installed": the binary was found on disk, only the version probe
+timed out. Detection signals the timeout distinctly and audit falls back
+to the last known version from local_state.json.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+skip_on_windows = pytest.mark.skipif(sys.platform == "win32", reason="Uses Unix shell scripts as fake binaries")
+
+
+# ===========================================================================
+# 1. run_with_timeout distinguishes timeout (None) from other failures ("")
+# ===========================================================================
+
+
+class TestRunWithTimeout:
+    @skip_on_windows
+    def test_returns_none_on_timeout(self):
+        from cli_audit.detection import run_with_timeout
+
+        assert run_with_timeout(["sleep", "2"], timeout=0.1) is None
+
+    def test_returns_empty_on_missing_binary(self):
+        from cli_audit.detection import run_with_timeout
+
+        assert run_with_timeout(["/nonexistent/definitely-not-a-binary"]) == ""
+
+    @skip_on_windows
+    def test_returns_line_on_success(self):
+        from cli_audit.detection import run_with_timeout
+
+        line = run_with_timeout(["echo", "tool 1.2.3"])
+        assert line == "tool 1.2.3"
+
+
+# ===========================================================================
+# 2. get_version_line returns None when the probe timed out
+# ===========================================================================
+
+
+@pytest.fixture
+def slow_binary(tmp_path: Path) -> str:
+    """A fake binary that sleeps past the (patched) timeout."""
+    script = tmp_path / "slowtool"
+    script.write_text("#!/bin/sh\nsleep 2\n")
+    script.chmod(script.stat().st_mode | stat.S_IXUSR)
+    return str(script)
+
+
+class TestGetVersionLine:
+    @skip_on_windows
+    def test_returns_none_on_timeout_with_version_flag(self, slow_binary, monkeypatch):
+        import cli_audit.detection as detection
+
+        monkeypatch.setattr(detection, "TIMEOUT_SECONDS", 0.1)
+        assert detection.get_version_line(slow_binary, "slowtool", version_flag="--version") is None
+
+    @skip_on_windows
+    def test_returns_none_on_timeout_with_generic_flags(self, slow_binary, monkeypatch):
+        import cli_audit.detection as detection
+
+        monkeypatch.setattr(detection, "TIMEOUT_SECONDS", 0.1)
+        assert detection.get_version_line(slow_binary, "slowtool") is None
+
+    @skip_on_windows
+    def test_returns_empty_when_probe_fails_without_timeout(self, tmp_path, monkeypatch):
+        """A binary that answers fast but uselessly still yields '' (not None)."""
+        import cli_audit.detection as detection
+
+        script = tmp_path / "quiettool"
+        script.write_text("#!/bin/sh\nexit 0\n")
+        script.chmod(script.stat().st_mode | stat.S_IXUSR)
+        monkeypatch.setattr(detection, "TIMEOUT_SECONDS", 1)
+        assert detection.get_version_line(str(script), "quiettool") == ""
+
+
+# ===========================================================================
+# 3. audit_tool_installation returns the timeout marker
+# ===========================================================================
+
+
+class TestAuditToolInstallationTimeout:
+    def test_timeout_marker_when_binary_found_but_probe_times_out(self, monkeypatch):
+        import cli_audit.detection as detection
+
+        monkeypatch.setattr(detection, "find_paths", lambda cand, deep=False: ["/fake/bin/slowtool"])
+        monkeypatch.setattr(
+            detection,
+            "get_version_line",
+            lambda path, tool_name, version_flag=None, version_command=None: None,
+        )
+        monkeypatch.setattr(detection, "detect_install_method", lambda path, tool_name: "manual")
+
+        result = detection.audit_tool_installation("slowtool", ("slowtool",))
+        assert result == ("", detection.VERSION_PROBE_TIMEOUT, "/fake/bin/slowtool", "manual")
+
+    def test_not_installed_unchanged_when_binary_missing(self, monkeypatch):
+        import cli_audit.detection as detection
+
+        monkeypatch.setattr(detection, "find_paths", lambda cand, deep=False: [])
+        result = detection.audit_tool_installation("ghosttool", ("ghosttool",))
+        assert result == ("", "X", "", "")
+
+
+# ===========================================================================
+# 4. audit falls back to last known local_state version on timeout
+# ===========================================================================
+
+
+@pytest.fixture
+def local_state_file(tmp_path, monkeypatch) -> Path:
+    state_file = tmp_path / "local_state.json"
+    state_file.write_text(
+        json.dumps(
+            {
+                "__meta__": {"schema_version": 2},
+                "tools": {
+                    "slowtool": {
+                        "installed_version": "1.26.0",
+                        "installed_path": "/home/user/.local/bin/slowtool",
+                        "installed_method": "manual",
+                        "status": "UP-TO-DATE",
+                        "classification_reason": "Detected via path analysis: manual",
+                        "category": "devops",
+                        "hint": "",
+                    }
+                },
+            }
+        )
+    )
+    monkeypatch.setenv("CLI_AUDIT_LOCAL_FILE", str(state_file))
+    return state_file
+
+
+class TestTimeoutFallback:
+    def test_falls_back_to_cached_version(self, local_state_file):
+        import audit
+        from cli_audit.detection import VERSION_PROBE_TIMEOUT
+
+        version_num, version_line, path, method = audit._apply_probe_timeout_fallback(
+            "slowtool", "", VERSION_PROBE_TIMEOUT, "/fake/bin/slowtool", "manual"
+        )
+        assert version_num == "1.26.0"
+        assert "1.26.0" in version_line
+        assert path == "/fake/bin/slowtool"
+        assert method == "manual"
+
+    def test_no_cached_version_reports_unknown(self, tmp_path, monkeypatch):
+        import audit
+        from cli_audit.detection import VERSION_PROBE_TIMEOUT
+
+        state_file = tmp_path / "empty_state.json"
+        state_file.write_text(json.dumps({"__meta__": {"schema_version": 2}, "tools": {}}))
+        monkeypatch.setenv("CLI_AUDIT_LOCAL_FILE", str(state_file))
+
+        version_num, version_line, path, method = audit._apply_probe_timeout_fallback(
+            "slowtool", "", VERSION_PROBE_TIMEOUT, "/fake/bin/slowtool", "manual"
+        )
+        assert version_num == ""
+        assert version_line == ""
+        assert path == "/fake/bin/slowtool"
+
+    def test_passthrough_when_no_timeout(self, local_state_file):
+        import audit
+
+        result = audit._apply_probe_timeout_fallback("slowtool", "2.0.0", "slowtool 2.0.0", "/usr/bin/slowtool", "apt")
+        assert result == ("2.0.0", "slowtool 2.0.0", "/usr/bin/slowtool", "apt")


### PR DESCRIPTION
## Problem

`make update` reported opengrep as `installed: n/a` even though the binary exists and answers `--version` with `1.26.0`. Root cause: `opengrep --version` needs ~2.5s (large Semgrep-fork binary) and the version probe timeout is 3s (`CLI_AUDIT_TIMEOUT_SECONDS`). Under parallel collection load the probe exceeds 3s, `run_with_timeout` swallowed the `TimeoutExpired` and returned `""` — indistinguishable from "no version output", so the tool was rendered as not installed.

## Fix

Treat a probe timeout as "installed, version momentarily unknown" instead of "not installed":

- `run_with_timeout` / `get_version_line` return `None` on timeout, distinct from `""` for other failures
- `audit_tool_installation` returns a `<probe-timeout>` marker when the binary was found on disk but every probe timed out
- `audit_tool` (make update) and `_detect_local_only` (make update-local) fall back to the last known version from `local_state.json` when they see the marker

Genuinely uninstalled tools are unaffected: no path is found, so no fallback applies.

The first commit is a mechanical `style(audit)` cleanup: `audit.py` predates the pre-commit config (black/isort/flake8), so any commit touching it fails the hooks until it is reformatted. Kept separate so the functional diff stays reviewable.

## Test plan

- 11 new tests in `tests/test_probe_timeout_fallback.py` (timeout vs. failure distinction, marker propagation, local-state fallback, not-installed passthrough)
- Full suite: 769 passed, 1 skipped; flake8 and mypy match the `main` baseline (no new findings); `./scripts/test_smoke.sh` OK
- End-to-end: with `CLI_AUDIT_TIMEOUT_SECONDS=1` (forcing the opengrep probe to time out), both collect and update-local paths now report `1.26.0 UP-TO-DATE` instead of `n/a`
