### PR TITLE
fix(audit): stop misclassifying manual installs as brew and surface removal failures

### DIFF
--- a/audit.py
+++ b/audit.py
@@ -1474,6 +1474,15 @@ def cmd_reconcile(args: argparse.Namespace) -> int:
                     )
                 )
             else:
+                # Per-tool outcomes must be visible without --verbose: a user
+                # who confirmed a removal needs to see why it failed.
+                for r in conflicts:
+                    if r.action_taken == "aborted":
+                        print(f"  {r.tool}: skipped (declined)", file=sys.stderr)
+                    elif r.action_taken == "blocked":
+                        print(f"  {r.tool}: skipped (protected system tool)", file=sys.stderr)
+                    elif not r.success and r.error_message:
+                        print(f"  ✗ {r.tool}: {r.error_message}", file=sys.stderr)
                 print(result.summary(), file=sys.stderr)
             # Fail only on real removal errors — not on protected tools (blocked)
             # or tools the user declined (aborted), which are expected outcomes.

--- a/cli_audit/reconcile.py
+++ b/cli_audit/reconcile.py
@@ -25,7 +25,6 @@ from .config import Config
 from .environment import Environment
 from .upgrade import compare_versions
 
-
 # Installation detection cache with TTL
 _detection_cache: dict[str, tuple[list[Installation], float]] = {}
 CACHE_TTL = 3600  # 1 hour
@@ -33,9 +32,33 @@ CACHE_TTL = 3600  # 1 hour
 
 # Critical system tools that should never be removed
 SYSTEM_TOOL_SAFELIST = {
-    'python', 'python3', 'bash', 'sh', 'sudo', 'rm', 'cp', 'mv', 'ls', 'cat',
-    'chmod', 'chown', 'grep', 'sed', 'awk', 'tar', 'gzip', 'gunzip', 'find',
-    'xargs', 'ps', 'kill', 'systemctl', 'apt', 'dnf', 'yum', 'pacman',
+    "python",
+    "python3",
+    "bash",
+    "sh",
+    "sudo",
+    "rm",
+    "cp",
+    "mv",
+    "ls",
+    "cat",
+    "chmod",
+    "chown",
+    "grep",
+    "sed",
+    "awk",
+    "tar",
+    "gzip",
+    "gunzip",
+    "find",
+    "xargs",
+    "ps",
+    "kill",
+    "systemctl",
+    "apt",
+    "dnf",
+    "yum",
+    "pacman",
 }
 
 
@@ -53,6 +76,7 @@ class Installation:
         valid: Whether the installation can be executed successfully
         preference_score: Tuple for sorting (tier, version, -path_index)
     """
+
     tool: str
     version: str
     method: str
@@ -89,6 +113,7 @@ class ReconciliationResult:
         success: Whether reconciliation succeeded
         error_message: Error message if failed
     """
+
     tool: str
     installations: tuple[Installation, ...]
     preferred: Installation | None
@@ -126,6 +151,7 @@ class BulkReconciliationResult:
         results: Individual reconciliation results
         duration_seconds: Total execution time
     """
+
     tools_checked: int
     conflicts_found: int
     conflicts_resolved: int
@@ -156,9 +182,17 @@ Reconciliation Summary:
 # Environment-name patterns for env managers without a pyvenv.cfg (conda etc.).
 # Mirrors the venv skip list in scripts/lib/capability.sh:detect_all_installations.
 _ENV_DIR_PATTERNS = (
-    "/venv/bin", "/.venv/bin", "/env/bin",
-    "/venvs/", "/.venvs/", "/virtualenvs/", "/.virtualenvs/",
-    "/envs/", "/conda/", "/miniconda", "/anaconda",
+    "/venv/bin",
+    "/.venv/bin",
+    "/env/bin",
+    "/venvs/",
+    "/.venvs/",
+    "/virtualenvs/",
+    "/.virtualenvs/",
+    "/envs/",
+    "/conda/",
+    "/miniconda",
+    "/anaconda",
 )
 
 
@@ -212,7 +246,7 @@ def detect_installations(
     seen_paths = set()
 
     # Get PATH directories
-    path_env = os.environ.get('PATH', '')
+    path_env = os.environ.get("PATH", "")
     path_dirs = [d for d in path_env.split(os.pathsep) if d]
 
     # Search each PATH directory
@@ -255,8 +289,9 @@ def detect_installations(
             version = None
             valid = True
             try:
-                from .detection import get_version_line
                 from .collectors import extract_version_number
+                from .detection import get_version_line
+
                 meta = _catalog_meta(tool_name)
                 line = get_version_line(real_path, tool_name, meta.get("version_flag"), None)
                 if line:
@@ -276,14 +311,16 @@ def detect_installations(
             active_path = shutil.which(candidate)
             is_active = (os.path.realpath(active_path) == real_path) if active_path else False
 
-            installations.append(Installation(
-                tool=tool_name,
-                version=version,
-                method=method,
-                path=real_path,
-                active=is_active,
-                valid=valid,
-            ))
+            installations.append(
+                Installation(
+                    tool=tool_name,
+                    version=version,
+                    method=method,
+                    path=real_path,
+                    active=is_active,
+                    valid=valid,
+                )
+            )
 
             vlog(f"  Found: {real_path} ({method}, {version})", verbose)
 
@@ -349,10 +386,10 @@ def _classify_via_queries(path: str, tool_name: str, verbose: bool) -> str:
         return _classify_via_path(path)
 
     # dpkg (Debian/Ubuntu)
-    if shutil.which('dpkg'):
+    if shutil.which("dpkg"):
         try:
             result = subprocess.run(
-                ['dpkg', '-S', path],
+                ["dpkg", "-S", path],
                 capture_output=True,
                 text=True,
                 timeout=2,
@@ -360,15 +397,15 @@ def _classify_via_queries(path: str, tool_name: str, verbose: bool) -> str:
             )
             if result.returncode == 0:
                 vlog("  Classified as apt via dpkg query", verbose)
-                return 'apt'
+                return "apt"
         except Exception:
             pass
 
     # rpm (Fedora/RHEL)
-    if shutil.which('rpm'):
+    if shutil.which("rpm"):
         try:
             result = subprocess.run(
-                ['rpm', '-qf', path],
+                ["rpm", "-qf", path],
                 capture_output=True,
                 text=True,
                 timeout=2,
@@ -376,15 +413,15 @@ def _classify_via_queries(path: str, tool_name: str, verbose: bool) -> str:
             )
             if result.returncode == 0:
                 vlog("  Classified as dnf/rpm via rpm query", verbose)
-                return 'dnf'
+                return "dnf"
         except Exception:
             pass
 
     # brew
-    if shutil.which('brew'):
+    if shutil.which("brew"):
         try:
             result = subprocess.run(
-                ['brew', 'list'],
+                ["brew", "list"],
                 capture_output=True,
                 text=True,
                 timeout=5,
@@ -393,7 +430,7 @@ def _classify_via_queries(path: str, tool_name: str, verbose: bool) -> str:
             if result.returncode == 0 and tool_name in result.stdout:
                 # Verify this tool is from brew
                 formula_result = subprocess.run(
-                    ['brew', 'list', tool_name],
+                    ["brew", "list", tool_name],
                     capture_output=True,
                     text=True,
                     timeout=2,
@@ -401,15 +438,15 @@ def _classify_via_queries(path: str, tool_name: str, verbose: bool) -> str:
                 )
                 if formula_result.returncode == 0 and path in formula_result.stdout:
                     vlog("  Classified as brew via brew list", verbose)
-                    return 'brew'
+                    return "brew"
         except Exception:
             pass
 
     # cargo
-    if shutil.which('cargo'):
+    if shutil.which("cargo"):
         try:
             result = subprocess.run(
-                ['cargo', 'install', '--list'],
+                ["cargo", "install", "--list"],
                 capture_output=True,
                 text=True,
                 timeout=5,
@@ -417,15 +454,15 @@ def _classify_via_queries(path: str, tool_name: str, verbose: bool) -> str:
             )
             if result.returncode == 0 and tool_name in result.stdout:
                 vlog("  Classified as cargo via cargo install --list", verbose)
-                return 'cargo'
+                return "cargo"
         except Exception:
             pass
 
     # pipx
-    if shutil.which('pipx'):
+    if shutil.which("pipx"):
         try:
             result = subprocess.run(
-                ['pipx', 'list'],
+                ["pipx", "list"],
                 capture_output=True,
                 text=True,
                 timeout=5,
@@ -433,15 +470,15 @@ def _classify_via_queries(path: str, tool_name: str, verbose: bool) -> str:
             )
             if result.returncode == 0 and tool_name in result.stdout:
                 vlog("  Classified as pipx via pipx list", verbose)
-                return 'pipx'
+                return "pipx"
         except Exception:
             pass
 
     # uv tool
-    if shutil.which('uv'):
+    if shutil.which("uv"):
         try:
             result = subprocess.run(
-                ['uv', 'tool', 'list'],
+                ["uv", "tool", "list"],
                 capture_output=True,
                 text=True,
                 timeout=5,
@@ -449,7 +486,7 @@ def _classify_via_queries(path: str, tool_name: str, verbose: bool) -> str:
             )
             if result.returncode == 0 and tool_name in result.stdout:
                 vlog("  Classified as uv via uv tool list", verbose)
-                return 'uv'
+                return "uv"
         except Exception:
             pass
 
@@ -459,34 +496,36 @@ def _classify_via_queries(path: str, tool_name: str, verbose: bool) -> str:
 def _classify_via_path(path: str) -> str:
     """Classify via path-based heuristics."""
     # User-level installations
-    if '/.cargo/bin' in path:
-        return 'cargo'
-    elif '/.local/bin' in path:
+    if "/.cargo/bin" in path:
+        return "cargo"
+    elif "/.local/bin" in path:
         # Could be pip --user, pipx, or uv
         # Default to pipx as most common
-        return 'pipx'
-    elif '/.uv/bin' in path or '/uv-python' in path:
-        return 'uv'
-    elif '/.nvm/' in path:
-        return 'nvm'
-    elif '/.pyenv/' in path:
-        return 'pyenv'
-    elif '/.rbenv/' in path:
-        return 'rbenv'
+        return "pipx"
+    elif "/.uv/bin" in path or "/uv-python" in path:
+        return "uv"
+    elif "/.nvm/" in path:
+        return "nvm"
+    elif "/.pyenv/" in path:
+        return "pyenv"
+    elif "/.rbenv/" in path:
+        return "rbenv"
 
     # System-level installations (check specific patterns before generic ones)
-    elif '/snap/bin' in path:
-        return 'snap'
-    elif '/opt/homebrew' in path:
-        return 'brew'
-    elif '/usr/local/bin' in path or '/usr/local/sbin' in path:
-        return 'brew'
-    elif '/usr/bin' in path or '/usr/sbin' in path:
-        return 'apt'  # Generic system PM
-    elif '/bin' in path or '/sbin' in path:
-        return 'system'
+    elif "/snap/bin" in path:
+        return "snap"
+    elif "/opt/homebrew" in path:
+        # Without brew installed these are manual installs (curl'd binaries);
+        # labeling them 'brew' makes removal run a nonexistent `brew uninstall`.
+        return "brew" if shutil.which("brew") else "manual"
+    elif "/usr/local/bin" in path or "/usr/local/sbin" in path:
+        return "brew" if shutil.which("brew") else "manual"
+    elif "/usr/bin" in path or "/usr/sbin" in path:
+        return "apt"  # Generic system PM
+    elif "/bin" in path or "/sbin" in path:
+        return "system"
 
-    return 'unknown'
+    return "unknown"
 
 
 def clear_detection_cache():
@@ -521,26 +560,27 @@ def sort_by_preference(
     Returns:
         Sorted list (highest preference first)
     """
+
     def get_preference_tier(installation: Installation) -> int:
         """Get preference tier (lower number = higher preference)."""
         method = installation.method
 
         # Tier 1: User-level vendor tools (highest priority)
-        if method in ('uv', 'pipx', 'rustup', 'nvm', 'pyenv', 'rbenv'):
+        if method in ("uv", "pipx", "rustup", "nvm", "pyenv", "rbenv"):
             return 1
 
         # Tier 2: User-level generic
-        if method in ('cargo', 'pip', 'npm'):
+        if method in ("cargo", "pip", "npm"):
             return 2
-        if '/.cargo/' in installation.path or '/.local/' in installation.path:
+        if "/.cargo/" in installation.path or "/.local/" in installation.path:
             return 2
 
         # Tier 3: Homebrew
-        if method == 'brew':
+        if method == "brew":
             return 3
 
         # Tier 4: System package managers (lowest priority)
-        if method in ('apt', 'dnf', 'yum', 'pacman', 'zypper', 'snap', 'system'):
+        if method in ("apt", "dnf", "yum", "pacman", "zypper", "snap", "system"):
             return 4
 
         # Unknown: treat as Tier 5
@@ -548,7 +588,7 @@ def sort_by_preference(
 
     # Score each installation
     scored = []
-    path_dirs = os.environ.get('PATH', '').split(os.pathsep)
+    path_dirs = os.environ.get("PATH", "").split(os.pathsep)
 
     for installation in installations:
         tier = get_preference_tier(installation)
@@ -611,6 +651,7 @@ def _catalog_meta(tool_name: str) -> dict:
             inst = _catalog_instance
             if inst is None:
                 from .catalog import ToolCatalog
+
                 inst = ToolCatalog()
                 # Only cache a catalog that actually loaded, so a transiently
                 # empty/unavailable filesystem doesn't poison later calls.
@@ -717,15 +758,9 @@ def reconcile_tool(
 
     # Execute reconciliation based on mode
     if mode == "aggressive":
-        return _reconcile_aggressive(
-            tool_name, sorted_installs, preferred, active,
-            path_issues, force, verbose
-        )
+        return _reconcile_aggressive(tool_name, sorted_installs, preferred, active, path_issues, force, verbose)
     else:  # parallel (default)
-        return _reconcile_parallel(
-            tool_name, sorted_installs, preferred, active,
-            path_issues, verbose
-        )
+        return _reconcile_parallel(tool_name, sorted_installs, preferred, active, path_issues, verbose)
 
 
 def _reconcile_parallel(
@@ -905,7 +940,7 @@ def _confirm_removal(tool_name: str, to_remove: list[Installation]) -> bool:
 
         print("\nProceed with removal? [y/N]: ", end="")
         response = input().strip().lower()
-        return response in ('y', 'yes')
+        return response in ("y", "yes")
 
 
 def _uninstall_installation(installation: Installation, verbose: bool) -> tuple[bool, str | None]:
@@ -922,10 +957,10 @@ def _uninstall_installation(installation: Installation, verbose: bool) -> tuple[
     vlog(f"  Uninstalling {tool} via {method}...", verbose)
 
     # Cargo
-    if method == 'cargo':
+    if method == "cargo":
         try:
             result = subprocess.run(
-                ['cargo', 'uninstall', tool],
+                ["cargo", "uninstall", tool],
                 capture_output=True,
                 text=True,
                 timeout=30,
@@ -939,10 +974,10 @@ def _uninstall_installation(installation: Installation, verbose: bool) -> tuple[
             return (False, str(e))
 
     # Pipx
-    elif method == 'pipx':
+    elif method == "pipx":
         try:
             result = subprocess.run(
-                ['pipx', 'uninstall', tool],
+                ["pipx", "uninstall", tool],
                 capture_output=True,
                 text=True,
                 timeout=30,
@@ -956,10 +991,10 @@ def _uninstall_installation(installation: Installation, verbose: bool) -> tuple[
             return (False, str(e))
 
     # UV
-    elif method == 'uv':
+    elif method == "uv":
         try:
             result = subprocess.run(
-                ['uv', 'tool', 'uninstall', tool],
+                ["uv", "tool", "uninstall", tool],
                 capture_output=True,
                 text=True,
                 timeout=30,
@@ -973,10 +1008,10 @@ def _uninstall_installation(installation: Installation, verbose: bool) -> tuple[
             return (False, str(e))
 
     # Brew
-    elif method == 'brew':
+    elif method == "brew":
         try:
             result = subprocess.run(
-                ['brew', 'uninstall', tool],
+                ["brew", "uninstall", tool],
                 capture_output=True,
                 text=True,
                 timeout=30,
@@ -990,11 +1025,11 @@ def _uninstall_installation(installation: Installation, verbose: bool) -> tuple[
             return (False, str(e))
 
     # System package managers (require sudo - don't auto-execute)
-    elif method in ('apt', 'dnf', 'pacman', 'system'):
+    elif method in ("apt", "dnf", "pacman", "system"):
         return (False, f"System package removal requires manual sudo: sudo {method} remove {tool}")
 
     # Manual removal (for GitHub releases, etc.)
-    elif method == 'unknown' or method == 'manual':
+    elif method == "unknown" or method == "manual":
         try:
             if os.path.exists(path):
                 os.remove(path)
@@ -1002,7 +1037,7 @@ def _uninstall_installation(installation: Installation, verbose: bool) -> tuple[
             else:
                 return (False, "Binary not found")
         except PermissionError:
-            return (False, f"Permission denied: {path}")
+            return (False, f"Permission denied — remove manually: sudo rm {path}")
         except Exception as e:
             return (False, str(e))
 
@@ -1037,6 +1072,7 @@ def bulk_reconcile(
         BulkReconciliationResult with outcomes
     """
     import time
+
     from .config import load_config
     from .environment import detect_environment
 
@@ -1113,26 +1149,25 @@ def bulk_reconcile(
 
             except Exception as e:
                 vlog(f"✗ {tool}: Error - {e}", verbose)
-                results.append(ReconciliationResult(
-                    tool=tool,
-                    installations=(),
-                    preferred=None,
-                    active=None,
-                    path_issues=(),
-                    action_taken="error",
-                    success=False,
-                    error_message=str(e),
-                ))
+                results.append(
+                    ReconciliationResult(
+                        tool=tool,
+                        installations=(),
+                        preferred=None,
+                        active=None,
+                        path_issues=(),
+                        action_taken="error",
+                        success=False,
+                        error_message=str(e),
+                    )
+                )
 
     duration = time.time() - start_time
 
     # Calculate statistics
     tools_checked = len(results)
     conflicts_found = sum(1 for r in results if len(r.installations) > 1)
-    conflicts_resolved = sum(
-        1 for r in results
-        if len(r.installations) > 1 and r.success and r.action_taken != "none"
-    )
+    conflicts_resolved = sum(1 for r in results if len(r.installations) > 1 and r.success and r.action_taken != "none")
 
     return BulkReconciliationResult(
         tools_checked=tools_checked,
@@ -1158,18 +1193,18 @@ def verify_path_ordering(config: Config | None = None, verbose: bool = False) ->
 
     # User bin directories (should come first)
     user_bins = [
-        os.path.expanduser('~/.local/bin'),
-        os.path.expanduser('~/.cargo/bin'),
-        os.path.expanduser('~/.uv/bin'),
-        os.path.expanduser('~/.pyenv/bin'),
-        os.path.expanduser('~/.rbenv/bin'),
+        os.path.expanduser("~/.local/bin"),
+        os.path.expanduser("~/.cargo/bin"),
+        os.path.expanduser("~/.uv/bin"),
+        os.path.expanduser("~/.pyenv/bin"),
+        os.path.expanduser("~/.rbenv/bin"),
     ]
 
     # System bin directories (should come later)
-    system_bins = ['/usr/local/bin', '/usr/bin', '/bin', '/usr/sbin', '/sbin']
+    system_bins = ["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"]
 
     # Get PATH
-    path_dirs = os.environ.get('PATH', '').split(os.pathsep)
+    path_dirs = os.environ.get("PATH", "").split(os.pathsep)
 
     # Check each user bin that exists
     for user_bin in user_bins:
@@ -1180,7 +1215,7 @@ def verify_path_ordering(config: Config | None = None, verbose: bool = False) ->
             issues.append(
                 f"Missing from PATH: {user_bin}\n"
                 f"  Fix: Add to ~/.bashrc or ~/.zshrc:\n"
-                f"    export PATH=\"{user_bin}:$PATH\""
+                f'    export PATH="{user_bin}:$PATH"'
             )
             continue
 
@@ -1199,7 +1234,7 @@ def verify_path_ordering(config: Config | None = None, verbose: bool = False) ->
                     f"PATH ordering issue: {sys_bin} appears before {user_bin}\n"
                     f"  Current PATH index: {sys_bin}={sys_idx}, {user_bin}={user_idx}\n"
                     f"  Fix: Add to ~/.bashrc or ~/.zshrc:\n"
-                    f"    export PATH=\"{user_bin}:$PATH\""
+                    f'    export PATH="{user_bin}:$PATH"'
                 )
 
     if verbose:

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -8,35 +8,32 @@ import os
 import sys
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, patch, mock_open
+from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
-# Skip marker for Windows (Unix-style paths and PATH separator differences)
-skip_on_windows = pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="Uses Unix-style paths and PATH separator (:)"
-)
-
-from cli_audit.reconcile import (
-    Installation,
-    ReconciliationResult,
-    BulkReconciliationResult,
-    detect_installations,
-    classify_install_method,
-    _classify_via_path,
-    clear_detection_cache,
-    sort_by_preference,
-    reconcile_tool,
-    bulk_reconcile,
-    verify_path_ordering,
-    _check_path_ordering,
-    _confirm_removal,
-    _uninstall_installation,
-    SYSTEM_TOOL_SAFELIST,
-)
 from cli_audit.config import Config, Preferences
 from cli_audit.environment import Environment
+from cli_audit.reconcile import (
+    SYSTEM_TOOL_SAFELIST,
+    BulkReconciliationResult,
+    Installation,
+    ReconciliationResult,
+    _check_path_ordering,
+    _classify_via_path,
+    _confirm_removal,
+    _uninstall_installation,
+    bulk_reconcile,
+    classify_install_method,
+    clear_detection_cache,
+    detect_installations,
+    reconcile_tool,
+    sort_by_preference,
+    verify_path_ordering,
+)
+
+# Skip marker for Windows (Unix-style paths and PATH separator differences)
+skip_on_windows = pytest.mark.skipif(sys.platform == "win32", reason="Uses Unix-style paths and PATH separator (:)")
 
 
 class TestInstallationDataclass:
@@ -104,10 +101,29 @@ class TestClassifyInstallMethod:
         assert method == "nvm"
 
     def test_classify_via_path_brew(self):
-        """Test brew classification via path."""
+        """Test brew classification via path when brew is installed."""
         path = "/usr/local/bin/ripgrep"
-        method = _classify_via_path(path)
+        with patch("cli_audit.reconcile.shutil.which", return_value="/home/linuxbrew/.linuxbrew/bin/brew"):
+            method = _classify_via_path(path)
         assert method == "brew"
+
+    def test_classify_via_path_usr_local_without_brew_is_manual(self):
+        """Without brew installed, /usr/local/bin binaries are manual installs.
+
+        Regression: manually-installed binaries in /usr/local/bin were labeled
+        'brew', so removal ran `brew uninstall` and failed with FileNotFoundError.
+        """
+        path = "/usr/local/bin/yq"
+        with patch("cli_audit.reconcile.shutil.which", return_value=None):
+            method = _classify_via_path(path)
+        assert method == "manual"
+
+    def test_classify_via_path_opt_homebrew_without_brew_is_manual(self):
+        """Without brew installed, /opt/homebrew paths are manual too."""
+        path = "/opt/homebrew/bin/yq"
+        with patch("cli_audit.reconcile.shutil.which", return_value=None):
+            method = _classify_via_path(path)
+        assert method == "manual"
 
     def test_classify_via_path_apt(self):
         """Test apt classification via path."""
@@ -544,9 +560,7 @@ class TestBulkReconcile:
                 # Single installation
                 return ReconciliationResult(
                     tool="fd",
-                    installations=(
-                        Installation("fd", "9.0.0", "cargo", "/home/user/.cargo/bin/fd", True),
-                    ),
+                    installations=(Installation("fd", "9.0.0", "cargo", "/home/user/.cargo/bin/fd", True),),
                     preferred=Installation("fd", "9.0.0", "cargo", "/home/user/.cargo/bin/fd", True),
                     active=Installation("fd", "9.0.0", "cargo", "/home/user/.cargo/bin/fd", True),
                     path_issues=(),
@@ -555,10 +569,12 @@ class TestBulkReconcile:
 
         mock_reconcile.side_effect = reconcile_side_effect
 
-        config = Config(tools={
-            "ripgrep": {},
-            "fd": {},
-        })
+        config = Config(
+            tools={
+                "ripgrep": {},
+                "fd": {},
+            }
+        )
         env = Environment(mode="workstation", confidence=1.0)
 
         result = bulk_reconcile(
@@ -765,7 +781,7 @@ class TestUninstallInstallation:
         assert success is True
         assert error is None
         mock_run.assert_called_once()
-        assert mock_run.call_args[0][0] == ['cargo', 'uninstall', 'ripgrep']
+        assert mock_run.call_args[0][0] == ["cargo", "uninstall", "ripgrep"]
 
     @patch("cli_audit.reconcile.subprocess.run")
     def test_uninstall_pipx(self, mock_run):
@@ -784,7 +800,7 @@ class TestUninstallInstallation:
 
         assert success is True
         mock_run.assert_called_once()
-        assert mock_run.call_args[0][0] == ['pipx', 'uninstall', 'black']
+        assert mock_run.call_args[0][0] == ["pipx", "uninstall", "black"]
 
     @patch("cli_audit.reconcile.subprocess.run")
     def test_uninstall_uv(self, mock_run):
@@ -803,7 +819,7 @@ class TestUninstallInstallation:
 
         assert success is True
         mock_run.assert_called_once()
-        assert mock_run.call_args[0][0] == ['uv', 'tool', 'uninstall', 'ruff']
+        assert mock_run.call_args[0][0] == ["uv", "tool", "uninstall", "ruff"]
 
     def test_uninstall_system_package(self):
         """Test system package requires sudo."""
@@ -836,6 +852,23 @@ class TestUninstallInstallation:
 
         assert success is True
         mock_remove.assert_called_once_with("/home/user/bin/tool")
+
+    @patch("os.remove", side_effect=PermissionError(13, "Permission denied"))
+    @patch("os.path.exists", return_value=True)
+    def test_uninstall_manual_permission_denied_suggests_sudo(self, mock_exists, mock_remove):
+        """Root-owned manual binaries surface actionable sudo guidance."""
+        inst = Installation(
+            tool="yq",
+            version="4.48.1",
+            method="manual",
+            path="/usr/local/bin/yq",
+            active=False,
+        )
+
+        success, error = _uninstall_installation(inst, False)
+
+        assert success is False
+        assert "sudo rm /usr/local/bin/yq" in error
 
 
 class TestSystemToolSafelist:

--- a/tests/test_reconcile_cli.py
+++ b/tests/test_reconcile_cli.py
@@ -3,14 +3,15 @@
 Covers plan shaping (active vs preferred markers), catalog candidate
 resolution, and the JSON output for plan/apply/protected/divergence cases.
 """
+
 import argparse
 import io
 import json
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from unittest.mock import patch
 
 import audit
-from cli_audit.reconcile import Installation, ReconciliationResult
+from cli_audit.reconcile import BulkReconciliationResult, Installation, ReconciliationResult
 
 
 def _ns(**kw):
@@ -37,8 +38,8 @@ class TestShapeReconcilePlan:
         assert plan["installations"][1]["preferred"] is False
 
     def test_active_differs_from_preferred(self):
-        pref = _inst("/home/u/.local/bin/demo")            # preferred, not active
-        act = _inst("/usr/local/bin/demo", active=True)     # active, not preferred
+        pref = _inst("/home/u/.local/bin/demo")  # preferred, not active
+        act = _inst("/usr/local/bin/demo", active=True)  # active, not preferred
         plan = audit._shape_reconcile_plan("demo", [pref, act], preferred=pref, active=act, protected=False)
 
         assert plan["preferred"]["path"] == "/home/u/.local/bin/demo"
@@ -58,18 +59,21 @@ class TestShapeReconcilePlan:
 class TestResolveCandidates:
     def test_returns_catalog_candidates(self):
         from cli_audit.reconcile import _resolve_candidates
+
         # pip declares candidates ["pip", "pip3"] in the catalog
         cands = _resolve_candidates("pip")
         assert cands is not None
         assert "pip3" in cands
 
     def test_unknown_tool_returns_none(self):
-        from cli_audit.reconcile import _resolve_candidates, _catalog_cache
+        from cli_audit.reconcile import _catalog_cache, _resolve_candidates
+
         _catalog_cache.pop("not-a-real-tool-xyz", None)
         assert _resolve_candidates("not-a-real-tool-xyz") is None
 
     def test_result_is_cached(self):
-        from cli_audit.reconcile import _resolve_candidates, _catalog_cache
+        from cli_audit.reconcile import _catalog_cache, _resolve_candidates
+
         _resolve_candidates("pip")
         assert "pip" in _catalog_cache
 
@@ -77,11 +81,13 @@ class TestResolveCandidates:
 class TestSafeBinaryPath:
     def test_accepts_normal_absolute_paths(self):
         from cli_audit.reconcile import _is_safe_binary_path
+
         assert _is_safe_binary_path("/usr/bin/rg")
         assert _is_safe_binary_path("/home/u/.cargo/bin/fd")
 
     def test_rejects_shell_metacharacters_and_relative(self):
         from cli_audit.reconcile import _is_safe_binary_path
+
         assert not _is_safe_binary_path("/opt/x; rm -rf /")
         assert not _is_safe_binary_path("/opt/a$(id)")
         assert not _is_safe_binary_path("rg")
@@ -91,6 +97,7 @@ class TestSafeBinaryPath:
         # An unsafe path must never reach a package-manager OS query; it falls
         # back to path-based classification instead.
         from cli_audit.reconcile import _classify_via_queries
+
         assert isinstance(_classify_via_queries("/opt/x; rm -rf /", "demo", False), str)
 
 
@@ -98,8 +105,10 @@ class TestCmdReconcilePlanJSON:
     def test_single_tool_plan_json(self):
         pref = _inst("/home/u/.local/bin/demo", active=True)
         other = _inst("/usr/local/bin/demo")
-        with patch("cli_audit.reconcile.detect_installations", return_value=[pref, other]), \
-                patch.object(audit, "JSON_MODE", True):
+        with (
+            patch("cli_audit.reconcile.detect_installations", return_value=[pref, other]),
+            patch.object(audit, "JSON_MODE", True),
+        ):
             buf = io.StringIO()
             with redirect_stdout(buf):
                 rc = audit.cmd_reconcile(_ns(tools=["demo"]))
@@ -128,8 +137,7 @@ class TestCmdReconcileApplyJSON:
             removed_installations=(removed,),
             success=True,
         )
-        with patch("cli_audit.reconcile.reconcile_tool", return_value=result), \
-                patch.object(audit, "JSON_MODE", True):
+        with patch("cli_audit.reconcile.reconcile_tool", return_value=result), patch.object(audit, "JSON_MODE", True):
             buf = io.StringIO()
             with redirect_stdout(buf):
                 rc = audit.cmd_reconcile(_ns(tools=["demo"], apply=True, yes=True))
@@ -137,6 +145,52 @@ class TestCmdReconcileApplyJSON:
         doc = json.loads(buf.getvalue())
         assert doc["results"][0]["action_taken"] == "removed"
         assert doc["results"][0]["removed_installations"][0]["path"] == "/usr/local/bin/demo"
+
+    def test_all_apply_prints_failures_and_declines_to_stderr(self):
+        """Failed removals after a confirmed prompt must be visible without --verbose.
+
+        Regression: `--all --apply` printed only the summary, so a user who
+        answered "y" saw "Conflicts resolved: 0" with no per-tool error.
+        """
+        kept = _inst("/home/u/.local/bin/yq", active=True)
+        failed = ReconciliationResult(
+            tool="yq",
+            installations=(kept, _inst("/usr/local/bin/yq")),
+            preferred=kept,
+            active=kept,
+            path_issues=(),
+            action_taken="removed",
+            success=False,
+            error_message="[Errno 2] No such file or directory: 'brew'",
+        )
+        kept_npm = _inst("/home/u/.local/bin/npm", active=True)
+        declined = ReconciliationResult(
+            tool="npm",
+            installations=(kept_npm, _inst("/usr/bin/npm")),
+            preferred=kept_npm,
+            active=kept_npm,
+            path_issues=(),
+            action_taken="aborted",
+            success=False,
+            error_message="User declined removal",
+        )
+        bulk = BulkReconciliationResult(
+            tools_checked=2,
+            conflicts_found=2,
+            conflicts_resolved=0,
+            results=(failed, declined),
+            duration_seconds=0.1,
+        )
+        with patch("cli_audit.reconcile.bulk_reconcile", return_value=bulk):
+            err = io.StringIO()
+            with redirect_stderr(err):
+                rc = audit.cmd_reconcile(_ns(all=True, apply=True, yes=True))
+        assert rc == 1
+        output = err.getvalue()
+        assert "yq" in output
+        assert "No such file or directory: 'brew'" in output
+        assert "npm" in output
+        assert "declined" in output
 
     def test_apply_protected_returns_nonzero(self):
         kept = _inst("/usr/bin/demo", active=True)
@@ -150,8 +204,7 @@ class TestCmdReconcileApplyJSON:
             success=False,
             error_message="on system safelist",
         )
-        with patch("cli_audit.reconcile.reconcile_tool", return_value=result), \
-                patch.object(audit, "JSON_MODE", True):
+        with patch("cli_audit.reconcile.reconcile_tool", return_value=result), patch.object(audit, "JSON_MODE", True):
             buf = io.StringIO()
             with redirect_stdout(buf):
                 rc = audit.cmd_reconcile(_ns(tools=["demo"], apply=True, yes=True))


### PR DESCRIPTION
## Problem

`make reconcile-all` prompted for removals, the user confirmed with `y`, yet the run ended with `Conflicts resolved: 0` and exit 1 — with no indication of what went wrong. Nothing was actually removed.

Root cause chain:

1. On machines without Homebrew, the path heuristic in `_classify_via_path` labeled any `/usr/local/bin` (or `/opt/homebrew`) binary as `brew`, so removal ran a nonexistent `brew uninstall` and failed with `FileNotFoundError`.
2. Even correctly-classified manual binaries in `/usr/local/bin` are typically root-owned, and `os.remove` fails with a bare `Permission denied` giving no path forward.
3. All per-tool removal errors were `vlog`-only, and the `--reconcile --all --apply` non-JSON path printed just the summary — so every failure after a confirmed prompt was silent.

## Fix

- Path heuristic returns `brew` for `/usr/local/bin` / `/opt/homebrew` only when `brew` is installed; otherwise `manual`. (The shell-side `scripts/lib/capability.sh` and `reconcile.sh` already gate on `command -v brew`; only the Python side was affected.)
- `PermissionError` during manual removal now surfaces actionable guidance: `Permission denied — remove manually: sudo rm <path>`, matching the existing apt/dnf behavior.
- `--reconcile --all --apply` prints per-tool outcomes to stderr before the summary: `✗ tool: <error>` for failures, `skipped (declined)`, `skipped (protected system tool)`.

## Test plan

- 4 new tests (written first, watched fail): brew-present vs brew-absent classification for `/usr/local/bin` and `/opt/homebrew`, sudo guidance on `PermissionError`, and per-tool stderr output for the `--all --apply` path.
- Full suite: 776 passed, 1 skipped. Pre-commit (flake8, isort, black) green; `./scripts/test_smoke.sh` passes.
- Real-world check on an affected machine: `audit.py --reconcile yq --apply --yes` now reports `Failed to remove /usr/local/bin/yq: Permission denied — remove manually: sudo rm /usr/local/bin/yq` instead of failing invisibly.

https://claude.ai/code/session_01MH3EaniXCnJdwqNvrMB4Ym
