### PR TITLE
feat(catalog): add Bitwarden CLI (bw) via npm_global

### DIFF
--- a/catalog/bw.json
+++ b/catalog/bw.json
@@ -1,0 +1,20 @@
+{
+  "name": "bw",
+  "category": "devops",
+  "install_method": "npm_global",
+  "description": "Bitwarden CLI - vault access and secure one-time Sends",
+  "homepage": "https://bitwarden.com/help/cli/",
+  "github_repo": "bitwarden/clients",
+  "package_name": "@bitwarden/cli",
+  "binary_name": "bw",
+  "requires": [
+    "node"
+  ],
+  "version_command": "bw --version 2>/dev/null | grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+' | head -1",
+  "guide": {
+    "display_name": "Bitwarden CLI",
+    "install_action": "install",
+    "order": 206
+  },
+  "notes": "Password manager CLI. Used for Bitwarden Send one-time password handover links. Requires login (API key) + session unlock; credentials live in Vault under netresearch/actors/<user>/priv."
+}


### PR DESCRIPTION
Adds a catalog entry for the Bitwarden CLI (`bw`, npm package `@bitwarden/cli`, install method `npm_global`, guide order 206 next to vault). Verified end-to-end on this machine: `make install-bw` installs 2026.7.0 and the snapshot refresh picks it up; full pytest suite passes (793 passed, 1 skipped). Motivation: IT password handovers use Bitwarden Send one-time links (see NRS-3980/NRS-4158 precedent); the agent toolset needs `bw` available to create Sends non-interactively.

https://claude.ai/code/session_01RUeyrHBbDhYzBwWDusz7Ey

Update since this was opened: the CLI is now in actual use rather than only anticipated. It backs `bitwarden-provision.py --send-ad-password` in [it-account-lifecycle-skill !40](https://git.netresearch.de/coding-ai/it-account-lifecycle-skill/-/merge_requests/40), which reads the initial password from Vault and issues a one-time Send for the credential handover. Two payload facts were measured against the real service while building that and are now pinned by tests there: `bw send create` validates the whole `send.text` template (omitting `disabled` fails with "The Disabled field is required"), and a Send's lifetime is capped at 31 days — `+31` is accepted, `+32` is refused.
