### PR TITLE
docs(agents): symlink editing rule, crates.io UA, jq optional chaining

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,10 @@
 - Ask before: heavy deps, full rewrites, breaking changes
 - Never commit secrets, PII, or credentials
 
+## Editing these instructions
+
+`AGENTS.md` is canonical; `CLAUDE.md` is a symlink to it (root and scoped dirs alike). Edit the resolved `AGENTS.md` target — editing `CLAUDE.md` fails the Edit-tool symlink guard.
+
 ## Setup
 
 **This project uses [uv](https://docs.astral.sh/uv/) for package management.** Always use `uv run` to execute Python commands.
@@ -108,6 +112,11 @@ This repo **is** a CLI tool manager, so the word "upgrade" is overloaded:
 | `make completion-<tool>` | Install bash completion for one tool (e.g. `make completion-gh`) |
 | `uv run python audit.py --versions` | Show multi-version runtime status |
 | `uv run python audit.py --versions php` | Show specific runtime versions |
+
+## External API gotchas
+
+- **crates.io requires a User-Agent** (`curl -fsSL -A "cli-audit" https://crates.io/api/v1/crates/<name>`) — without it the response is non-JSON and parsing throws. The package-version MCP tools do not cover crates/cargo; manual curl is the fallback.
+- **Default to jq optional chaining** over external API JSON (`.arr[]?`, `.field?`): iterating a null/absent array with `.arr[]` aborts the whole pipeline (`Cannot iterate over null`), killing loops on one empty response. Safe even when the field is usually present.
 
 ## Data files
 


### PR DESCRIPTION
## What

Three promoted learnings (`/retro promote`, batch 4) into `AGENTS.md`:

- `CLAUDE.md` is a symlink to `AGENTS.md` (root and scoped) — edit the resolved target; editing the symlink fails the Edit-tool guard.
- crates.io rejects UA-less requests with non-JSON; always pass `-A`, and note the package-version MCP has no crates coverage.
- Default to jq optional chaining (`.arr[]?`) over external API JSON — a null array otherwise aborts the whole pipeline.

The deps-vs-system-upgrade note from the same batch is already covered by "Project maintenance vs. tool feature" and was tombstoned without an upward write.

Came from /retro: yes
