### PR TITLE
fix(audit): recompute status in merged render instead of serving stored verdict

### DIFF
--- a/cli_audit/local_state.py
+++ b/cli_audit/local_state.py
@@ -83,9 +83,7 @@ class LocalState:
                 "count": self.count,
                 "partial_failures": self.partial_failures,
             },
-            "tools": {
-                name: tool.to_dict() for name, tool in self.tools.items()
-            },
+            "tools": {name: tool.to_dict() for name, tool in self.tools.items()},
         }
 
     @classmethod
@@ -94,10 +92,7 @@ class LocalState:
         meta = data.get("__meta__", {})
         tools_raw = data.get("tools", {})
 
-        tools = {
-            name: LocalInstallation.from_dict(tool_data)
-            for name, tool_data in tools_raw.items()
-        }
+        tools = {name: LocalInstallation.from_dict(tool_data) for name, tool_data in tools_raw.items()}
 
         return cls(
             tools=tools,
@@ -163,19 +158,11 @@ def write_local_state(
         path = get_local_state_path()
 
     # Update metadata
-    state.collected_at = (
-        datetime.datetime.now(datetime.timezone.utc)
-        .replace(microsecond=0)
-        .isoformat()
-        .replace("+00:00", "Z")
-    )
+    state.collected_at = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
     state.hostname = socket.gethostname()
     state.offline = offline
     state.count = len(state.tools)
-    state.partial_failures = sum(
-        1 for t in state.tools.values()
-        if t.status == "UNKNOWN" and not t.installed_version
-    )
+    state.partial_failures = sum(1 for t in state.tools.values() if t.status == "UNKNOWN" and not t.installed_version)
 
     # Atomic write: write to temp file then rename
     try:
@@ -251,6 +238,28 @@ def migrate_from_snapshot(snapshot: dict[str, Any]) -> LocalState:
     return state
 
 
+def _display_status(loc: LocalInstallation, up: UpstreamVersion) -> str:
+    """Recompute display status from the current pair of inputs.
+
+    local_state.json stores the status computed at collect time; serving it
+    verbatim after the committed upstream baseline moved pairs a fresh latest
+    with a stale verdict (bwrap: installed 0.9.0 rendered UP-TO-DATE next to
+    latest 0.11.2). A stored status is only valid for the inputs it was
+    computed from, so recompute whenever both sides are present. Directional
+    like compute_status: installed >= latest is UP-TO-DATE. CONFLICT is not a
+    version verdict and passes through unchanged.
+    """
+    from .upgrade import compare_versions
+
+    if loc.status == "CONFLICT":
+        return loc.status
+    installed = (loc.installed_version or "").lstrip("v")
+    latest = (up.latest_version or "").lstrip("v")
+    if not installed or not latest:
+        return loc.status
+    return "OUTDATED" if compare_versions(installed, latest) < 0 else "UP-TO-DATE"
+
+
 def merge_for_display(
     upstream: UpstreamCache,
     local: LocalState,
@@ -286,7 +295,7 @@ def merge_for_display(
             "installed_method": loc.installed_method,
             "installed_path_selected": loc.installed_path,
             "classification_reason_selected": loc.classification_reason,
-            "status": loc.status,
+            "status": _display_status(loc, up),
             # Upstream info (from upstream cache). Display the normalized
             # version, not latest_tag (which holds the raw tag, e.g. "v1.7.12",
             # used for URL construction).

--- a/tests/test_local_state.py
+++ b/tests/test_local_state.py
@@ -6,22 +6,23 @@ Target coverage: 85%+
 
 import json
 import os
-import pytest
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from cli_audit.local_state import (
+    DEFAULT_LOCAL_STATE_FILE,
     LocalInstallation,
     LocalState,
+    build_legacy_snapshot,
+    get_local_installation,
     get_local_state_path,
     load_local_state,
-    write_local_state,
-    get_local_installation,
-    update_local_installation,
-    migrate_from_snapshot,
     merge_for_display,
-    build_legacy_snapshot,
-    DEFAULT_LOCAL_STATE_FILE,
+    migrate_from_snapshot,
+    update_local_installation,
+    write_local_state,
 )
 from cli_audit.upstream_cache import UpstreamCache, UpstreamVersion
 
@@ -286,9 +287,7 @@ class TestWriteLocalState:
     def test_write_local_state_basic(self, tmp_path):
         """Test writing state file."""
         path = tmp_path / "local_state.json"
-        state = LocalState(
-            tools={"fd": LocalInstallation(installed_version="10.0.0")}
-        )
+        state = LocalState(tools={"fd": LocalInstallation(installed_version="10.0.0")})
         write_local_state(state, path)
 
         assert path.exists()
@@ -300,9 +299,7 @@ class TestWriteLocalState:
     def test_write_local_state_updates_metadata(self, tmp_path):
         """Test that write updates metadata fields."""
         path = tmp_path / "local_state.json"
-        state = LocalState(
-            tools={"tool": LocalInstallation(installed_version="1.0.0")}
-        )
+        state = LocalState(tools={"tool": LocalInstallation(installed_version="1.0.0")})
 
         write_local_state(state, path)
 
@@ -379,9 +376,7 @@ class TestStateHelpers:
 
     def test_update_local_installation_overwrite(self):
         """Test overwriting existing tool in state."""
-        state = LocalState(
-            tools={"tool": LocalInstallation(installed_version="1.0.0")}
-        )
+        state = LocalState(tools={"tool": LocalInstallation(installed_version="1.0.0")})
         new_install = LocalInstallation(installed_version="2.0.0")
         update_local_installation("tool", new_install, state)
 
@@ -468,9 +463,7 @@ class TestMergeForDisplay:
 
     def test_merge_for_display_upstream_only(self):
         """Test merging with only upstream data."""
-        upstream = UpstreamCache(
-            versions={"fd": UpstreamVersion(latest_version="10.0.0")}
-        )
+        upstream = UpstreamCache(versions={"fd": UpstreamVersion(latest_version="10.0.0")})
         local = LocalState()
         result = merge_for_display(upstream, local)
 
@@ -482,9 +475,7 @@ class TestMergeForDisplay:
     def test_merge_for_display_local_only(self):
         """Test merging with only local data."""
         upstream = UpstreamCache()
-        local = LocalState(
-            tools={"bat": LocalInstallation(installed_version="0.25.0")}
-        )
+        local = LocalState(tools={"bat": LocalInstallation(installed_version="0.25.0")})
         result = merge_for_display(upstream, local)
 
         assert len(result) == 1
@@ -529,6 +520,44 @@ class TestMergeForDisplay:
         assert tool["installed_method"] == "cargo"
         assert tool["status"] == "OUTDATED"
         assert tool["category"] == "rust-core"
+
+    def test_merge_recomputes_stale_up_to_date_status(self):
+        """A stored UP-TO-DATE must not survive a moved upstream baseline.
+
+        Regression (bwrap): local_state.json stored UP-TO-DATE for 0.9.0,
+        the committed baseline later moved to 0.11.2, and the merged row
+        rendered installed 0.9.0 / latest 0.11.2 / status UP-TO-DATE — so
+        guide.sh printed "target: 0.11.2 (same); up-to-date; skipping.".
+        """
+        upstream = UpstreamCache(versions={"bwrap": UpstreamVersion(latest_version="0.11.2")})
+        local = LocalState(tools={"bwrap": LocalInstallation(installed_version="0.9.0", status="UP-TO-DATE")})
+        result = merge_for_display(upstream, local)
+
+        assert result[0]["status"] == "OUTDATED"
+
+    def test_merge_recomputes_installed_ahead_as_up_to_date(self):
+        """Installed ahead of a stale baseline renders UP-TO-DATE (directional)."""
+        upstream = UpstreamCache(versions={"atuin": UpstreamVersion(latest_version="18.10.0")})
+        local = LocalState(tools={"atuin": LocalInstallation(installed_version="18.17.1", status="OUTDATED")})
+        result = merge_for_display(upstream, local)
+
+        assert result[0]["status"] == "UP-TO-DATE"
+
+    def test_merge_keeps_stored_status_without_upstream_version(self):
+        """No upstream latest → the stored status is the best information."""
+        upstream = UpstreamCache()
+        local = LocalState(tools={"bat": LocalInstallation(installed_version="0.25.0", status="UP-TO-DATE")})
+        result = merge_for_display(upstream, local)
+
+        assert result[0]["status"] == "UP-TO-DATE"
+
+    def test_merge_keeps_conflict_status(self):
+        """CONFLICT is not a version verdict and must pass through."""
+        upstream = UpstreamCache(versions={"node": UpstreamVersion(latest_version="24.0.0")})
+        local = LocalState(tools={"node": LocalInstallation(installed_version="22.0.0", status="CONFLICT")})
+        result = merge_for_display(upstream, local)
+
+        assert result[0]["status"] == "CONFLICT"
 
     def test_merge_for_display_sorted(self):
         """Test that merged tools are sorted alphabetically."""


### PR DESCRIPTION
## Problem

Real field output from `make upgrade`:

```
==> ✅ bwrap
    installed: 0.9.0 via apt
    target:    0.11.2 (same)
    up-to-date; skipping.
```

`0.9.0` reported as "(same)" as `0.11.2`. Root cause chain, each step verified live:

1. `compute_status("0.9.0", "0.11.2")` is correct (`OUTDATED`) — comparison logic is not at fault.
2. `merge_for_display` (`cli_audit/local_state.py`) built display rows with `"status": loc.status` — the verdict **stored** in `local_state.json` at collect time — while joining `latest_version` **fresh** from the upstream baseline.
3. When the committed baseline moves without a local re-collect, the row pairs the new latest with the stale verdict. The stale pairing was baked into `tools_snapshot.json` (row contained `latest_version: 0.11.2` + `status: UP-TO-DATE` simultaneously), `audit.py` derived `is_up_to_date` from it, and `guide.sh` printed "(same) / up-to-date; skipping".

## Fix

`_display_status()` recomputes the verdict from the current `(installed_version, latest_version)` pair at merge time — directional like `compute_status` (installed ≥ latest is UP-TO-DATE, handles installed-ahead-of-stale-baseline). `CONFLICT` passes through; a missing side keeps the stored status (best available information). A stored derived value is only valid for the inputs it was computed from.

## Test plan

- 4 new tests (written first, watched fail): stale UP-TO-DATE → OUTDATED (the bwrap case), installed-ahead → UP-TO-DATE, stored status preserved without upstream data, CONFLICT passthrough.
- Full suite: 793 passed, 1 skipped; smoke test OK; pre-commit green.
- Real-machine end-to-end: after `audit.py --update-local`, the snapshot row and `CLI_AUDIT_JSON=1 audit.py bwrap` both report `OUTDATED` / `is_up_to_date: false` for 0.9.0 vs 0.11.2.

https://claude.ai/code/session_01MH3EaniXCnJdwqNvrMB4Ym
