### PR TITLE
chore: ignore .claude/ (local agent settings)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ vendor/
 
 # AI agent session context (not committed)
 claudedocs/
+.claude/
 .serena/
 .beads/
 .agents/


### PR DESCRIPTION
Adds `.claude/` to the AI-agent-session block in .gitignore so the machine-local permission allowlist (`.claude/settings.json`) stays uncommitted.

https://claude.ai/code/session_01MH3EaniXCnJdwqNvrMB4Ym